### PR TITLE
fix: initial run of `adc configure` does not throw error

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -184,7 +184,10 @@ func saveConfiguration(cmd *cobra.Command) error {
 	viper.Set("insecure", rootConfig.Insecure)
 
 	if overwrite {
-		err = viper.WriteConfig()
+		// because WriteConfig fails to write if the file does not exist
+		// and WriteConfigAs does write even if the file does not exist
+		// see: https://github.com/spf13/viper/issues/433
+		err = viper.WriteConfigAs(cfgFile)
 	} else {
 		err = viper.SafeWriteConfig()
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
-	_, err := os.Stat(cfgFile)
+	_, err := os.Stat(os.ExpandEnv(cfgFile))
 
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,12 +75,19 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
-	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
-		color.Yellow("Configuration file %s doesn't exist.", cfgFile)
-		return
+	_, err := os.Stat(cfgFile)
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			color.Yellow("Configuration file %s doesn't exist.", cfgFile)
+			return
+		} else {
+			color.Red("Failed to read configuration file: %s", err.Error())
+			return
+		}
 	}
 
-	err := viper.ReadInConfig()
+	err = viper.ReadInConfig()
 	if err != nil {
 		color.Red("Failed to read configuration file: %s", err.Error())
 		return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func initConfig() {
 			color.Yellow("Configuration file %s doesn't exist.", cfgFile)
 			return
 		} else {
-			color.Red("Failed to read configuration file: %s", err.Error())
+			color.Red("Error reading configuration file: %s", err.Error())
 			return
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,17 +75,14 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	}
 
-	if _, err := os.Stat(os.ExpandEnv(cfgFile)); err != nil {
-		color.Yellow("Config file not found at %s. Creating...", cfgFile)
-		_, err := os.Create(os.ExpandEnv(cfgFile))
-		if err != nil {
-			color.Red("Failed to initialize configuration file: %s", err.Error())
-		}
+	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
+		color.Yellow("Configuration file %s doesn't exist.", cfgFile)
+		return
 	}
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		color.Red("Failed to read configuration file, please run `adc configure` first to configure ADC.")
+		color.Red("Failed to read configuration file: %s", err.Error())
 		return
 	}
 


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Handling a different scenario just for the config command is different. This approach makes it better by showing warnings indicating the lack of a configuration file. Now commands that require a configuration file ask users to run `adc configure`, and if the configuration file is not present, it is shown as a warning.

In the `adc configure` subcommand, when it is run initially without the configuration file being present, will show that the configuration file is not present and then proceed to create one without needing the `-f` flag to overwrite the created file.

```text
➜  adc sync
Configuration file /Users/navendu/.adc.yaml doesn't exist.
ADC isn't configured, run `adc configure` to configure ADC.
➜  adc configure
Configuration file /Users/navendu/.adc.yaml doesn't exist.
Please enter the APISIX server address: 
http://127.0.0.1:9081
Please enter the APISIX token: 
token
ADC configured successfully!
```

Fixes #83

The other alternative was to create a new configuration file if it is not present and then write to it properly if it has just been initialized, but this is a more simple and central solution.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
