### PR TITLE
feat(core): support multiple file input for OAS converter

### DIFF
--- a/apps/cli/src/command/convert.command.ts
+++ b/apps/cli/src/command/convert.command.ts
@@ -1,6 +1,8 @@
 import { OpenAPIConverter } from '@api7/adc-converter-openapi';
+import * as ADCSDK from '@api7/adc-sdk';
 import OpenAPIParser from '@readme/openapi-parser';
 import { Listr } from 'listr2';
+import { cloneDeep } from 'lodash';
 import { existsSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { OpenAPIV3 } from 'openapi-types';
@@ -11,10 +13,15 @@ import { TaskContext } from './diff.command';
 import { BaseCommand } from './helper';
 
 interface ConvertOptions {
-  file: string;
+  file: Array<string>;
   output: string;
   verbose: number;
 }
+
+type ConvertContext = TaskContext & {
+  oas?: OpenAPIV3.Document;
+  buffer?: Array<ADCSDK.Configuration>;
+};
 
 class BaseConvertCommand extends BaseCommand {
   constructor(name: string) {
@@ -22,63 +29,80 @@ class BaseConvertCommand extends BaseCommand {
     this.option(
       '-f, --file <openapi-file-path>',
       'OpenAPI specification file path',
+      (filePath, files: Array<string> = []) => files.concat(filePath),
     ).option('-o, --output <output-path>', 'output file path', 'adc.yaml');
   }
 }
 
 const OpenAPICommand = new BaseConvertCommand('openapi')
-  .description('Convert an OpenAPI specification to equivalent ADC configuration.\n\nLearn more at: https://docs.api7.ai/enterprise/reference/openapi-adc')
+  .description(
+    'Convert an OpenAPI specification to equivalent ADC configuration.\n\nLearn more at: https://docs.api7.ai/enterprise/reference/openapi-adc',
+  )
   .summary('convert OpenAPI spec to ADC configuration')
   .addExamples([
     {
-      title: 'Convert OpenAPI specification in YAML format to ADC configuration and write to the default adc.yaml file',
+      title:
+        'Convert OpenAPI specification in YAML format to ADC configuration and write to the default adc.yaml file',
       command: 'adc convert openapi -f openapi.yaml',
     },
     {
-      title: 'Convert OpenAPI specification in JSON format to ADC configuration and write to the specified file',
+      title:
+        'Convert OpenAPI specification in JSON format to ADC configuration and write to the specified file',
       command: 'adc convert openapi -f openapi.json -o converted-adc.yaml',
-    }
+    },
+    {
+      title:
+        'Convert multiple OpenAPI specifications to single ADC configuration',
+      command: 'adc convert openapi -f openapi.yaml -f openapi.json',
+    },
   ])
   .action(async () => {
     const opts = OpenAPICommand.optsWithGlobals<ConvertOptions>();
 
-    const tasks = new Listr<
-      TaskContext & { oas?: OpenAPIV3.Document },
-      typeof SignaleRenderer
-    >(
+    const tasks = new Listr<ConvertContext, typeof SignaleRenderer>(
       [
-        {
-          title: 'Load OpenAPI document',
-          task: async (ctx) => {
-            const filePath = opts.file;
+        ...opts.file.map((filePath) => {
+          return {
+            title: `Convert OpenAPI document "${resolve(filePath)}"`,
+            task: async (ctx: ConvertContext) => {
+              // check existance
+              if (!existsSync(filePath)) {
+                const error = new Error(
+                  `File "${resolve(filePath)}" does not exist`,
+                );
+                error.stack = '';
+                throw error;
+              }
 
-            // check existance
-            if (!existsSync(filePath)) {
-              const error = new Error(
-                `File "${resolve(filePath)}" does not exist`,
-              );
-              error.stack = '';
-              throw error;
-            }
-
-            try {
-              ctx.oas = (await OpenAPIParser.dereference(
-                filePath,
-              )) as OpenAPIV3.Document;
-            } catch (error) {
-              error.message = error.message.replace('\n', '');
-              error.stack = '';
-              throw error;
-            }
-          },
-        },
-        {
-          title: 'Convert OpenAPI document',
-          task: (ctx) => new OpenAPIConverter().toADC(ctx.oas),
-        },
+              try {
+                const oas = (await OpenAPIParser.dereference(
+                  filePath,
+                )) as OpenAPIV3.Document;
+                const task = new OpenAPIConverter().toADC(oas);
+                task.add([
+                  {
+                    task: (subCtx) => {
+                      if (!ctx.buffer) {
+                        ctx.buffer = [cloneDeep(subCtx.local)];
+                      } else {
+                        ctx.buffer.push(cloneDeep(subCtx.local));
+                      }
+                    },
+                  },
+                ]);
+                return task;
+              } catch (error) {
+                error.message = error.message.replace('\n', '');
+                error.stack = '';
+                throw error;
+              }
+            },
+          };
+        }),
         {
           title: 'Write converted OpenAPI file',
           task: (ctx, task) => {
+            ctx.local.services = ctx.buffer.flatMap((item) => item.services);
             const yamlStr = stringify(ctx.local, {});
             writeFileSync(opts.output, yamlStr);
             task.title = `Converted OpenAPI file to "${resolve(
@@ -102,6 +126,8 @@ const OpenAPICommand = new BaseConvertCommand('openapi')
   });
 
 export const ConvertCommand = new BaseCommand('convert')
-  .description('Convert API definitions in other formats to equivalent ADC configuration.')
+  .description(
+    'Convert API definitions in other formats to equivalent ADC configuration.',
+  )
   .summary('convert API definitions in other formats to ADC configuration')
   .addCommand(OpenAPICommand);


### PR DESCRIPTION
### Description

Add the ability to convert multiple OAS specs simultaneously to a single ADC configuration to the OAS converter.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible: The command line outputs will change, but they should not have been relied upon, so this will be compatible.

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
