### PR TITLE
feat(core): add lint on diff and sync in default

### DIFF
--- a/apps/cli/src/command/diff.command.ts
+++ b/apps/cli/src/command/diff.command.ts
@@ -8,7 +8,8 @@ import YAML from 'yaml';
 import { DifferV3 } from '../differ/differv3';
 import { SignaleRenderer } from '../utils/listr';
 import { LoadRemoteConfigurationTask } from './dump.command';
-import { BackendCommand } from './helper';
+import { BackendCommand, NoLintOption } from './helper';
+import { LintTask } from './lint.command';
 import { BackendOptions } from './typing';
 import {
   fillLabels,
@@ -22,6 +23,7 @@ import {
 
 type DiffOptions = BackendOptions & {
   file: Array<string>;
+  lint: boolean;
 };
 
 export interface TaskContext {
@@ -163,6 +165,7 @@ export const DiffCommand = new BackendCommand<DiffOptions>(
     'The files you want to synchronize, can be set more than one.',
     (filePath, files: Array<string> = []) => files.concat(filePath),
   )
+  .addOption(NoLintOption)
   .addExample('adc diff -f service-a.yaml -f service-b.yaml')
   .handle(async (opts) => {
     const backend = loadBackend(opts.backend, opts);
@@ -175,6 +178,7 @@ export const DiffCommand = new BackendCommand<DiffOptions>(
           opts.includeResourceType,
           opts.excludeResourceType,
         ),
+        opts.lint ? LintTask() : { task: () => undefined },
         LoadRemoteConfigurationTask({
           backend,
           labelSelector: opts.labelSelector,

--- a/apps/cli/src/command/helper.ts
+++ b/apps/cli/src/command/helper.ts
@@ -203,3 +203,5 @@ export class BackendCommand<OPTS extends object = object> extends BaseCommand {
       );
   }
 }
+
+export const NoLintOption = new Option('--no-lint', 'Disable lint check');

--- a/apps/cli/src/command/sync.command.ts
+++ b/apps/cli/src/command/sync.command.ts
@@ -7,12 +7,14 @@ import {
   TaskContext,
 } from './diff.command';
 import { LoadRemoteConfigurationTask } from './dump.command';
-import { BackendCommand } from './helper';
+import { BackendCommand, NoLintOption } from './helper';
+import { LintTask } from './lint.command';
 import { BackendOptions } from './typing';
 import { loadBackend } from './utils';
 
 type SyncOption = BackendOptions & {
   file: Array<string>;
+  lint: boolean;
 };
 
 export const SyncCommand = new BackendCommand<SyncOption>(
@@ -24,6 +26,7 @@ export const SyncCommand = new BackendCommand<SyncOption>(
     'The files you want to synchronize, can be set more than one.',
     (filePath, files: Array<string> = []) => files.concat(filePath),
   )
+  .addOption(NoLintOption)
   .addExample('adc sync -f service-a.yaml -f service-b.yaml')
   .handle(async (opts) => {
     const backend = loadBackend(opts.backend, opts);
@@ -36,6 +39,7 @@ export const SyncCommand = new BackendCommand<SyncOption>(
           opts.includeResourceType,
           opts.excludeResourceType,
         ),
+        opts.lint ? LintTask() : { task: () => undefined },
         LoadRemoteConfigurationTask({
           backend,
           labelSelector: opts.labelSelector,

--- a/apps/cli/src/linter/schema.ts
+++ b/apps/cli/src/linter/schema.ts
@@ -65,32 +65,30 @@ const upstreamSchema = z
     key: z.string().optional(),
     checks: z
       .object({
-        active: z
-          .object({
-            type: upstreamHealthCheckType.optional(),
-            timeout: z.number().default(1).optional(),
-            concurrency: z.number().default(10).optional(),
-            host: z.string(),
-            port: portSchema,
-            http_path: z.string().default('/').optional(),
-            https_verify_cert: z.boolean().default(true).optional(),
-            http_request_headers: z.array(z.string()).min(1).optional(),
-            healthy: z
-              .object({
-                interval: z.number().int().min(1).default(1),
-              })
-              .merge(upstreamHealthCheckPassiveHealthy)
-              .strict()
-              .optional(),
-            unhealthy: z
-              .object({
-                interval: z.number().int().min(1).default(1),
-              })
-              .merge(upstreamHealthCheckPassiveUnhealthy)
-              .strict()
-              .optional(),
-          })
-          .optional(),
+        active: z.object({
+          type: upstreamHealthCheckType.optional(),
+          timeout: z.number().default(1).optional(),
+          concurrency: z.number().default(10).optional(),
+          host: z.string(),
+          port: portSchema,
+          http_path: z.string().default('/').optional(),
+          https_verify_cert: z.boolean().default(true).optional(),
+          http_request_headers: z.array(z.string()).min(1).optional(),
+          healthy: z
+            .object({
+              interval: z.number().int().min(1).default(1),
+            })
+            .merge(upstreamHealthCheckPassiveHealthy)
+            .strict()
+            .optional(),
+          unhealthy: z
+            .object({
+              interval: z.number().int().min(1).default(1),
+            })
+            .merge(upstreamHealthCheckPassiveUnhealthy)
+            .strict()
+            .optional(),
+        }),
         passive: z
           .object({
             type: upstreamHealthCheckType.optional(),


### PR DESCRIPTION
### Description

The current lint in the ADC is manual and will not be executed by default when diff and sync are executed, which can lead to unintended commit behavior, so this PR lists lint as a step in the diff and sync commands.

If you wish to turn off lint checking on diff and sync, you can use `--no-lint` to disable lint checking.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
