### PR TITLE
ci: add install script

### DIFF
--- a/.github/workflows/update-s3-and-cloudfront.yaml
+++ b/.github/workflows/update-s3-and-cloudfront.yaml
@@ -1,0 +1,36 @@
+name: Update S3 and Cloudfront
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-s3-and-cloudfront:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET_REGION: ${{ secrets.S3_BUCKET_REGION }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.S3_BUCKET_REGION }}
+      
+      - name: Deploy
+        # The path to the install script will be /adc/install
+        run: aws s3 sync ./s3 s3://${{ secrets.S3_BUCKET }}/adc
+
+      - name: Invalidate CloudFront
+        uses: chetan/invalidate-cloudfront-action@v2
+        env:
+          DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          PATHS: "/"
+          AWS_REGION: "${{ secrets.S3_BUCKET_REGION }}"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/update-s3-and-cloudfront.yaml
+++ b/.github/workflows/update-s3-and-cloudfront.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/update-s3-and-cloudfront.yaml
+      - s3/install
 
 jobs:
   update-s3-and-cloudfront:

--- a/s3/install
+++ b/s3/install
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+ARCH="$(uname -m)"
+OS="$(uname)"
+
+# convert to standard arch names used in files
+if [ "x${ARCH}" = "xx86_64" ]; then
+    ARCH="amd64"
+fi
+
+# convert to standard os names used in files
+# TODO: support Windows
+if [ "x${OS}" = "xDarwin" ]; then
+    OS="darwin"
+else
+    OS="linux"
+fi
+
+# either specify the version in an environment variable or get the latest from GitHub
+if [ "x${ADC_VERSION}" = "x" ]; then
+    ADC_VERSION=$(curl -L -s https://github.com/api7/adc/releases/latest |
+        grep "adc/releases/tag/" | head -1 | awk -F '"' '{print $4}' |
+        awk -F '/' '{print $NF}')
+fi
+
+if [ "x${ADC_VERSION}" = "x" ]; then
+    printf "Unable to find the latest version of ADC. Please set the ADC_VERSION environment variable and try again. For example, export ADC_VERSION=0.5.0\n"
+    exit 1
+fi
+
+# if version has v in prefix, remove it
+ADC_VERSION=${ADC_VERSION#v}
+
+FILENAME="adc_${ADC_VERSION}_${OS}_${ARCH}.tar.gz"
+
+# example download URL format: https://github.com/api7/adc/releases/download/v0.5.0/adc_0.5.0_darwin_arm64.tar.gz
+URL="https://github.com/api7/adc/releases/download/v${ADC_VERSION}/${FILENAME}"
+
+printf "Downloading ADC v${ADC_VERSION} for ${OS} ${ARCH}..."
+# printf "Download URL: %s\n" "$URL"
+
+curl -L -s ${URL} -o ${PWD}/adc.tar.gz
+if [ $? -ne 0 ]; then
+    echo "Error downloading ADC. Please check your internet connection and try again."
+    exit 1
+fi
+
+# temporary folder name to extract the downloaded file
+TEMP_FOLDER_NAME=$(tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null | head -c 16)
+if [ -z "$TEMP_FOLDER_NAME" ]; then
+    TEMP_FOLDER_NAME="TEMP_ADC_FOLDER"
+fi
+
+mkdir $TEMP_FOLDER_NAME
+
+printf "\nExtracting ADC to temporary folder %s...\n" "$TEMP_FOLDER_NAME"
+
+tar -xzf "${PWD}/adc.tar.gz" -C "${PWD}/${TEMP_FOLDER_NAME}"
+if [ $? -ne 0 ]; then
+    echo "Error extracting ADC. The downloaded file might be corrupted. Please try again and make sure that you are installing the correct version."
+    exit 1
+fi
+
+INSTALL_DIR=${ADC_DIR}
+if [ -z "$INSTALL_DIR" ]; then
+    INSTALL_DIR="/usr/local/bin"
+fi
+
+printf "Installing ADC in $INSTALL_DIR...\n"
+
+WHOAMI=$(whoami)
+
+# install adc binary, use sudo if user doesn't have permission to install in INSTALL_DIR
+if mv "${PWD}/$TEMP_FOLDER_NAME/adc" "$INSTALL_DIR/adc" >/dev/null 2>&1; then
+    echo "ADC installed successfully!"
+else
+    if sudo mv ${PWD}/$TEMP_FOLDER_NAME/adc $INSTALL_DIR/adc; then
+        echo "ADC installed successfully with sudo permissions!"
+    else
+        echo "Unable to install ADC. Please check the permissions of the user $WHOAMI for the directory $INSTALL_DIR."
+        exit 1
+    fi
+fi
+
+# clean up temporary files
+printf "Removing temporary files...\n"
+rm -rf adc.tar.gz ${PWD}/$TEMP_FOLDER_NAME/
+
+printf "Done!\n"

--- a/s3/install
+++ b/s3/install
@@ -9,7 +9,6 @@ if [ "x${ARCH}" = "xx86_64" ]; then
 fi
 
 # convert to standard os names used in files
-# TODO: support Windows
 if [ "x${OS}" = "xDarwin" ]; then
     OS="darwin"
 else


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Adds an install script and a workflow to publish the script to our s3 bucket. The install script downloads and installs the appropriate ADC binary to make it easy for users to use ADC.

A user should be able to install ADC by just running:

```shell
curl -sL https://run.api7.ai/adc/install | sh
```

Updates to the documentation, both in readme and the docs website will be made after this PR is merged and tested.

Test:

![Screenshot 2024-07-22 at 7 20 58 PM](https://github.com/user-attachments/assets/211c098a-8fe8-4e50-8e09-2a8e57c835fc)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
