### PR TITLE
fix: pin Ginkgo version in CI

### DIFF
--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -58,7 +58,8 @@ jobs:
 
       - name: Install ginkgo
         run: |
-          go install github.com/onsi/ginkgo/v2/ginkgo@latest
+          go get github.com/onsi/ginkgo/v2@v2.11.0
+          go install github.com/onsi/ginkgo/v2/ginkgo
           sudo cp ~/go/bin/ginkgo /usr/local/bin
 
       - name: Deploy Apache APISIX

--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -58,7 +58,6 @@ jobs:
 
       - name: Install ginkgo
         run: |
-          go get github.com/onsi/ginkgo/v2@v2.11.0
           go install github.com/onsi/ginkgo/v2/ginkgo
           sudo cp ~/go/bin/ginkgo /usr/local/bin
 


### PR DESCRIPTION
Signed-off-by: Navendu Pottekkat <navendu@apache.org>

Pins the Ginkgo version used in CI to the Ginkgo version used in the code to ensure parity in tests.

Before:
![Screenshot 2023-09-14 at 12 14 06 PM](https://github.com/api7/adc/assets/49474499/6ab655f4-985a-4181-9dc6-371031339891)

After:
![Screenshot 2023-09-14 at 12 14 13 PM](https://github.com/api7/adc/assets/49474499/5b37153f-ebd5-4432-9d82-5e5c4c9cfcb2)