### PR TITLE
feat(api7): support API-level label selector

### DIFF
--- a/libs/backend-api7/e2e/label-selector.e2e-spec.ts
+++ b/libs/backend-api7/e2e/label-selector.e2e-spec.ts
@@ -1,0 +1,78 @@
+import * as ADCSDK from '@api7/adc-sdk';
+
+import { BackendAPI7 } from '../src';
+import {
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  syncEvents,
+} from './support/utils';
+
+describe('Label Selector', () => {
+  const commonBackendOpts = {
+    server: process.env.SERVER,
+    token: process.env.TOKEN,
+    tlsSkipVerify: true,
+    gatewayGroup: 'default',
+  };
+  let backend: BackendAPI7;
+
+  beforeAll(() => {
+    backend = new BackendAPI7(commonBackendOpts);
+  });
+
+  describe('Consumer', () => {
+    const consumer1Name = 'consumer1';
+    const consumer1 = {
+      username: consumer1Name,
+      labels: { team: '1' },
+      plugins: {
+        'key-auth': {
+          key: consumer1Name,
+        },
+      },
+    } as ADCSDK.Consumer;
+    const consumer2Name = 'consumer2';
+    const consumer2 = {
+      username: consumer2Name,
+      labels: { team: '2' },
+      plugins: {
+        'key-auth': {
+          key: consumer2Name,
+        },
+      },
+    } as ADCSDK.Consumer;
+
+    it('Create consumers', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name, consumer1),
+        createEvent(ADCSDK.ResourceType.CONSUMER, consumer2Name, consumer2),
+      ]));
+
+    it('Dump consumer whit label team = 1', async () => {
+      const backend = new BackendAPI7({
+        ...commonBackendOpts,
+        labelSelector: { team: '1' }, // add custom label selector
+      });
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.consumers).toHaveLength(1);
+      expect(result.consumers[0]).toMatchObject(consumer1);
+    });
+
+    it('Dump consumer whit label team = 2', async () => {
+      const backend = new BackendAPI7({
+        ...commonBackendOpts,
+        labelSelector: { team: '2' }, // add custom label selector
+      });
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.consumers).toHaveLength(1);
+      expect(result.consumers[0]).toMatchObject(consumer2);
+    });
+
+    it('Delete consumers', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name),
+        deleteEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name),
+      ]));
+  });
+});

--- a/libs/backend-api7/e2e/label-selector.e2e-spec.ts
+++ b/libs/backend-api7/e2e/label-selector.e2e-spec.ts
@@ -1,4 +1,7 @@
 import * as ADCSDK from '@api7/adc-sdk';
