### PR TITLE
fix: correct upstream numbers

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -96,7 +96,7 @@ func displayConfigOverview(d *types.Configuration) {
 		changed = true
 	}
 	if len(d.Upstreams) > 0 {
-		msg += fmt.Sprintf(", upstreams: %v", len(d.StreamRoutes))
+		msg += fmt.Sprintf(", upstreams: %v", len(d.Upstreams))
 		changed = true
 	}
 	if !changed {


### PR DESCRIPTION
### Description

The number of upstream is wrong while executing `adc validate`, this pr corrected the upstream numbers in cmd/validate.go:99


Fixes # (issue)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
