### PR TITLE
feat(api7): move to publish free api

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,7 +53,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
       matrix:
-        version: [3.2.14.6, 3.2.15.2, 3.2.16.7, 3.3.2, 3.4.1, 3.5.1]
+        version: [3.3.2, 3.4.1, 3.5.1]
     env:
       BACKEND_API7_VERSION: ${{ matrix.version }}
       BACKEND_API7_DOWNLOAD_URL: https://run.api7.ai/api7-ee/api7-ee-v${{ matrix.version }}.tar.gz

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,7 +53,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
       matrix:
-        version: [3.2.14.6, 3.2.15.2, 3.2.16.7, 3.3.2]
+        version: [3.2.14.6, 3.2.15.2, 3.2.16.7, 3.3.2, 3.4.1, 3.5.1]
     env:
       BACKEND_API7_VERSION: ${{ matrix.version }}
       BACKEND_API7_DOWNLOAD_URL: https://run.api7.ai/api7-ee/api7-ee-v${{ matrix.version }}.tar.gz

--- a/libs/backend-api7/e2e/support/global-setup.ts
+++ b/libs/backend-api7/e2e/support/global-setup.ts
@@ -111,7 +111,10 @@ const initUser = async (
 const activateAPI7 = async () => {
   console.log('Upload license');
   await httpClient.put(`/api/license`, {
-    data: process.env.BACKEND_API7_LICENSE,
+    data: Buffer.from(
+      `${process.env.BACKEND_API7_LICENSE}`,
+      'base64',
+    ).toString(),
   });
 };
 

--- a/libs/backend-api7/src/fetcher.ts
+++ b/libs/backend-api7/src/fetcher.ts
@@ -27,28 +27,41 @@ export class Fetcher {
       title: 'Fetch services',
       skip: this.isSkip([ADCSDK.ResourceType.SERVICE]),
       task: async (ctx, task) => {
-        const resp = await this.client.get<{ list: Array<typing.Service> }>(
-          `/api/gateway_groups/${ctx.gatewayGroupId}/services`,
+        const resp = await this.client.get<typing.ListResponse<typing.Service>>(
+          `/apisix/admin/services`,
+          {
+            params: {
+              gateway_group_id: ctx.gatewayGroupId,
+            },
+          },
         );
         task.output = buildReqAndRespDebugOutput(resp, 'Get services');
 
         const services = resp?.data?.list;
         const fetchRoutes = services.map(async (service) => {
           if (service.type === 'http') {
-            const resp = await this.client.get<{
-              list: Array<typing.Route>;
-            }>(`/api/service_versions/${service.service_version_id}/routes`);
+            const resp = await this.client.get<
+              typing.ListResponse<typing.Route>
+            >(`/apisix/admin/routes`, {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+                service_id: service.service_id,
+              },
+            });
             task.output = buildReqAndRespDebugOutput(
               resp,
               `Get routes in service "${service.name}"`,
             );
             service.routes = resp?.data?.list;
           } else {
-            const resp = await this.client.get<{
-              list: Array<typing.StreamRoute>;
-            }>(
-              `/api/service_versions/${service.service_version_id}/stream_routes`,
-            );
+            const resp = await this.client.get<
+              typing.ListResponse<typing.StreamRoute>
+            >(`/apisix/admin/stream_routes`, {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+                service_id: service.service_id,
+              },
+            });
             task.output = buildReqAndRespDebugOutput(
               resp,
               `Get stream routes in service "${service.name}"`,
@@ -158,11 +171,16 @@ export class Fetcher {
       title: 'Fetch plugin metadata',
       skip: this.isSkip([ADCSDK.ResourceType.PLUGIN_METADATA]),
       task: async (ctx, task) => {
-        if (semVerGTE(ctx.api7Version, '3.2.14')) {
-          return this.listMetadatasGTE03021400(ctx, task);
-        } else {
-          return this.listMetadatasLT03021400(ctx, task);
-        }
+        const resp = await this.client.get<{
+          value: ADCSDK.Plugins;
+        }>('/apisix/admin/plugin_metadata', {
+          params: { gateway_group_id: ctx.gatewayGroupId },
+        });
+        task.output = buildReqAndRespDebugOutput(resp, 'Get plugin metadata');
+
+        ctx.remote.plugin_metadata = this.toADC.transformPluginMetadatas(
+          resp.data.value,
+        );
       },
     };
   }
@@ -201,60 +219,6 @@ export class Fetcher {
       }
     };
   }
-
-  // Get plugin metadata on API7 3.2.14.0 and up
-  private listMetadatasGTE03021400: FetchTask['task'] = async (ctx, task) => {
-    const resp = await this.client.get<{
-      value: ADCSDK.Plugins;
-    }>('/apisix/admin/plugin_metadata', {
-      params: { gateway_group_id: ctx.gatewayGroupId },
-    });
-    task.output = buildReqAndRespDebugOutput(resp, 'Get plugin metadata');
-    ctx.remote.plugin_metadata = this.toADC.transformPluginMetadatas(
-      resp.data.value,
-    );
-  };
-
-  // [DEPRECATED] Get plugin metadata below API7 3.2.14.0
-  // Support for 3.2.14.0 has been dropped, so this code will be removed in the future.
-  private listMetadatasLT03021400: FetchTask['task'] = async (ctx, task) => {
-    const resp = await this.client.get<Array<string>>(
-      '/apisix/admin/plugins/list',
-      {
-        params: { has_metadata: true },
-      },
-    );
-    task.output = buildReqAndRespDebugOutput(
-      resp,
-      'Get plugins that contain plugin metadata',
-    );
-
-    const plugins = resp.data;
-    const getMetadataConfig = plugins.map<
-      Promise<[string, typing.PluginMetadata]>
-    >(async (pluginName) => {
-      try {
-        const resp = await this.client.get<{
-          value: typing.PluginMetadata;
-        }>(`/apisix/admin/plugin_metadata/${pluginName}`, {
-          params: { gateway_group_id: ctx.gatewayGroupId },
-        });
-        task.output = buildReqAndRespDebugOutput(
-          resp,
-          `Get plugin metadata for "${pluginName}"`,
-        );
-        return [pluginName, resp?.data?.value];
-      } catch (err) {
-        return [pluginName, null];
-      }
-    });
-    const metadataObj = Object.fromEntries(
-      (await Promise.all(getMetadataConfig)).filter((item) => item[1]),
-    );
-
-    ctx.remote.plugin_metadata =
-      this.toADC.transformPluginMetadatas(metadataObj);
-  };
 
   private attachLabelSelector(
     params: Record<string, string>,

--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -245,7 +245,6 @@ export class BackendAPI7 implements ADCSDK.Backend {
                   ),
                 ),
             },
-        operator.publishService(),
       ],
       {
         //@ts-expect-error TODO reorg renderer

--- a/libs/backend-api7/src/operator.ts
+++ b/libs/backend-api7/src/operator.ts
@@ -28,33 +28,44 @@ export class Operator {
       task: async (ctx, task) => {
         let resp: AxiosResponse<{ error_msg?: string }>;
         if (event.resourceType === ADCSDK.ResourceType.SERVICE) {
-          ctx.needPublishServices[event.resourceId] = this.fromADC(
-            event,
-          ) as typing.Service;
-
-          // Create a service template instead of create published service directly
+          // Create published service directly
           resp = await this.client.put(
-            `/api/services/template/${event.resourceId}`,
+            `/apisix/admin/services/${event.resourceId}`,
             this.fromADC(event),
-            { validateStatus: () => true },
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
+            },
           );
           task.output = buildReqAndRespDebugOutput(resp);
         } else if (event.resourceType === ADCSDK.ResourceType.ROUTE) {
-          // Create a route template instead of create route directly
+          // Create route directly
           const route = this.fromADC(event);
           if (!semVerGTE(ctx.api7Version, '3.2.16')) unset(route, 'vars');
           resp = await this.client.put(
-            `/api/routes/template/${event.resourceId}`,
+            `/apisix/admin/routes/${event.resourceId}`,
             this.fromADC(event),
-            { validateStatus: () => true },
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
+            },
           );
           task.output = buildReqAndRespDebugOutput(resp);
         } else if (event.resourceType === ADCSDK.ResourceType.STREAM_ROUTE) {
-          // Create a stream route template instead of create stream route directly
+          // Create stream route directly
           resp = await this.client.put(
-            `/api/stream_routes/template/${event.resourceId}`,
+            `/apisix/admin/stream_routes/${event.resourceId}`,
             this.fromADC(event),
-            { validateStatus: () => true },
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
+            },
           );
           task.output = buildReqAndRespDebugOutput(resp);
         } else if (
@@ -87,7 +98,6 @@ export class Operator {
         }
 
         if (resp?.data?.error_msg) throw new Error(resp.data.error_msg);
-        // [200, 201].includes(resp.status);
       },
     };
   }
