### PR TITLE
fix(core): upstream linter check either nodes or service discovery

### DIFF
--- a/apps/cli/src/linter/schema.ts
+++ b/apps/cli/src/linter/schema.ts
@@ -106,15 +106,17 @@ const upstreamSchema = z
         },
       )
       .optional(),
-    nodes: z.array(
-      z.object({
-        host: z.string(),
-        port: portSchema.optional(),
-        weight: z.number().int().min(0),
-        priority: z.number().default(0).optional(),
-        metadata: z.record(z.string(), z.any()).optional(),
-      }),
-    ),
+    nodes: z
+      .array(
+        z.object({
+          host: z.string(),
+          port: portSchema.optional(),
+          weight: z.number().int().min(0),
+          priority: z.number().default(0).optional(),
+          metadata: z.record(z.string(), z.any()).optional(),
+        }),
+      )
+      .optional(),
     scheme: z
       .enum(['grpc', 'grpcs', 'http', 'https', 'tcp', 'tls', 'udp', 'kafka'])
       .default('http')

--- a/apps/cli/src/linter/specs/upstream.spec.ts
+++ b/apps/cli/src/linter/specs/upstream.spec.ts
@@ -1,0 +1,74 @@
+import * as ADCSDK from '@api7/adc-sdk';
+
+import { check } from '../';
+
+describe('Upstream Linter', () => {
+  const cases = [
+    {
+      name: 'should check either nodes or discovery (neither)',
+      input: {
+        services: [
+          {
+            name: 'No_Node_And_Discovery',
+            upstream: {},
+          },
+        ],
+      } as ADCSDK.Configuration,
+      expect: false,
+      errors: [
+        {
+          code: 'custom',
+          message:
+            'Upstream must either explicitly specify nodes or use service discovery and not both',
+          path: ['services', 0, 'upstream'],
+        },
+      ],
+    },
+    {
+      name: 'should check either nodes or discovery (with nodes)',
+      input: {
+        services: [
+          {
+            name: 'No_Node_And_Discovery',
+            upstream: {
+              nodes: [
+                {
+                  host: '1.1.1.1',
+                  port: 443,
+                  weight: 100,
+                },
+              ],
+            },
+          },
+        ],
+      } as ADCSDK.Configuration,
+      expect: true,
+    },
+    {
+      name: 'should check either nodes or discovery (with discovery and service name)',
+      input: {
+        services: [
+          {
+            name: 'No_Node_And_Discovery',
+            upstream: {
+              discovery_type: 'mock',
+              service_name: 'service_mock',
+            },
+          },
+        ],
+      } as ADCSDK.Configuration,
+      expect: true,
+    },
+  ];
+
+  // test cases runner
+  cases.forEach((item) => {
+    it(item.name, () => {
+      const result = check(item.input);
+      expect(result.success).toEqual(item.expect);
+      if (!item.expect) {
+        expect(result.error.errors).toEqual(item.errors);
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Description

The current upstream schema lists `nodes` as a required field, thus preventing the use of service discovery.
Now `nodes` will be optional, and an additional checker will ensure that one of `nodes` and `discovery` is set.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
