### PR TITLE
fix(apisix): upstream nodes should be allowed to be null

### DIFF
--- a/libs/backend-apisix/e2e/resources/consumer.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/consumer.e2e-spec.ts
@@ -1,5 +1,5 @@
 import * as ADCSDK from '@api7/adc-sdk';
-import { gte, lt } from 'semver';
+import { gte } from 'semver';
 
 import { BackendAPISIX } from '../../src';
 import { server, token } from '../support/constants';

--- a/libs/backend-apisix/e2e/resources/consumer.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/consumer.e2e-spec.ts
@@ -96,7 +96,6 @@ describe('Consumer E2E', () => {
           backend,
         )) as ADCSDK.Configuration;
         expect(result.consumers).toHaveLength(1);
-        console.log(result.consumers[0]);
         expect(result.consumers[0].credentials).toBeUndefined();
       });
 

--- a/libs/backend-apisix/e2e/resources/upstream.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/upstream.e2e-spec.ts
@@ -1,18 +1,15 @@
 import * as ADCSDK from '@api7/adc-sdk';
-import { gte, lt } from 'semver';
 
 import { BackendAPISIX } from '../../src';
 import { server, token } from '../support/constants';
-import { conditionalDescribe, semverCondition } from '../support/utils';
 import {
   createEvent,
   deleteEvent,
   dumpConfiguration,
   syncEvents,
-  updateEvent,
 } from '../support/utils';
 
-describe('Consumer E2E', () => {
+describe('Upstream E2E', () => {
   let backend: BackendAPISIX;
 
   beforeAll(() => {
@@ -29,59 +26,29 @@ describe('Consumer E2E', () => {
       discovery_type: 'kubernetes',
       service_name: 'test',
     } as ADCSDK.Upstream;
-    const service1Name = 'service1';
-    const service1 = {
-      name: service1Name,
-      upstream: structuredClone(upstream),
-    } as ADCSDK.Service;
-    const service2Name = 'service2';
-    const service2 = {
-      name: service2Name,
+    const serviceName = 'service1';
+    const service = {
+      name: serviceName,
       upstream: structuredClone(upstream),
     } as ADCSDK.Service;
 
     it('Create services', async () =>
       syncEvents(backend, [
-        createEvent(ADCSDK.ResourceType.SERVICE, service1Name, service1),
-        createEvent(ADCSDK.ResourceType.SERVICE, service2Name, service2),
+        createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
       ]));
 
     it('Dump', async () => {
       const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.services).toHaveLength(2);
-      expect(result.services[0]).toMatchObject(service2);
-      expect(result.services[1]).toMatchObject(service1);
-    });
-
-    it('Update service1', async () => {
-      service1.description = 'desc';
-      await syncEvents(backend, [
-        updateEvent(ADCSDK.ResourceType.SERVICE, service1Name, service1),
-      ]);
-    });
-
-    it('Dump again (service1 updated)', async () => {
-      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.services[1]).toMatchObject(service1);
-    });
-
-    it('Delete service1', async () =>
-      syncEvents(backend, [
-        deleteEvent(ADCSDK.ResourceType.SERVICE, service1Name),
-      ]));
-
-    it('Dump again (service1 should not exist)', async () => {
-      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
       expect(result.services).toHaveLength(1);
-      expect(result.services[0]).toMatchObject(service2);
+      expect(result.services[0]).toMatchObject(service);
     });
 
-    it('Delete service2', async () =>
+    it('Delete service', async () =>
       syncEvents(backend, [
-        deleteEvent(ADCSDK.ResourceType.SERVICE, service2Name),
+        deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
       ]));
 
-    it('Dump again (service2 should not exist)', async () => {
+    it('Dump again', async () => {
       const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
       expect(result.services).toHaveLength(0);
     });

--- a/libs/backend-apisix/e2e/resources/upstream.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/upstream.e2e-spec.ts
@@ -1,0 +1,89 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import { gte, lt } from 'semver';
+
+import { BackendAPISIX } from '../../src';
+import { server, token } from '../support/constants';
+import { conditionalDescribe, semverCondition } from '../support/utils';
+import {
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  syncEvents,
+  updateEvent,
+} from '../support/utils';
+
+describe('Consumer E2E', () => {
+  let backend: BackendAPISIX;
+
+  beforeAll(() => {
+    backend = new BackendAPISIX({
+      server,
+      token,
+      tlsSkipVerify: true,
+    });
+  });
+
+  describe('Sync and dump upstream (nodes = null)', () => {
+    const upstream = {
+      scheme: 'https',
+      discovery_type: 'kubernetes',
+      service_name: 'test',
+    } as ADCSDK.Upstream;
+    const service1Name = 'service1';
+    const service1 = {
+      name: service1Name,
+      upstream: structuredClone(upstream),
+    } as ADCSDK.Service;
+    const service2Name = 'service2';
+    const service2 = {
+      name: service2Name,
+      upstream: structuredClone(upstream),
+    } as ADCSDK.Service;
+
+    it('Create services', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.SERVICE, service1Name, service1),
+        createEvent(ADCSDK.ResourceType.SERVICE, service2Name, service2),
+      ]));
+
+    it('Dump', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(2);
+      expect(result.services[0]).toMatchObject(service2);
+      expect(result.services[1]).toMatchObject(service1);
+    });
+
+    it('Update service1', async () => {
+      service1.description = 'desc';
+      await syncEvents(backend, [
+        updateEvent(ADCSDK.ResourceType.SERVICE, service1Name, service1),
+      ]);
+    });
+
+    it('Dump again (service1 updated)', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services[1]).toMatchObject(service1);
+    });
+
+    it('Delete service1', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.SERVICE, service1Name),
+      ]));
+
+    it('Dump again (service1 should not exist)', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject(service2);
+    });
+
+    it('Delete service2', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.SERVICE, service2Name),
+      ]));
+
+    it('Dump again (service2 should not exist)', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(0);
+    });
+  });
+});

--- a/libs/backend-apisix/src/transformer.ts
+++ b/libs/backend-apisix/src/transformer.ts
@@ -179,21 +179,23 @@ export class ToADC {
       grpc: 80,
       grpcs: 443,
     };
-    const nodes = Array.isArray(upstream.nodes)
-      ? upstream.nodes
-      : Object.keys(upstream.nodes).map<ADCSDK.UpstreamNode>((node) => {
-          const hostport = node.split(':');
-          return {
-            host: hostport[0],
-            port:
-              hostport.length === 2
-                ? parseInt(hostport[1])
-                : defaultPortMap[upstream.scheme]
-                  ? defaultPortMap[upstream.scheme]
-                  : 80,
-            weight: upstream.nodes[node],
-          };
-        });
+    const nodes = upstream.nodes
+      ? Array.isArray(upstream.nodes)
+        ? upstream.nodes
+        : Object.keys(upstream.nodes).map<ADCSDK.UpstreamNode>((node) => {
+            const hostport = node.split(':');
+            return {
+              host: hostport[0],
+              port:
+                hostport.length === 2
+                  ? parseInt(hostport[1])
+                  : defaultPortMap[upstream.scheme]
+                    ? defaultPortMap[upstream.scheme]
+                    : 80,
+              weight: upstream.nodes[node],
+            };
+          })
+      : undefined;
     return ADCSDK.utils.recursiveOmitUndefined({
       name: upstream.name ?? upstream.id,
       description: upstream.desc,


### PR DESCRIPTION
### Description

When using service discovery, nodes may be null, so it handler needs to be somewhat fault tolerant.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