@@ -96,86 +106,49 @@ export class Operator {
     return {
       title: this.generateTaskName(event),
       task: async (ctx, task) => {
-        // If the resource type is Service, we should first disable it
+        let resp: AxiosResponse<{ error_msg?: string }>;
         if (event.resourceType === ADCSDK.ResourceType.SERVICE) {
-          // Modify the status of published service on gateway group
-          let resp = await this.client.patch(
-            `/api/gateway_groups/${ctx.gatewayGroupId}/services/${event.resourceId}/runtime_configuration`,
-            [
-              {
-                op: 'replace',
-                path: '/status',
-                value: 0,
-              },
-            ],
-            { validateStatus: () => true },
-          );
-          task.output = buildReqAndRespDebugOutput(
-            resp,
-            `Disable service "${event.resourceName}" on the gateway group ${this.gatewayGroupName}`,
-          );
-
-          // Remove disabled service on the gateway group
+          // Remove published service on the gateway group
           resp = await this.client.delete(
-            `/api/gateway_groups/${ctx.gatewayGroupId}/services/${event.resourceId}`,
-            { validateStatus: () => true },
+            `/apisix/admin/services/${event.resourceId}`,
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
+            },
           );
           task.output = buildReqAndRespDebugOutput(
             resp,
             `Remove service "${event.resourceName}" on the gateway group ${this.gatewayGroupName}`,
           );
-
-          // Check for other references to the service template and do not attempt
-          // to delete the service template if there are other references
-          interface UnknownList {
-            list: Array<unknown>;
-          }
-          resp = await this.client.get<UnknownList>(
-            `/api/services/${event.resourceId}/published_services`,
-            { validateStatus: () => true },
-          );
-          task.output = buildReqAndRespDebugOutput(
-            resp,
-            `Get publish record for service "${event.resourceName}"`,
-          );
-          if ((resp.data as UnknownList)?.list?.length > 0) {
-            task.output = JSON.stringify({
-              type: 'debug',
-              messages: [
-                'Service template delete is skipped: it is still used by other gateway groups',
-              ],
-            });
-            return;
-          }
-
-          resp = await this.client.delete(
-            `/api/services/template/${event.resourceId}`,
-            { validateStatus: () => true },
-          );
-          task.output = buildReqAndRespDebugOutput(
-            resp,
-            `Remove service template "${event.resourceName}"`,
-          );
-          return;
         } else if (event.resourceType === ADCSDK.ResourceType.ROUTE) {
-          const resp = await this.client.delete(
-            `/api/routes/template/${event.resourceId}`,
-            { validateStatus: () => true },
+          resp = await this.client.delete(
+            `/apisix/admin/routes/${event.resourceId}`,
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
+            },
           );
           task.output = buildReqAndRespDebugOutput(resp);
-          return;
         } else if (event.resourceType === ADCSDK.ResourceType.STREAM_ROUTE) {
-          const resp = await this.client.delete(
-            `/api/stream_routes/template/${event.resourceId}`,
-            { validateStatus: () => true },
+          resp = await this.client.delete(
+            `/apisix/admin/stream_routes/${event.resourceId}`,
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
+            },
           );
           task.output = buildReqAndRespDebugOutput(resp);
-          return;
         } else if (
           event.resourceType === ADCSDK.ResourceType.CONSUMER_CREDENTIAL &&
           semVerGTE(ctx.api7Version, '3.2.15')
         ) {
-          const resp = await this.client.delete(
+          resp = await this.client.delete(
             `/apisix/admin/consumers/${event.parentId}/credentials/${event.resourceId}`,
             {
               params: {
@@ -185,70 +158,20 @@ export class Operator {
             },
           );
           task.output = buildReqAndRespDebugOutput(resp);
-          return;
-        }
-
-        const resp = await this.client.delete(
-          `/apisix/admin/${this.generateResourceTypeInAPI(event.resourceType)}/${event.resourceId}`,
-          {
-            params: {
-              gateway_group_id: ctx.gatewayGroupId,
+        } else {
+          resp = await this.client.delete(
+            `/apisix/admin/${this.generateResourceTypeInAPI(event.resourceType)}/${event.resourceId}`,
+            {
+              params: {
+                gateway_group_id: ctx.gatewayGroupId,
+              },
+              validateStatus: () => true,
             },
-            validateStatus: () => true,
-          },
-        );
-        task.output = buildReqAndRespDebugOutput(resp);
-
-        if (resp?.data?.error_msg) throw new Error(resp.data.error_msg);
-        // [200, 404].includes(resp.status);
-      },
-    };
-  }
-
-  public publishService(): OperateTask {
-    return {
-      title: 'Publish services',
-      skip: (ctx) => {
-        if (!ctx.needPublishServices || size(ctx.needPublishServices) <= 0)
-          return 'No services to be published';
-      },
-      task: async (ctx, task) => {
-        const services = ctx.needPublishServices;
-
-        for (const [serviceId, service] of Object.entries(services)) {
-          if (!service) {
-            const resp = await this.client.get<{ value: typing.Service }>(
-              `/api/gateway_groups/${ctx.gatewayGroupId}/services/${serviceId}`,
-            );
-            task.output = buildReqAndRespDebugOutput(
-              resp,
-              `Fill in nil service, id ${serviceId}`,
-            );
-            services[serviceId] = resp?.data?.value;
-          }
+          );
+          task.output = buildReqAndRespDebugOutput(resp);
         }
 
-        const resp = await this.client.post(
-          '/api/services/publish',
-          {
-            create_new_version: true,
-            gateway_group_id: ctx.gatewayGroupId,
-            services: Object.values(services).map(
-              (service: typing.Service) => ({
-                ...service,
-                version: new Date().getTime().toString(),
-                hosts: service?.hosts?.length ? service.hosts : undefined,
-              }),
-            ),
-          },
-          {
-            validateStatus: () => true,
-          },
-        );
-        task.output = buildReqAndRespDebugOutput(resp, 'Publish all services');
-
         if (resp?.data?.error_msg) throw new Error(resp.data.error_msg);
-        // [200, 201].includes(resp.status);
       },
     };
   }

--- a/libs/backend-api7/src/typing.ts
+++ b/libs/backend-api7/src/typing.ts
@@ -139,3 +139,8 @@ export interface Resources {
   globalRules: Array<GlobalRule>;
   pluginMetadatas: PluginMetadata;
 }
+
+export interface ListResponse<T> {
+  list: Array<T>;
+  total: number;
+}


### PR DESCRIPTION
### Description

Based on the reference design provided by API7, the service template will no longer handle having runtime parameters about upstream, service and routing plugins.
Therefore the need for ADC to continue to use service templates instead of directly manipulating resources will no longer exist, and this PR modifies the API call to a direct manipulation of the published service.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
