### PR TITLE
feat: add an install script for easy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,24 @@ It is built using the [Cobra](https://github.com/spf13/cobra) library.
 
 ## Installation
 
-### macOS/Linux
+ADC can be installed using the `go install` command:
 
-You can install ADC using the install script by running:
-
-```shell
-curl -sL https://run.api7.ai/adc/install | sh
+```
+go install github.com/api7/adc@latest
 ```
 
-To install a specific version or set a custom install directory, use the `ADC_VERSION` and `ADC_DIR` environment variables respectievely:
-
-```shell
-export ADC_VERSION=0.5.0
-export ADC_DIR=/bin
-```
+This will install the `adc` binary to your `$GOPATH/bin` directory.
 
 You can also download the appropriate binary from the [releases page](https://github.com/api7/adc/releases):
 
 ```bash
-wget https://github.com/api7/adc/releases/download/v0.5.0/adc_0.5.0_linux_amd64.tar.gz
-tar -zxvf adc_0.5.0_linux_amd64.tar.gz
+wget https://github.com/api7/adc/releases/download/v0.1.0/adc_0.1.0_linux_amd64.tar.gz
+tar -zxvf adc_0.1.0_linux_amd64.tar.gz
 mv adc /usr/local/bin/adc
 ```
 
 > [!IMPORTANT]
 > Make sure that these directories are in your `$PATH` environment variable.
-
-### Windows
-
-You can download the release for Windows from the [releases page](https://github.com/api7/adc/releases) and extract it. You can then use the `adc.exe` executable to run ADC.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,24 +6,35 @@ It is built using the [Cobra](https://github.com/spf13/cobra) library.
 
 ## Installation
 
-ADC can be installed using the `go install` command:
+### macOS/Linux
 
-```
-go install github.com/api7/adc@latest
+You can install ADC using the install script by running:
+
+```shell
+curl -sL https://run.api7.ai/adc/install | sh
 ```
 
-This will install the `adc` binary to your `$GOPATH/bin` directory.
+To install a specific version or set a custom install directory, use the `ADC_VERSION` and `ADC_DIR` environment variables respectievely:
+
+```shell
+export ADC_VERSION=0.5.0
+export ADC_DIR=/bin
+```
 
 You can also download the appropriate binary from the [releases page](https://github.com/api7/adc/releases):
 
 ```bash
-wget https://github.com/api7/adc/releases/download/v0.1.0/adc_0.1.0_linux_amd64.tar.gz
-tar -zxvf adc_0.1.0_linux_amd64.tar.gz
+wget https://github.com/api7/adc/releases/download/v0.5.0/adc_0.5.0_linux_amd64.tar.gz
+tar -zxvf adc_0.5.0_linux_amd64.tar.gz
 mv adc /usr/local/bin/adc
 ```
 
 > [!IMPORTANT]
 > Make sure that these directories are in your `$PATH` environment variable.
+
+### Windows
+
+You can download the release for Windows from the [releases page](https://github.com/api7/adc/releases) and extract it. You can then use the `adc.exe` executable to run ADC.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ OS="$(uname)"
 # convert to standard arch names used in files
 if [ "x${ARCH}" = "xx86_64" ]; then
     ARCH="amd64"
+fi
 
 # convert to standard os names used in files
 # TODO: support Windows

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ fi
 
 if [ "x${ADC_VERSION}" = "x" ]; then
     printf "Unable to find the latest version of ADC. Please set the ADC_VERSION environment variable and try again. For example, export ADC_VERSION=0.5.0\n"
-    exit
+    exit 1
 fi
 
 # if version has v in prefix, remove it

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,10 @@
 ARCH="$(uname -m)"
 OS="$(uname)"
 
+# convert to standard arch names used in files
+if [ "x${ARCH}" = "xx86_64" ]; then
+    ARCH="amd64"
+
 # convert to standard os names used in files
 # TODO: support Windows
 if [ "x${OS}" = "xDarwin" ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+ARCH="$(uname -m)"
+OS="$(uname)"
+
+# convert to standard os names used in files
+# TODO: support Windows
+if [ "x${OS}" = "xDarwin" ]; then
+    OS="darwin"
+else
+    OS="linux"
+fi
+
+# either specify the version in an environment variable or get the latest from GitHub
+if [ "x${ADC_VERSION}" = "x" ]; then
+    ADC_VERSION=$(curl -L -s https://github.com/api7/adc/releases/latest |
+        grep "adc/releases/tag/" | head -1 | awk -F '"' '{print $4}' |
+        awk -F '/' '{print $NF}')
+fi
+
+if [ "x${ADC_VERSION}" = "x" ]; then
+    printf "Unable to find the latest version of ADC. Please set the ADC_VERSION environment variable and try again. For example, export ADC_VERSION=0.5.0\n"
+    exit
+fi
+
+# if version has v in prefix, remove it
+ADC_VERSION=${ADC_VERSION#v}
+
+FILENAME="adc_${ADC_VERSION}_${OS}_${ARCH}.tar.gz"
+
+# example download URL format: https://github.com/api7/adc/releases/download/v0.5.0/adc_0.5.0_darwin_arm64.tar.gz
+URL="https://github.com/api7/adc/releases/download/v${ADC_VERSION}/${FILENAME}"
+
+printf "Downloading ADC v${ADC_VERSION} for ${OS} ${ARCH}...\n\n"
+# printf "Download URL: %s\n" "$URL"
+
+curl -L ${URL} -o ${PWD}/adc.tar.gz
+if [ $? -ne 0 ]; then
+    echo "Error downloading ADC. Please check your internet connection and try again."
+    exit 1
+fi
+
+# temporary folder name to extract the downloaded file
+TEMP_FOLDER_NAME=$(tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null | head -c 16)
+if [ -z "$TEMP_FOLDER_NAME" ]; then
+    TEMP_FOLDER_NAME="TEMP_ADC_FOLDER"
+fi
+
+mkdir $TEMP_FOLDER_NAME
+
+printf "\nExtracting ADC to temporary folder %s...\n" "$TEMP_FOLDER_NAME"
+
+tar -xzf "${PWD}/adc.tar.gz" -C "${PWD}/${TEMP_FOLDER_NAME}"
+if [ $? -ne 0 ]; then
+    echo "Error extracting ADC. The downloaded file might be corrupted. Please try again and make sure that you are installing the correct version."
+    exit 1
+fi
+
+INSTALL_DIR=${ADC_DIR}
+if [ -z "$INSTALL_DIR" ]; then
+    INSTALL_DIR="/usr/local/bin"
+fi
+
+printf "Installing ADC in $INSTALL_DIR...\n"
+
+WHOAMI=$(whoami)
+
+# install adc binary, use sudo if user doesn't have permission to install in INSTALL_DIR
+if mv "${PWD}/$TEMP_FOLDER_NAME/adc" "$INSTALL_DIR/adc" >/dev/null 2>&1; then
+    echo "ADC installed successfully!"
+else
+    if sudo mv ${PWD}/$TEMP_FOLDER_NAME/adc $INSTALL_DIR/adc; then
+        echo "ADC installed successfully with sudo permissions!"
+    else
+        echo "Unable to install ADC. Please check the permissions of the user $WHOAMI for the directory $INSTALL_DIR."
+        exit 1
+    fi
+fi
+
+# clean up temporary files
+printf "Removing temporary files...\n"
+rm -rf adc.tar.gz ${PWD}/$TEMP_FOLDER_NAME/
+
+printf "Done!\n"


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Adds an install script that users can just run, and it will install the appropriate version of the ADC binary for macOS and Linux.

TODO:

We need to serve this file similar to how we serve https://run.api7.ai/apisix/quickstart

I suggest this URL https://run.api7.ai/adc/install

Once we do that, users can install ADC by just running `curl -sL https://run.api7.ai/adc/install | sh`.

@juzhiyuan Can you help with this?

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
