### PR TITLE
feat(api7): allow dev version and admin key mode

### DIFF
--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -169,6 +169,10 @@ export class BackendAPI7 implements ADCSDK.Backend {
           ctx.gatewayGroupId = this.gatewayGroupId;
           return;
         }
+        if (this.opts?.token?.startsWith('a7adm-')) {
+          ctx.gatewayGroupId = this.gatewayGroupId = '';
+          return;
+        }
 
         const resp = await this.client.get<{ list: Array<{ id: string }> }>(
           '/api/gateway_groups',
@@ -203,6 +207,11 @@ export class BackendAPI7 implements ADCSDK.Backend {
 
         const resp = await this.client.get<{ value: string }>('/api/version');
         task.output = buildReqAndRespDebugOutput(resp, `Get API7 version`);
+
+        if (resp?.data?.value === 'dev') {
+          ctx.api7Version = this.version = semver.coerce('999.999.999');
+          return;
+        }
         ctx.api7Version = this.version =
           semver.coerce(resp?.data?.value) || semver.coerce('0.0.0');
       },


### PR DESCRIPTION
### Description

1. Make semver handle non-standardized version numbers like `dev` normally, which will make new features always on and old feature gates always off.

2. When using an admin key with a gateway group hint, the ADC should not attempt to obtain the gateway group id via the API.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
