### PR TITLE
feat(core): support resolve env var syntax in input

### DIFF
--- a/apps/cli/src/command/diff.command.ts
+++ b/apps/cli/src/command/diff.command.ts
@@ -15,6 +15,7 @@ import {
   filterResourceType,
   loadBackend,
   mergeKVConfigurations,
+  recursiveReplaceEnvVars,
   toConfiguration,
   toKVConfiguration,
 } from './utils';
@@ -85,6 +86,12 @@ export const LoadLocalConfigurationTask = (
               ),
             );
             ctx.local = toConfiguration(localKVConfiguration);
+          },
+        },
+        {
+          title: 'Resolve value variables',
+          task: async () => {
+            ctx.local = recursiveReplaceEnvVars(ctx.local);
           },
         },
         {


### PR DESCRIPTION
### Description

There have long been calls from users for ADC to add support for environment variable references in declarative API files, which would help avoid hard-coding secret values.

Yes, it has become a reality.

With this PR, users will be able to reference an environment variable in a YAML declarative API file using syntax like `${ENV_VAR}`.

It will work no matter which backend you use. The only restriction is that only values are allowed to use environment variables, while property names in objects are not.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
