### PR TITLE
fix(api7): mismatched fields in upstream mtls

### DIFF
--- a/apps/cli/src/linter/exporter.ts
+++ b/apps/cli/src/linter/exporter.ts
@@ -1,7 +1,7 @@
 /**
  * Export jsonschema file by:
  *
- * $ ts-node apps/cli/src/linter/exporter.ts
+ * $ nx export-schema cli
  *
  */
 import { writeFileSync } from 'fs';

--- a/apps/cli/src/linter/schema.ts
+++ b/apps/cli/src/linter/schema.ts
@@ -138,15 +138,16 @@ const upstreamSchema = z
     timeout: timeoutSchema.optional(),
     tls: z
       .object({
-        cert: z.string(),
-        key: z.string(),
+        client_cert: z.string(),
+        client_key: z.string(),
         client_cert_id: z.string(),
         verify: z.boolean(),
       })
       .refine(
         (data) =>
-          (data.cert && data.key && !data.client_cert_id) ||
-          (data.client_cert_id && !data.cert && !data.key),
+          (data.client_cert && data.client_key && !data.client_cert_id) ||
+          (data.client_cert_id && !data.client_cert && !data.client_key),
+        'The client_cert and client_key certificate pair or client_cert_id SSL reference ID must be set',
       )
       .optional(),
     keepalive_pool: z

--- a/apps/cli/src/linter/schema.ts
+++ b/apps/cli/src/linter/schema.ts
@@ -143,6 +143,7 @@ const upstreamSchema = z
         client_cert_id: z.string(),
         verify: z.boolean(),
       })
+      .strict()
       .refine(
         (data) =>
           (data.client_cert && data.client_key && !data.client_cert_id) ||

--- a/apps/cli/src/linter/schema.ts
+++ b/apps/cli/src/linter/schema.ts
@@ -138,10 +138,10 @@ const upstreamSchema = z
     timeout: timeoutSchema.optional(),
     tls: z
       .object({
-        client_cert: z.string(),
-        client_key: z.string(),
-        client_cert_id: z.string(),
-        verify: z.boolean(),
+        client_cert: z.string().optional(),
+        client_key: z.string().optional(),
+        client_cert_id: z.string().optional(),
+        verify: z.boolean().optional(),
       })
       .strict()
       .refine(

--- a/apps/cli/src/linter/specs/upstream.spec.ts
+++ b/apps/cli/src/linter/specs/upstream.spec.ts
@@ -98,7 +98,7 @@ describe('Upstream Linter', () => {
       input: {
         services: [
           {
-            name: 'No_HealthChecker_HostPort',
+            name: 'Upstream TLS',
             upstream: {
               nodes: [
                 {

--- a/apps/cli/src/linter/specs/upstream.spec.ts
+++ b/apps/cli/src/linter/specs/upstream.spec.ts
@@ -93,6 +93,30 @@ describe('Upstream Linter', () => {
       } as ADCSDK.Configuration,
       expect: true,
     },
+    {
+      name: 'should only allow upstream mtls in client_cert and client_key',
+      input: {
+        services: [
+          {
+            name: 'No_HealthChecker_HostPort',
+            upstream: {
+              nodes: [
+                {
+                  host: '1.1.1.1',
+                  port: 443,
+                  weight: 100,
+                },
+              ],
+              tls: {
+                client_cert: '0000',
+                client_key: '0000',
+              },
+            },
+          },
+        ],
+      } as ADCSDK.Configuration,
+      expect: true,
+    },
   ];
 
   // test cases runner

--- a/apps/cli/src/linter/specs/upstream.spec.ts
+++ b/apps/cli/src/linter/specs/upstream.spec.ts
@@ -98,7 +98,7 @@ describe('Upstream Linter', () => {
       input: {
         services: [
           {
-            name: 'Upstream TLS',
+            name: 'Upstream mTLS',
             upstream: {
               nodes: [
                 {

--- a/libs/backend-api7/README.md
+++ b/libs/backend-api7/README.md
@@ -4,5 +4,13 @@
 
 | Features      | Supported |
 | ------------- | --------- |
-| Dump to ADC   | ✅        |
-| Sync from ADC | ✅        |
+| Dump to ADC   | ✅         |
+| Sync from ADC | ✅         |
+
+## Supported Versions
+
+| Versions | Supported |
+| -------- | --------- |
+| 3.2.14.6 | ✅         |
+| 3.2.15.2 | ✅         |
+| 3.2.16.2 | ✅         |

--- a/libs/backend-api7/src/typing.ts
+++ b/libs/backend-api7/src/typing.ts
@@ -118,6 +118,12 @@ export interface Upstream {
   retries?: number;
   retry_timeout?: number;
   timeout?: UpstreamTimeout;
+  tls?: {
+    client_cert: string;
+    client_key: string;
+    client_cert_id: string;
+    verify: boolean;
+  };
   keepalive_pool?: {
     size: number;
     idle_timeout: number;

--- a/libs/sdk/src/core/index.ts
+++ b/libs/sdk/src/core/index.ts
@@ -67,8 +67,8 @@ export interface UpstreamTimeout {
   read: number;
 }
 export interface UpstreamClientTLS {
-  cert: string;
-  key: string;
+  client_cert: string;
+  client_key: string;
   client_cert_id: string;
   verify: boolean;
 }

--- a/schema.json
+++ b/schema.json
@@ -325,12 +325,6 @@
                     "type": "boolean"
                   }
                 },
-                "required": [
-                  "client_cert",
-                  "client_key",
-                  "client_cert_id",
-                  "verify"
-                ],
                 "additionalProperties": false
               },
               "keepalive_pool": {

--- a/schema.json
+++ b/schema.json
@@ -312,10 +312,10 @@
               "tls": {
                 "type": "object",
                 "properties": {
-                  "cert": {
+                  "client_cert": {
                     "type": "string"
                   },
-                  "key": {
+                  "client_key": {
                     "type": "string"
                   },
                   "client_cert_id": {
@@ -326,8 +326,8 @@
                   }
                 },
                 "required": [
-                  "cert",
-                  "key",
+                  "client_cert",
+                  "client_key",
                   "client_cert_id",
                   "verify"
                 ],


### PR DESCRIPTION
### Description

API7 let the upstream mtls settings as `cert` and `key` instead of `client_cert` and `client_key` in the converter, which is not schema compliant, so fix it.

Also, cert and key do not emphasize their roles, so they need to be modified.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible: This aligns the schema so it's a fix and not backward compatible.

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
