### PR TITLE
fix(api7): unexpectedly pass the empty string gateway group id

### DIFF
--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -163,14 +163,11 @@ export class BackendAPI7 implements ADCSDK.Backend {
 
   private getGatewayGroupIdTask(name: string): ListrTask {
     return {
-      enabled: (ctx) => !ctx.gatewayGroupId,
+      enabled: (ctx) =>
+        !ctx.gatewayGroupId && !this.opts?.token?.startsWith('a7adm-'),
       task: async (ctx, task) => {
         if (this.gatewayGroupId) {
           ctx.gatewayGroupId = this.gatewayGroupId;
-          return;
-        }
-        if (this.opts?.token?.startsWith('a7adm-')) {
-          ctx.gatewayGroupId = this.gatewayGroupId = '';
           return;
         }
 
@@ -271,6 +268,12 @@ export class BackendAPI7 implements ADCSDK.Backend {
         rendererOptions: { scope: BackendAPI7.logScope },
       },
     );
+
+    [
+      'GET_VER',
+      'GET_GG_ID',
+      ['DELETE#1', 'DELETE#2', 'DELETE#3', 'UPDATE#1', 'UPDATE#2'],
+    ];
   }
 
   // Preprocess events for sync:


### PR DESCRIPTION
### Description

Fix: unexpectedly passing the empty string as the gateway group id.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
