### PR TITLE
add flags to pass dry run during sync

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -34,6 +34,7 @@ func newSyncCmd() *cobra.Command {
 
 	cmd.Flags().StringArrayP("file", "f", []string{"apisix.yaml"}, "configuration file path")
 	cmd.Flags().BoolP("partial", "p", false, "partial apply mode. In partial mode, only add and update event will be applied.")
+	cmd.Flags().BoolP("dryRun", "d", false, "dry run mode. In dry run mode, no configuration will be applied.")
 
 	return cmd
 }
@@ -146,6 +147,12 @@ func sync(cmd *cobra.Command, dryRun bool) error {
 	if len(files) == 0 {
 		color.Red("No input files")
 		return nil
+	}
+
+	dryRun, err = cmd.Flags().GetBool("dryRun")
+	if err != nil {
+		color.Red("Failed to get dry run option: %v", err)
+		return err
 	}
 
 	partial := false


### PR DESCRIPTION
### Description
Currently there are no flags added for dry-run during the sync process. This PR adding this flag in the cli. 
Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
