### PR TITLE
feat(backend): enable keepalive for backend api call

### DIFF
--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -4,7 +4,14 @@ import { JSONSchema4 } from 'json-schema';
 import { Listr, ListrTask } from 'listr2';
 import { isEmpty, isNil } from 'lodash';
 import { readFileSync } from 'node:fs';
-import { AgentOptions, Agent as httpsAgent } from 'node:https';
+import {
+  Agent as httpAgent,
+  AgentOptions as httpAgentOptions,
+} from 'node:http';
+import {
+  Agent as httpsAgent,
+  AgentOptions as httpsAgentOptions,
+} from 'node:https';
 import semver, { SemVer } from 'semver';
 
 import { Fetcher } from './fetcher';
@@ -23,17 +30,22 @@ export class BackendAPI7 implements ADCSDK.Backend {
   private defaultValue: ADCSDK.DefaultValue;
 
   constructor(private readonly opts: ADCSDK.BackendOptions) {
+    const keepAlive: httpAgentOptions = {
+      keepAlive: true,
+      keepAliveMsecs: 60000,
+    };
     const config: CreateAxiosDefaults = {
       baseURL: `${opts.server}`,
       headers: {
         'X-API-KEY': opts.token,
         'Content-Type': 'application/json',
-        //'User-Agent': 'ADC/0.9.0-alpha.9 (ADC-API7-BACKEND)',
       },
+      httpAgent: new httpAgent(keepAlive),
     };
 
     if (opts.server.startsWith('https')) {
-      const agentConfig: AgentOptions = {
+      const agentConfig: httpsAgentOptions = {
+        ...keepAlive,
         rejectUnauthorized: !opts?.tlsSkipVerify,
       };
 

--- a/libs/backend-apisix/src/index.ts
+++ b/libs/backend-apisix/src/index.ts
@@ -2,7 +2,14 @@ import * as ADCSDK from '@api7/adc-sdk';
 import axios, { Axios, CreateAxiosDefaults } from 'axios';
 import { Listr, ListrTask } from 'listr2';
 import { readFileSync } from 'node:fs';
-import { AgentOptions, Agent as httpsAgent } from 'node:https';
+import {
+  Agent as httpAgent,
+  AgentOptions as httpAgentOptions,
+} from 'node:http';
+import {
+  Agent as httpsAgent,
+  AgentOptions as httpsAgentOptions,
+} from 'node:https';
 import semver from 'semver';
 
 import { Fetcher } from './fetcher';
@@ -14,16 +21,22 @@ export class BackendAPISIX implements ADCSDK.Backend {
   private static logScope = ['APISIX'];
 
   constructor(private readonly opts: ADCSDK.BackendOptions) {
+    const keepAlive: httpAgentOptions = {
+      keepAlive: true,
+      keepAliveMsecs: 60000,
+    };
     const config: CreateAxiosDefaults = {
       baseURL: `${opts.server}`,
       headers: {
         'Content-Type': 'application/json',
         'X-API-KEY': opts.token,
       },
+      httpAgent: new httpAgent(keepAlive),
     };
 
     if (opts.server.startsWith('https')) {
-      const agentConfig: AgentOptions = {
+      const agentConfig: httpsAgentOptions = {
+        ...keepAlive,
         rejectUnauthorized: !opts?.tlsSkipVerify,
       };
 


### PR DESCRIPTION
### Description

Enabled connection pool on the API7 and APISIX backend APIs to enhance their performance and time consumption when sending large numbers of API requests.
Specifically, instead of establishing a new TCP connection on each request, ADC will attempt to reuse existing connections.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
