### PR TITLE
feat: add inline examples

### DIFF
--- a/apps/cli/src/command/convert.command.ts
+++ b/apps/cli/src/command/convert.command.ts
@@ -22,13 +22,23 @@ class BaseConvertCommand extends BaseCommand {
     this.option(
       '-f, --file <openapi-file-path>',
       'OpenAPI specification file path',
-    ).option('-o, --output <output-path>', 'output file path');
+    ).option('-o, --output <output-path>', 'output file path', 'adc.yaml');
   }
 }
 
 const OpenAPICommand = new BaseConvertCommand('openapi')
   .description('Convert an OpenAPI specification to equivalent ADC configuration.\n\nLearn more at: https://docs.api7.ai/enterprise/reference/openapi-adc')
   .summary('convert OpenAPI spec to ADC configuration')
+  .addExamples([
+    {
+      title: 'Convert OpenAPI specification in YAML format to ADC configuration and write to the default adc.yaml file',
+      command: 'adc convert openapi -f openapi.yaml',
+    },
+    {
+      title: 'Convert OpenAPI specification in JSON format to ADC configuration and write to the specified file',
+      command: 'adc convert openapi -f openapi.json -o converted-adc.yaml',
+    }
+  ])
   .action(async () => {
     const opts = OpenAPICommand.optsWithGlobals<ConvertOptions>();
 
@@ -70,7 +80,6 @@ const OpenAPICommand = new BaseConvertCommand('openapi')
           title: 'Write converted OpenAPI file',
           task: (ctx, task) => {
             const yamlStr = stringify(ctx.local, {});
-            if (!opts.output) opts.output = './adc.yaml';
             writeFileSync(opts.output, yamlStr);
             task.title = `Converted OpenAPI file to "${resolve(
               opts.output,

--- a/apps/cli/src/command/diff.command.ts
+++ b/apps/cli/src/command/diff.command.ts
@@ -169,7 +169,7 @@ export const DiffCommand = new BackendCommand<DiffOptions>(
   .addOption(NoLintOption)
   .addExamples([
     {
-      title: 'Compare configuration in specified file with the backend configuration',
+      title: 'Compare configuration in a specified file with the backend configuration',
       command: 'adc diff -f adc.yaml',
     },
     {

--- a/apps/cli/src/command/diff.command.ts
+++ b/apps/cli/src/command/diff.command.ts
@@ -167,8 +167,16 @@ export const DiffCommand = new BackendCommand<DiffOptions>(
     (filePath, files: Array<string> = []) => files.concat(filePath),
   )
   .addOption(NoLintOption)
-  .addExample('adc diff -f adc.yaml')
-  .addExample('adc diff -f service-a.yaml -f service-b.yaml')
+  .addExamples([
+    {
+      title: 'Compare configuration in specified file with the backend configuration',
+      command: 'adc diff -f adc.yaml',
+    },
+    {
+      title: 'Compare configuration in multiple specified files with the backend configuration',
+      command: 'adc diff -f service-a.yaml -f service-b.yaml',
+    },
+  ])
   .handle(async (opts) => {
     const backend = loadBackend(opts.backend, opts);
 

--- a/apps/cli/src/command/dump.command.ts
+++ b/apps/cli/src/command/dump.command.ts
@@ -88,7 +88,7 @@ export const DumpCommand = new BackendCommand<DumpOptions>(
       command: 'adc dump --include-resource-type global_rule --include-resource-type plugin_metadata',
     },
     {
-      title: 'Save only the resources with the specified lables',
+      title: 'Save only the resources with the specified labels',
       command: 'adc dump --label-selector app=catalog',
     },
   ])

--- a/apps/cli/src/command/dump.command.ts
+++ b/apps/cli/src/command/dump.command.ts
@@ -74,8 +74,24 @@ export const DumpCommand = new BackendCommand<DumpOptions>(
     'path of the file to save the configuration',
     'adc.yaml',
   )
-  .addExample('adc dump')
-  .addExample('adc dump -o service-configuration.yaml')
+  .addExamples([
+    {
+      title: 'Save backend configuration to the default adc.yaml file',
+      command: 'adc dump'
+    },
+    {
+      title: 'Save backend configuration to the specified file',
+      command: 'adc dump -o service-configuration.yaml'
+    },
+    {
+      title: 'Save only specified resource types from the backend',
+      command: 'adc dump --include-resource-type global_rule --include-resource-type plugin_metadata',
+    },
+    {
+      title: 'Save only the resources with the specified lables',
+      command: 'adc dump --label-selector app=catalog',
+    },
+  ])
   .handle(async (opts) => {
     const backend = loadBackend(opts.backend, opts);
     const tasks = new Listr<TaskContext, typeof SignaleRenderer>(

--- a/apps/cli/src/command/helper.ts
+++ b/apps/cli/src/command/helper.ts
@@ -8,7 +8,7 @@ import parseDuration from 'parse-duration';
 import qs from 'qs';
 
 export class BaseCommand extends Command {
-  private exmaples: Array<string> = [];
+  private examples: Array<{ title: string; command: string }> = [];
 
   constructor(name: string, summary?: string, description?: string) {
     super(name);
@@ -32,15 +32,21 @@ export class BaseCommand extends Command {
     );
   }
 
-  public addExample(exmaple: string) {
-    if (this.exmaples.length === 0)
-      this.addHelpText('after', () => {
-        return `\nExamples:\n\n${this.exmaples
-          .map((example) => `  $ ${example}`)
-          .join('\n')}\n`;
-      });
+  // Appends the provided examples to description
+  public addExamples(examples: Array<{ title: string, command: string }>) {
+    this.examples.push(...examples);
 
-    this.exmaples.push(exmaple);
+    // Title of each example is a comment which describes the actual command
+    const exampleText = this.examples
+      .map((example) => `  # ${example.title}\n  ${example.command}`)
+      .join('\n\n');
+
+    const exampleHeader = this.examples.length === 1 ? 'Example:' : 'Examples:';
+
+    const currDescription = this.description() || '';
+
+    // Append the examples to the description
+    this.description(`${currDescription}\n\n${exampleHeader}\n${exampleText}`);
     return this;
   }
 }

--- a/apps/cli/src/command/lint.command.ts
+++ b/apps/cli/src/command/lint.command.ts
@@ -65,8 +65,16 @@ export const LintCommand = new BaseCommand('lint')
     'file to lint',
     (filePath, files: Array<string> = []) => files.concat(filePath),
   )
