### PR TITLE
fix(core): incorrect empty remote in ingress mode

### DIFF
--- a/apps/cli/src/command/ingress-sync.command.ts
+++ b/apps/cli/src/command/ingress-sync.command.ts
@@ -47,11 +47,6 @@ export const IngressSyncCommand = new BackendCommand<SyncOption>('sync')
               excludeResourceType: opts.excludeResourceType,
             })
           : ExperimentalRemoteStateFileTask(opts.remoteStateFile),
-        {
-          task: (ctx) => {
-            ctx.remote = {};
-          },
-        },
         DiffResourceTask(false, false),
         {
           title: 'Sync configuration',


### PR DESCRIPTION
### Description

The remote configuration was incorrectly cleared in ingress mode, which invalidated the delete operation. Fix it.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
