### PR TITLE
feat(core): add remote state file as experimental feature

### DIFF
--- a/apps/cli/src/command/index.ts
+++ b/apps/cli/src/command/index.ts
@@ -23,7 +23,7 @@ export const setupCommands = (): Command => {
 
   if (
     process.env.ADC_EXPERIMENTAL_FEATURE_FLAGS &&
-    process.env.ADC_EXPERIMENTAL_FEATURE_FLAGS.includes('remote-state-cache')
+    process.env.ADC_EXPERIMENTAL_FEATURE_FLAGS.includes('remote-state-file')
   ) {
     const desc =
       'path of the remote state file, which will allow the ADC to skip the initial dump process and use the ADC configuration contained in the remote state file directly';

--- a/apps/cli/src/command/index.ts
+++ b/apps/cli/src/command/index.ts
@@ -14,10 +14,22 @@ export const setupCommands = (): Command => {
   const program = new Command('adc');
 
   program
-    .description('API Declarative CLI (ADC) is a utility to manage API7 Enterprise and Apache APISIX declaratively.\n\nLearn more at: https://docs.api7.ai/enterprise/reference/adc')
+    .description(
+      'API Declarative CLI (ADC) is a utility to manage API7 Enterprise and Apache APISIX declaratively.\n\nLearn more at: https://docs.api7.ai/enterprise/reference/adc',
+    )
     .configureHelp({ showGlobalOptions: true })
     .passThroughOptions()
     .version('0.17.0', '-v, --version', 'display ADC version');
+
+  if (
+    process.env.ADC_EXPERIMENTAL_FEATURE_FLAGS &&
+    process.env.ADC_EXPERIMENTAL_FEATURE_FLAGS.includes('remote-state-cache')
+  ) {
+    const desc =
+      'path of the remote state file, which will allow the ADC to skip the initial dump process and use the ADC configuration contained in the remote state file directly';
+    DiffCommand.option('--remote-state-file <file-path>', desc);
+    SyncCommand.option('--remote-state-file <file-path>', desc);
+  }
 
   program
     .addCommand(PingCommand)

--- a/apps/cli/src/command/sync.command.ts
+++ b/apps/cli/src/command/sync.command.ts
@@ -3,6 +3,7 @@ import { Listr } from 'listr2';
 import { SignaleRenderer } from '../utils/listr';
 import {
   DiffResourceTask,
+  ExperimentalRemoteStateFileTask,
   LoadLocalConfigurationTask,
   TaskContext,
 } from './diff.command';
@@ -15,6 +16,9 @@ import { loadBackend } from './utils';
 type SyncOption = BackendOptions & {
   file: Array<string>;
   lint: boolean;
+
+  // experimental feature
+  remoteStateFile: string;
 };
 
 export const SyncCommand = new BackendCommand<SyncOption>(
@@ -76,12 +80,14 @@ export const SyncCommand = new BackendCommand<SyncOption>(
           opts.excludeResourceType,
         ),
         opts.lint ? LintTask() : { task: () => undefined },
-        LoadRemoteConfigurationTask({
-          backend,
-          labelSelector: opts.labelSelector,
-          includeResourceType: opts.includeResourceType,
-          excludeResourceType: opts.excludeResourceType,
-        }),
+        !opts.remoteStateFile
+          ? LoadRemoteConfigurationTask({
+              backend,
+              labelSelector: opts.labelSelector,
+              includeResourceType: opts.includeResourceType,
+              excludeResourceType: opts.excludeResourceType,
+            })
+          : ExperimentalRemoteStateFileTask(opts.remoteStateFile),
         DiffResourceTask(false, false),
         {
           title: 'Sync configuration',


### PR DESCRIPTION
### Description

Specify a remote state file, which will allow the ADC to skip the initial dump process and use the ADC configuration contained in the state file directly.

**This is an experimental feature for some specific purposes and you should not use and rely on them as this may be removed at any time in the future.**

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
