### PR TITLE
fix: `adc configure` initializes configuration file

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -51,7 +51,7 @@ func saveConfiguration() error {
 	// use viper to save the configuration
 	viper.Set("server", rootConfig.Server)
 	viper.Set("token", rootConfig.Token)
-	if err := viper.SafeWriteConfig(); err != nil {
+	if err := viper.WriteConfig(); err != nil {
 		color.Red("Failed to configure ADC")
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,15 +55,22 @@ func Execute() {
 }
 
 func initConfig() {
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// set default config file $HOME/.adc.yaml
-		viper.SetConfigFile("$HOME/.adc.yaml")
+	if cfgFile == "" {
+		cfgFile = "$HOME/.adc.yaml"
 	}
+	viper.SetConfigFile(cfgFile)
 	viper.SetConfigName(".adc")
 	viper.SetConfigType("yaml")
 	viper.AddConfigPath("$HOME/")
+
+	if _, err := os.Stat(os.ExpandEnv(cfgFile)); err != nil {
+		color.Yellow("Config file not found at %s. Creating...", cfgFile)
+		_, err := os.Create(os.ExpandEnv(cfgFile))
+		if err != nil {
+			color.Red("Failed to initialize configuration file: %s", err)
+		}
+	}
+
 	err := viper.ReadInConfig()
 	if err != nil {
 		color.Red("Failed to read configuration file, please run `adc configure` first to configure ADC.")


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Running `adc configure` for the first time would first initialize a configuration file instead of throwing an error.

Current UX:

```shell
adc configure
Config file not found at $HOME/.adc.yaml. Creating...
Please enter the APISIX server address: 
```

Previous UX:

```shell
adc configure
Fatal to read config file, please run `adc configure` to configure the client first.
Please input the server address:
```

Fixes #39 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