-  .addExample('adc lint -f adc.yaml')
-  .addExample('adc lint -f service-a.yaml -f service-b.yaml')
+  .addExamples([
+    {
+      title: 'Lint the specified configuration file',
+      command: 'adc lint -f adc.yaml',
+    },
+    {
+      title: 'Lint multiple configuration files',
+      command: 'adc lint -f service-a.yaml -f service-b.yaml',
+    },
+  ])
   .action(async () => {
     const opts = LintCommand.optsWithGlobals();
 

--- a/apps/cli/src/command/ping.command.ts
+++ b/apps/cli/src/command/ping.command.ts
@@ -10,14 +10,29 @@ export const PingCommand = new BackendCommand<PingOptions>(
   'ping',
   'check connectivity with the backend',
   'Check connectivity with the configured backend.',
-).handle(async (opts) => {
-  const backend = loadBackend(opts.backend, opts);
+)
+  .addExamples([
+    {
+      title: 'Check connectivity with the configured backend',
+      command: 'adc ping',
+    },
+    {
+      title: 'Check connectivity with the specified backend',
+      command: 'adc ping --backend apisix --server http://192.168.1.21:9180',
+    },
+  ])
+  .handle(async (opts) => {
+    const backend = loadBackend(opts.backend, opts);
 
-  try {
-    await backend.ping();
-    console.log(chalk.green(`Connected to the "${opts.backend}" backend successfully!`));
-  } catch (err) {
-    console.log(chalk.red(`Unable to connect to the "${opts.backend}" backend. ${err}`));
-    process.exit(1);
-  }
-});
+    try {
+      await backend.ping();
+      console.log(
+        chalk.green(`Connected to the "${opts.backend}" backend successfully!`),
+      );
+    } catch (err) {
+      console.log(
+        chalk.red(`Unable to connect to the "${opts.backend}" backend. ${err}`),
+      );
+      process.exit(1);
+    }
+  });

--- a/apps/cli/src/command/sync.command.ts
+++ b/apps/cli/src/command/sync.command.ts
@@ -28,8 +28,36 @@ export const SyncCommand = new BackendCommand<SyncOption>(
     (filePath, files: Array<string> = []) => files.concat(filePath),
   )
   .addOption(NoLintOption)
-  .addExample('adc sync -f adc.yaml')
-  .addExample('adc sync -f service-a.yaml -f service-b.yaml')
+  .addExamples([
+    {
+      title: 'Synchronize configuration from a single file',
+      command: 'adc sync -f adc.yaml',
+    },
+    {
+      title: 'Synchronize configuration from multiple files',
+      command: 'adc sync -f service-a.yaml -f service-b.yaml',
+    },
+    {
+      title: 'Synchronize configuration to a specific gateway group',
+      command: 'adc sync -f adc.yaml --gateway-group production',
+    },
+    {
+      title: 'Synchronize configuration without lint check',
+      command: 'adc sync -f adc.yaml --no-lint',
+    },
+    {
+      title: 'Synchronize configuration with debug logs',
+      command: 'adc sync -f adc.yaml --verbose',
+    },
+    {
+      title: 'Synchronize only specified resource types from the configuration file',
+      command: 'adc sync -f adc.yaml --include-resource-type global_rule --include-resource-type plugin_metadata',
+    },
+    {
+      title: 'Synchronize only the resources with the specified lables',
+      command: 'adc sync -f adc.yaml --label-selector app=catalog',
+    },
+  ])
   .handle(async (opts) => {
     const backend = loadBackend(opts.backend, opts);
 

--- a/apps/cli/src/command/sync.command.ts
+++ b/apps/cli/src/command/sync.command.ts
@@ -47,7 +47,7 @@ export const SyncCommand = new BackendCommand<SyncOption>(
     },
     {
       title: 'Synchronize configuration with debug logs',
-      command: 'adc sync -f adc.yaml --verbose',
+      command: 'adc sync -f adc.yaml --verbose 2',
     },
     {
       title: 'Synchronize only specified resource types from the configuration file',


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Adds inline examples to subcommands to improve ease of use.

Now, users can easily refer to the examples to figure out specific flows instead of having to navigate through each option.

The examples are added in an "easy to copy" way with the description of each example in a shell comment form similar to other popular CLIs like `kubectl`. Examples are also added before the `Options` section to make it obvious. Users can look at the docs for specific options after they find the example they want.

![Screenshot 2024-08-21 at 12 49 07 PM](https://github.com/user-attachments/assets/ec5018ff-50cc-4079-a687-e6aa3c678042)

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
