### PR TITLE
fix(apisix): store stream route name correctly

### DIFF
--- a/apps/cli/src/linter/schema.ts
+++ b/apps/cli/src/linter/schema.ts
@@ -218,12 +218,7 @@ const serviceSchema = z
 
     upstream: upstreamSchema.optional(),
     plugins: pluginsSchema.optional(),
-    path_prefix: z
-      .string()
-      .optional()
-      .refine((val) => val?.startsWith('/'), {
-        message: 'Path prefix must start with "/"',
-      }),
+    path_prefix: z.string().optional(),
     strip_path_prefix: z.boolean().optional(),
     hosts: z.array(z.string()).optional(),
 
@@ -236,6 +231,15 @@ const serviceSchema = z
     {
       message:
         'HTTP routes and Stream routes are mutually exclusive and should not exist in the same service',
+    },
+  )
+  .refine(
+    (val) => {
+      if (!val.path_prefix) return true;
+      return val.path_prefix.startsWith('/');
+    },
+    {
+      message: 'Path prefix must start with "/"',
     },
   );
 

--- a/libs/backend-apisix/e2e/assets/apisix_conf/http.yaml
+++ b/libs/backend-apisix/e2e/assets/apisix_conf/http.yaml
@@ -5,6 +5,11 @@ apisix:
   control:
     ip: "0.0.0.0"
     port: 9092
+  proxy_mode: http&stream
+  stream_proxy:
+    tcp:
+      - addr: 33060
+        tls: true
 deployment:
   admin:
     allow_admin:

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -213,7 +213,7 @@ describe('Sync and Dump - 1', () => {
       const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
       expect(result.services).toHaveLength(1);
       expect(result.services[0]).toMatchObject(service);
-      expect(result.services[0].stream_routes).toHaveLength(0);
+      expect(result.services[0].stream_routes).toBeUndefined();
     });
 
     it('Delete service', async () =>

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -188,7 +188,12 @@ describe('Sync and Dump - 1', () => {
     it('Create resources', async () =>
       syncEvents(backend, [
         createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
-        createEvent(ADCSDK.ResourceType.ROUTE, route1Name, route1, serviceName),
+        createEvent(
+          ADCSDK.ResourceType.STREAM_ROUTE,
+          route1Name,
+          route1,
+          serviceName,
+        ),
       ]));
 
     it('Dump', async () => {

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -206,7 +206,7 @@ describe('Sync and Dump - 1', () => {
 
     it('Delete stream route', async () =>
       syncEvents(backend, [
-        deleteEvent(ADCSDK.ResourceType.ROUTE, route1Name, serviceName),
+        deleteEvent(ADCSDK.ResourceType.STREAM_ROUTE, route1Name, serviceName),
       ]));
 
     it('Dump again (non-route)', async () => {

--- a/libs/backend-apisix/src/typing.ts
+++ b/libs/backend-apisix/src/typing.ts
@@ -108,7 +108,7 @@ export interface StreamRoute {
   id: string;
   desc?: string;
   labels?: Labels;
-  name: string;
+  //name: string; // As of 3.9.1, APISIX does not support name on the stream route
 
   remote_addr?: string;
   server_addr?: string;

--- a/schema.json
+++ b/schema.json
@@ -230,6 +230,9 @@
                     "additionalProperties": false
                   }
                 },
+                "required": [
+                  "active"
+                ],
                 "additionalProperties": false
               },
               "nodes": {
@@ -538,8 +541,7 @@
           }
         },
         "required": [
-          "name",
-          "path_prefix"
+          "name"
         ],
         "additionalProperties": false
       }


### PR DESCRIPTION
### Description

Synchronization fails due to the fact that APISIX resources are non-standard, e.g. the stream route does not have a name field that can be used to store names.

This PR has some compatibility fixes, it uses `labels` to store a key called `__ADC_NAME` to store the name, which is transparent to the user, and is automatically added during sync and removed during dump.

I'm going to push for standardization of resource objects in APISIX, but until that's done, this compatibility measure is unavoidable.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
