### PR TITLE
fix: convert url variables to colon x

### DIFF
--- a/internal/pkg/openapi2apisix/openapi2apisix.go
+++ b/internal/pkg/openapi2apisix/openapi2apisix.go
@@ -22,7 +22,9 @@ var (
 )
 
 func convertPathVariables(path string) string {
-	return _pathVariableRegex.ReplaceAllString(path, "*")
+	return _pathVariableRegex.ReplaceAllStringFunc(path, func(match string) string {
+		return ":" + match[1:len(match)-1]
+	})
 }
 
 // Slugify converts a name to a valid name by removing and replacing unallowed characters

--- a/internal/pkg/openapi2apisix/openapi2apisix_test.go
+++ b/internal/pkg/openapi2apisix/openapi2apisix_test.go
@@ -74,6 +74,8 @@ var (
 	tagsTest []byte
 	//go:embed testdata/tags.json
 	tagsJsonTest []byte
+	//go:embed testdata/urlVariables.yaml
+	urlVariables []byte
 )
 
 func TestConvert(t *testing.T) {
@@ -140,14 +142,14 @@ func TestConvert(t *testing.T) {
 						Description: "Remove customer",
 						// Labels:      []string{"default"},
 						Methods: []string{"DELETE"},
-						Uris:    []string{"/customer/*"},
+						Uris:    []string{"/customer/:customer_id"},
 					},
 					{
 						Name:        "api-101_put_customer-customer-id",
 						Description: "Update customer",
 						// Labels:      []string{"default"},
 						Methods: []string{"PUT"},
-						Uris:    []string{"/customer/*"},
+						Uris:    []string{"/customer/:customer_id"},
 					},
 					{
 						Name:        "api-101_get_customers",
@@ -195,7 +197,7 @@ func TestConvert(t *testing.T) {
 						Description: "Update customer",
 						// Labels:      []string{"default"},
 						Methods: []string{"PUT"},
-						Uris:    []string{"/customer/*"},
+						Uris:    []string{"/customer/:customer_id"},
 					},
 					{
 						Name:        "getCustomers",
@@ -289,6 +291,57 @@ func TestConvert(t *testing.T) {
 						// Labels:      []string{"default", "customer"},
 						Methods: []string{"GET"},
 						Uris:    []string{"/customers"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "urlVariables",
+			args: args{
+				content: urlVariables,
+			},
+			want: &apitypes.Configuration{
+				Services: []*apitypes.Service{
+					{
+						Name: "URL variables",
+						Upstream: &apitypes.Upstream{
+							Scheme: "https",
+							Nodes: []apitypes.UpstreamNode{
+								{
+									Host:   "example.com",
+									Port:   443,
+									Weight: 100,
+								},
+							},
+							Timeout: &apitypes.UpstreamTimeout{
+								Connect: 60,
+								Send:    60,
+								Read:    60,
+							},
+							PassHost: apitypes.UpstreamPassHostPass,
+						},
+						//  Labels:      make([]apitypes.Labels, 0),
+					},
+				},
+				Routes: []*apitypes.Route{
+					{
+						Name: "url-variables_get_base64-value",
+						// Labels:      []string{"default"},
+						Methods: []string{"GET"},
+						Uris:    []string{"/base64/:value"},
+					},
+					{
+						Name: "url-variables_get_basic-auth-user-passwd",
+						// Labels:      []string{"default"},
+						Methods: []string{"GET"},
+						Uris:    []string{"/basic-auth/:user/:passwd"},
+					},
+					{
+						Name: "url-variables_get_digest-auth-qop-user-passwd-algorithm-stale-after",
+						// Labels:      []string{"default"},
+						Methods: []string{"GET"},
+						Uris:    []string{"/digest-auth/:qop/:user/:passwd/:algorithm/:stale_after"},
 					},
 				},
 			},

--- a/internal/pkg/openapi2apisix/testdata/urlVariables.yaml
+++ b/internal/pkg/openapi2apisix/testdata/urlVariables.yaml
@@ -1,0 +1,86 @@
+openapi: 3.0.1
+info:
+  title: URL variables
+  version: 1.0.0
+servers:
+- url: https://example.com/
+paths:
+  /base64/{value}:
+    get:
+      tags:
+      - Dynamic data
+      parameters:
+      - name: value
+        in: path
+        required: true
+        schema:
+          type: string
+          default: SFRUUEJJTiBpcyBhd2Vzb21l
+      responses:
+        200:
+          description: Decoded base64 content.
+          content: {}
+  /basic-auth/{user}/{passwd}:
+    get:
+      tags:
+      - Auth
+      parameters:
+      - name: user
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: passwd
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Sucessful authentication.
+          content: {}
+        401:
+          description: Unsuccessful authentication.
+          content: {}
+  /digest-auth/{qop}/{user}/{passwd}/{algorithm}/{stale_after}:
+    get:
+      tags:
+      - Auth
+      parameters:
+      - name: qop
+        in: path
+        description: auth or auth-int
+        required: true
+        schema:
+          type: string
+      - name: user
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: passwd
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: algorithm
+        in: path
+        description: MD5, SHA-256, SHA-512
+        required: true
+        schema:
+          type: string
+          default: MD5
+      - name: stale_after
+        in: path
+        required: true
+        schema:
+          type: string
+          default: never
+      responses:
+        200:
+          description: Sucessful authentication.
+          content: {}
+        401:
+          description: Unsuccessful authentication.
+          content: {}
+components: {}


### PR DESCRIPTION
### Description

Currently, the path variable in OpenAPI will be converted to *, its implementation on APISIX, which allows for arbitrary strings containing slash, which potentially doesn't fit our needs.

So this PR actually replaces variables like /order/{order_id} with /order/:order_id, which is more appropriate.

Specifically:

The original implementation:

```
/order/{order_id} => /order/*
/order/{order_id}/good/{good_no} => /order/*/good/*
```

While this does work, it will actually allow requests like this to be matched:

```
/order/12345/blahblah => /order/*
/order/12345/54321/good/12345 => /order/*/good/*
```

I.e., allowing `*` paths like `xxx/xxx` to be matched, which could change the semantics of the URL and pose a security risk.

Variables such as `:xxx` are not allowed to contain `/`, i.e., they match at most one level of the directory on the URL.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