+import { unset } from 'lodash';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { BackendAPI7 } from '../src';
 import {
@@ -72,7 +75,78 @@ describe('Label Selector', () => {
     it('Delete consumers', async () =>
       syncEvents(backend, [
         deleteEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name),
-        deleteEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name),
+        deleteEvent(ADCSDK.ResourceType.CONSUMER, consumer2Name),
+      ]));
+  });
+
+  describe('SSL', () => {
+    const certificates = [
+      {
+        certificate: readFileSync(
+          join(__dirname, 'assets/certs/test-ssl1.cer'),
+        ).toString('utf-8'),
+        key: readFileSync(
+          join(__dirname, 'assets/certs/test-ssl1.key'),
+        ).toString('utf-8'),
+      },
+      {
+        certificate: readFileSync(
+          join(__dirname, 'assets/certs/test-ssl2.cer'),
+        ).toString('utf-8'),
+        key: readFileSync(
+          join(__dirname, 'assets/certs/test-ssl2.key'),
+        ).toString('utf-8'),
+      },
+    ];
+    const ssl1SNIs = ['ssl1-1.com', 'ssl1-2.com'];
+    const ssl1 = {
+      snis: ssl1SNIs,
+      labels: { team: '1' },
+      certificates: [certificates[0]],
+    } as ADCSDK.SSL;
+    const ssl2SNIs = ['ssl2-1.com', 'ssl2-2.com'];
+    const ssl2 = {
+      snis: ssl2SNIs,
+      labels: { team: '2' },
+      certificates: [certificates[1]],
+    } as ADCSDK.SSL;
+    const sslName = (snis: Array<string>) => snis.join(',');
+
+    const ssl1test = structuredClone(ssl1);
+    const ssl2test = structuredClone(ssl2);
+    unset(ssl1test, 'certificates.0.key');
+    unset(ssl2test, 'certificates.0.key');
+
+    it('Create ssls', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.SSL, sslName(ssl1SNIs), ssl1),
+        createEvent(ADCSDK.ResourceType.SSL, sslName(ssl2SNIs), ssl2),
+      ]));
+
+    it('Dump consumer whit label team = 1', async () => {
+      const backend = new BackendAPI7({
+        ...commonBackendOpts,
+        labelSelector: { team: '1' }, // add custom label selector
+      });
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.ssls).toHaveLength(1);
+      expect(result.ssls[0]).toMatchObject(ssl1test);
+    });
+
+    it('Dump consumer whit label team = 2', async () => {
+      const backend = new BackendAPI7({
+        ...commonBackendOpts,
+        labelSelector: { team: '2' }, // add custom label selector
+      });
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.ssls).toHaveLength(1);
+      expect(result.ssls[0]).toMatchObject(ssl2test);
+    });
+
+    it('Delete ssls', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.SSL, sslName(ssl1SNIs)),
+        deleteEvent(ADCSDK.ResourceType.SSL, sslName(ssl2SNIs)),
       ]));
   });
 });

--- a/libs/backend-api7/src/utils.ts
+++ b/libs/backend-api7/src/utils.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 export const capitalizeFirstLetter = (str: string) =>
   str.charAt(0).toUpperCase() + str.slice(1);
@@ -24,7 +24,7 @@ export const buildReqAndRespDebugOutput = (
     messages: [
       `${desc ?? ''}\n`, //TODO time consumption
       // request
-      `${config.method.toUpperCase()} ${config.url}\n`,
+      `${config.method.toUpperCase()} ${axios.getUri(config)}\n`,
       ...transformHeaders(config.headers),
       config?.data ? `\n${config.data}\n` : '',
       '\n',

--- a/libs/backend-apisix/src/utils.ts
+++ b/libs/backend-apisix/src/utils.ts
@@ -1,5 +1,5 @@
 import * as ADCSDK from '@api7/adc-sdk';
-import { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 export const resourceTypeToAPIName = (resourceType: ADCSDK.ResourceType) =>
   resourceType !== ADCSDK.ResourceType.PLUGIN_METADATA
@@ -30,7 +30,7 @@ export const buildReqAndRespDebugOutput = (
     messages: [
       `${desc ?? ''}\n`, //TODO time consumption
       // request
-      `${config.method.toUpperCase()} ${config.url}\n`,
+      `${config.method.toUpperCase()} ${axios.getUri(config)}\n`,
       ...transformHeaders(config.headers),
       config?.data ? `\n${config.data}\n` : '',
       '\n',


### PR DESCRIPTION
### Description

The current API7 backend uses an implementation that pulls completely and performs label filtering locally. This can be inefficient when the number of potential resources is high.
This PR moves label filtering to the API7 API level, where the server performs resource filtering and only returns resources that match the labeling rules.

It supports the following resource types:
- Consumer
- SSL

Resource types that will not be supported (These resources do not have a labels field):
- Global Rule
- Plugin Metadata

Resources that may be supported later:
- Service: Right now, its not supported for labels based filtering, we will add support for it when the server starts supporting it.

Even though services do not perform API-level label filtering, label filtering will still work and its mode of operation will fall back to full pull and local filtering. This will be improved later.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
