### PR TITLE
feat: imporve backend error handling

### DIFF
--- a/apps/cli/src/command/ingress-sync.command.ts
+++ b/apps/cli/src/command/ingress-sync.command.ts
@@ -53,7 +53,9 @@ export const IngressSyncCommand = new BackendCommand<SyncOption>('sync')
           task: async (ctx) => {
             try {
               const results = await lastValueFrom(
-                ctx.backend.sync(ctx.diff).pipe(toArray()),
+                ctx.backend
+                  .sync(ctx.diff, { exitOnFailure: false })
+                  .pipe(toArray()),
               );
 
               const successes = results.filter((result) => result.success);

--- a/apps/cli/src/command/sync.command.ts
+++ b/apps/cli/src/command/sync.command.ts
@@ -93,7 +93,11 @@ export const SyncCommand = new BackendCommand<SyncOption>(
           title: 'Sync configuration',
           task: async (ctx, task) => {
             const cancel = addBackendEventListener(ctx.backend, task);
-            await lastValueFrom(ctx.backend.sync(ctx.diff).pipe(toArray()));
+            await lastValueFrom(
+              ctx.backend
+                .sync(ctx.diff, { exitOnFailure: true })
+                .pipe(toArray()),
+            );
             cancel();
           },
           exitOnError: true,

--- a/libs/backend-api7/e2e/misc.e2e-spec.ts
+++ b/libs/backend-api7/e2e/misc.e2e-spec.ts
@@ -183,5 +183,11 @@ describe('Miscellaneous', () => {
         errorPattern,
       );
     });
+
+    it('Delete services', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.SERVICE, service1Name),
+        deleteEvent(ADCSDK.ResourceType.SERVICE, service2Name),
+      ]));
   });
 });

--- a/libs/backend-api7/e2e/misc.e2e-spec.ts
+++ b/libs/backend-api7/e2e/misc.e2e-spec.ts
@@ -187,7 +187,6 @@ describe('Miscellaneous', () => {
     it('Delete services', async () =>
       syncEvents(backend, [
         deleteEvent(ADCSDK.ResourceType.SERVICE, service1Name),
-        deleteEvent(ADCSDK.ResourceType.SERVICE, service2Name),
       ]));
   });
 });

--- a/libs/backend-api7/e2e/misc.e2e-spec.ts
+++ b/libs/backend-api7/e2e/misc.e2e-spec.ts
@@ -1,13 +1,8 @@
 import * as ADCSDK from '@api7/adc-sdk';
+import { toString } from 'lodash';
 
 import { BackendAPI7 } from '../src';
-import {
-  createEvent,
-  deleteEvent,
-  dumpConfiguration,
-  overrideEventResourceId,
-  syncEvents,
-} from './support/utils';
+import { createEvent, syncEvents } from './support/utils';
 
 describe('Miscellaneous', () => {
   let backend: BackendAPI7;
@@ -21,115 +16,54 @@ describe('Miscellaneous', () => {
     });
   });
 
-  describe('Sync resources with the name/description greater than 256 bytes', () => {
-    const routeName = ''.padEnd(64 * 1024, '0'); // 65536 bytes
-    const serviceName = ''.padEnd(64 * 1024, '0'); // 65536 bytes
-    const route = {
-      name: routeName,
-      uris: ['/test'],
-    };
-    const service = {
-      name: serviceName,
-      description: ''.padEnd(64 * 1024, '0'), // 65536 bytes
-      upstream: {
-        scheme: 'https',
-        nodes: [
-          {
-            host: 'httpbin.org',
-            port: 443,
-            weight: 100,
-          },
-        ],
-      },
-      routes: [route],
+  describe('Sync options (exitOnFailure)', () => {
+    const upstream = {
+      scheme: 'https',
+      nodes: [
+        {
+          host: 'httpbin.org',
+          port: 443,
+          weight: 100,
+        },
+      ],
+    } as ADCSDK.Upstream;
+    const service1Name = 'service1';
+    const service1 = {
+      name: service1Name,
+      upstream: structuredClone(upstream),
+    } as ADCSDK.Service;
+    const service2Name = 'service2';
+    //@ts-expect-error error test
+    const service2 = {
+      name: service2Name,
+      path_prefix: 12345,
+      upstream: structuredClone(upstream),
     } as ADCSDK.Service;
 
-    it('Create services', async () =>
-      syncEvents(backend, [
-        createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
-        createEvent(ADCSDK.ResourceType.ROUTE, routeName, route, serviceName),
-      ]));
-
-    it('Dump', async () => {
-      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.services).toHaveLength(1);
-      expect(result.services[0]).toMatchObject(service);
-      expect(result.services[0]).toMatchObject(service);
-      expect(result.services[0].routes[0]).toMatchObject(route);
+    const errorPattern = `validate request failed: request body has an error: doesn't match schema: doesn't match schema due to: Error at "/path_prefix": value must be a string`;
+    it('Create services (exitOnFailure = true, default)', async () => {
+      await expect(
+        syncEvents(backend, [
+          createEvent(ADCSDK.ResourceType.SERVICE, service1Name, service1),
+          createEvent(ADCSDK.ResourceType.SERVICE, service2Name, service2),
+        ]),
+      ).rejects.toThrow(new RegExp(errorPattern));
     });
 
-    it('Delete service', async () =>
-      syncEvents(backend, [
-        deleteEvent(ADCSDK.ResourceType.ROUTE, routeName, serviceName),
-        deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
-      ]));
-
-    it('Dump again', async () => {
-      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.services).toHaveLength(0);
-    });
-  });
-
-  describe('Sync resources with custom id', () => {
-    const routeName = 'Test Route';
-    const serviceName = 'Test Service';
-    const route = {
-      id: 'custom-route',
-      name: routeName,
-      uris: ['/test'],
-    };
-    const service = {
-      id: 'custom-service',
-      name: serviceName,
-      upstream: {
-        scheme: 'https',
-        nodes: [
-          {
-            host: 'httpbin.org',
-            port: 443,
-            weight: 100,
-          },
+    it('Create services (exitOnFailure = false)', async () => {
+      const results = await syncEvents(
+        backend,
+        [
+          createEvent(ADCSDK.ResourceType.SERVICE, service1Name, service1),
+          createEvent(ADCSDK.ResourceType.SERVICE, service2Name, service2),
         ],
-      },
-      routes: [route],
-    } as ADCSDK.Service;
+        { exitOnFailure: false },
+      );
 
-    it('Create services', async () =>
-      syncEvents(backend, [
-        overrideEventResourceId(
-          createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
-          'custom-service',
-        ),
-        overrideEventResourceId(
-          createEvent(ADCSDK.ResourceType.ROUTE, routeName, route, serviceName),
-          'custom-route',
-          'custom-service',
-        ),
-      ]));
-
-    it('Dump', async () => {
-      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.services).toHaveLength(1);
-      expect(result.services[0]).toMatchObject(service);
-      expect(result.services[0].routes[0]).toMatchObject(route);
-    });
-
-    it('Delete service', async () =>
-      syncEvents(backend, [
-        overrideEventResourceId(
-          deleteEvent(ADCSDK.ResourceType.ROUTE, routeName, serviceName),
-          'custom-route',
-          'custom-service',
-        ),
-        overrideEventResourceId(
-          deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
-          'custom-service',
-        ),
-      ]));
-
-    it('Dump again', async () => {
-      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.services).toHaveLength(0);
+      expect(results.filter((r) => r.success)).toHaveLength(1);
+      expect(toString(results.filter((r) => !r.success)[0].error)).toContain(
+        errorPattern,
+      );
     });
   });
 });

--- a/libs/backend-api7/e2e/misc.e2e-spec.ts
+++ b/libs/backend-api7/e2e/misc.e2e-spec.ts
@@ -2,7 +2,13 @@ import * as ADCSDK from '@api7/adc-sdk';
 import { toString } from 'lodash';
 
 import { BackendAPI7 } from '../src';
-import { createEvent, syncEvents } from './support/utils';
+import {
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  overrideEventResourceId,
+  syncEvents,
+} from './support/utils';
 
 describe('Miscellaneous', () => {
   let backend: BackendAPI7;
@@ -13,6 +19,118 @@ describe('Miscellaneous', () => {
       token: process.env.TOKEN,
       tlsSkipVerify: true,
       gatewayGroup: process.env.GATEWAY_GROUP,
+    });
+  });
+
+  describe('Sync resources with the name/description greater than 256 bytes', () => {
+    const routeName = ''.padEnd(64 * 1024, '0'); // 65536 bytes
+    const serviceName = ''.padEnd(64 * 1024, '0'); // 65536 bytes
+    const route = {
+      name: routeName,
+      uris: ['/test'],
+    };
+    const service = {
+      name: serviceName,
+      description: ''.padEnd(64 * 1024, '0'), // 65536 bytes
+      upstream: {
+        scheme: 'https',
+        nodes: [
+          {
+            host: 'httpbin.org',
+            port: 443,
+            weight: 100,
+          },
+        ],
+      },
+      routes: [route],
+    } as ADCSDK.Service;
+
+    it('Create services', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
+        createEvent(ADCSDK.ResourceType.ROUTE, routeName, route, serviceName),
+      ]));
+
+    it('Dump', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject(service);
+      expect(result.services[0]).toMatchObject(service);
+      expect(result.services[0].routes[0]).toMatchObject(route);
+    });
+
+    it('Delete service', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.ROUTE, routeName, serviceName),
+        deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
+      ]));
+
+    it('Dump again', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(0);
+    });
+  });
+
+  describe('Sync resources with custom id', () => {
+    const routeName = 'Test Route';
+    const serviceName = 'Test Service';
+    const route = {
+      id: 'custom-route',
+      name: routeName,
+      uris: ['/test'],
+    };
+    const service = {
+      id: 'custom-service',
+      name: serviceName,
+      upstream: {
+        scheme: 'https',
+        nodes: [
+          {
+            host: 'httpbin.org',
+            port: 443,
+            weight: 100,
+          },
+        ],
+      },
+      routes: [route],
+    } as ADCSDK.Service;
+
+    it('Create services', async () =>
+      syncEvents(backend, [
+        overrideEventResourceId(
+          createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
+          'custom-service',
+        ),
+        overrideEventResourceId(
+          createEvent(ADCSDK.ResourceType.ROUTE, routeName, route, serviceName),
+          'custom-route',
+          'custom-service',
+        ),
+      ]));
+
+    it('Dump', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject(service);
+      expect(result.services[0].routes[0]).toMatchObject(route);
+    });
+
+    it('Delete service', async () =>
+      syncEvents(backend, [
+        overrideEventResourceId(
+          deleteEvent(ADCSDK.ResourceType.ROUTE, routeName, serviceName),
+          'custom-route',
+          'custom-service',
+        ),
+        overrideEventResourceId(
+          deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
+          'custom-service',
+        ),
+      ]));
+
+    it('Dump again', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.services).toHaveLength(0);
     });
   });
 

--- a/libs/backend-api7/e2e/support/global-setup.ts
+++ b/libs/backend-api7/e2e/support/global-setup.ts
@@ -141,7 +141,6 @@ const generateToken = async () => {
       expires_at: 0,
       name: randomUUID(),
     },
-    { validateStatus: () => true },
   );
 
   process.env.TOKEN = resp.data.value.token;

--- a/libs/backend-api7/e2e/support/utils.ts
+++ b/libs/backend-api7/e2e/support/utils.ts
@@ -26,7 +26,8 @@ export const runTask = async (tasks: Listr, ctx = {}) => {
 export const syncEvents = async (
   backend: BackendAPI7,
   events: Array<ADCSDK.Event> = [],
-) => lastValueFrom(backend.sync(events).pipe(toArray()));
+  opts?: ADCSDK.BackendSyncOptions,
+) => lastValueFrom(backend.sync(events, opts).pipe(toArray()));
 
 export const dumpConfiguration = async (backend: BackendAPI7) =>
   lastValueFrom(backend.dump());

--- a/libs/backend-api7/src/fetcher.ts
+++ b/libs/backend-api7/src/fetcher.ts
@@ -4,6 +4,7 @@ import { produce } from 'immer';
 import { curry, isEmpty } from 'lodash';
 import {
   Subject,
+  catchError,
   combineLatest,
   from,
   map,
@@ -225,7 +226,7 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
     );
   }
 
-  public allTask() {
+  public dump() {
     return combineLatest([
       this.listServices(),
       this.listConsumers(),

--- a/libs/backend-api7/src/operator.ts
+++ b/libs/backend-api7/src/operator.ts
@@ -51,7 +51,6 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
         method: 'DELETE',
         url: path,
         params: { gateway_group_id: this.opts.gatewayGroupId },
-        validateStatus: () => true,
         ...(isUpdate && {
           method: 'PUT',
           data: this.fromADC(event),
@@ -60,7 +59,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
     );
   }
 
-  public sync(events: Array<ADCSDK.Event>) {
+  public sync(events: Array<ADCSDK.Event>, opts: ADCSDK.BackendSyncOptions) {
     return this.syncPreprocessEvents(events).pipe(
       concatMap((group) =>
         from(group).pipe(
@@ -71,34 +70,29 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
             logger(taskStateEvent('TASK_START'));
             return from(this.operate(event)).pipe(
               tap((resp) => logger(this.debugLogEvent(resp))),
-              map<AxiosResponse, ADCSDK.BackendSyncResult>((response) => {
-                return {
-                  success: true,
-                  event,
-                  axiosResponse: response,
-                  ...(response?.data?.error_msg && {
-                    success: false,
-                    error: new Error(response.data.error_msg),
-                  }),
-                } satisfies ADCSDK.BackendSyncResult;
-              }),
+              map<AxiosResponse, ADCSDK.BackendSyncResult>(
+                (response) =>
+                  ({
+                    success: true,
+                    event,
+                    axiosResponse: response,
+                  }) satisfies ADCSDK.BackendSyncResult,
+              ),
               catchError<
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
-                if (axios.isAxiosError(error)) {
-                  //TODO exitOnFailed if (opts.exitOnFailed) throw error;
-                  return of({
-                    success: false,
-                    event,
-                    axiosResponse: error.response,
-                    error,
-                  } satisfies ADCSDK.BackendSyncResult);
-                }
+                if (opts.exitOnFailure) throw error;
                 return of({
                   success: false,
                   event,
                   error,
+                  ...(axios.isAxiosError(error) && {
+                    axiosResponse: error.response,
+                    ...(error.response?.data?.error_msg && {
+                      error: new Error(error.response.data.error_msg),
+                    }),
+                  }),
                 } satisfies ADCSDK.BackendSyncResult);
               }),
               tap(() => logger(taskStateEvent('TASK_DONE'))),

--- a/libs/backend-api7/src/operator.ts
+++ b/libs/backend-api7/src/operator.ts
@@ -82,7 +82,10 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
-                if (opts.exitOnFailure) throw error;
+                if (opts.exitOnFailure)
+                  throw new Error(
+                    `Error: ${axios.isAxiosError(error) && error.response ? error.response.data?.error_msg : error.message}, `,
+                  );
                 return of({
                   success: false,
                   event,

--- a/libs/backend-apisix/e2e/support/utils.ts
+++ b/libs/backend-apisix/e2e/support/utils.ts
@@ -97,6 +97,9 @@ export const overrideEventResourceId = (
 export const sortResult = <T>(result: Array<T>, field: string) =>
   structuredClone(result).sort((a, b) => a[field].localeCompare(b[field]));
 
+export const wait = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 type cond = boolean | (() => boolean);
 
 export const conditionalDescribe = (cond: cond) =>

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -170,6 +170,7 @@ describe('Sync and Dump - 1', () => {
       //   Admin API write etcd => etcd push delete event => handle event and take effect
       // before it can be updated, this makes service deletions always tend to fail, so
       // this requires a short pause to wait for APISIX to synchronize.
+      //   https://github.com/apache/apisix/blob/master/apisix/admin/services.lua#L88
       // This seems to require some modification in APISIX to make the process complete
       // faster to increase the success rate of deletions.
       await wait(200);

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -16,6 +16,7 @@ import {
   sortResult,
   syncEvents,
   updateEvent,
+  wait,
 } from './support/utils';
 
 describe('Sync and Dump - 1', () => {
@@ -157,11 +158,15 @@ describe('Sync and Dump - 1', () => {
       expect(result.services[0].routes[0]).toMatchObject(route2);
     });
 
-    it('Delete service', async () =>
-      syncEvents(backend, [
+    it('Delete service', async () => {
+      await syncEvents(backend, [
         deleteEvent(ADCSDK.ResourceType.ROUTE, route2Name, serviceName),
+      ]);
+      await wait(1000);
+      await syncEvents(backend, [
         deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
-      ]));
+      ]);
+    });
 
     it('Dump again (service should not exist)', async () => {
       const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -162,7 +162,17 @@ describe('Sync and Dump - 1', () => {
       await syncEvents(backend, [
         deleteEvent(ADCSDK.ResourceType.ROUTE, route2Name, serviceName),
       ]);
-      await wait(1000);
+
+      // Since APISIX uses its in-memory routes configuration to check for referential
+      // relationships when deleting services, when we delete a route and its associated
+      // service at almost the same time, since the in-memory cache update needs to go
+      // through the
+      //   Admin API write etcd => etcd push delete event => handle event and take effect
+      // before it can be updated, this makes service deletions always tend to fail, so
+      // this requires a short pause to wait for APISIX to synchronize.
+      // This seems to require some modification in APISIX to make the process complete
+      // faster to increase the success rate of deletions.
+      await wait(200);
       await syncEvents(backend, [
         deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
       ]);

--- a/libs/backend-apisix/src/fetcher.ts
+++ b/libs/backend-apisix/src/fetcher.ts
@@ -45,11 +45,7 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
     const logger = this.getLogger(taskName);
     const taskStateEvent = this.taskStateEvent(taskName);
     logger(taskStateEvent('TASK_START'));
-    return from(
-      this.client.get<RESP_TYPE>(`/apisix/admin/${apiName}`, {
-        validateStatus: () => true,
-      }),
-    ).pipe(
+    return from(this.client.get<RESP_TYPE>(`/apisix/admin/${apiName}`)).pipe(
       tap((resp) => logger(this.debugLogEvent(resp))),
       map((resp) => resp.data),
       finalize(() => logger(taskStateEvent('TASK_DONE'))),
@@ -88,7 +84,6 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
     return from(
       this.client.get<typing.ListResponse<typing.Consumer>>(
         `/apisix/admin/consumers`,
-        { validateStatus: () => true },
       ),
     ).pipe(
       tap((resp) => logger(this.debugLogEvent(resp))),
@@ -101,7 +96,6 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
               from(
                 this.client.get<typing.ListResponse<typing.ConsumerCredential>>(
                   `/apisix/admin/consumers/${consumer.username}/credentials`,
-                  { validateStatus: () => true },
                 ),
               ).pipe(
                 tap((resp) =>
@@ -170,7 +164,6 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
     return from(
       this.client.get<typing.ListResponse<typing.StreamRoute>>(
         `/apisix/admin/stream_routes`,
-        { validateStatus: () => true },
       ),
     ).pipe(
       map((resp) => {

--- a/libs/backend-apisix/src/fetcher.ts
+++ b/libs/backend-apisix/src/fetcher.ts
@@ -96,6 +96,7 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
               from(
                 this.client.get<typing.ListResponse<typing.ConsumerCredential>>(
                   `/apisix/admin/consumers/${consumer.username}/credentials`,
+                  { validateStatus: () => true },
                 ),
               ).pipe(
                 tap((resp) =>

--- a/libs/backend-apisix/src/index.ts
+++ b/libs/backend-apisix/src/index.ts
@@ -105,6 +105,7 @@ export class BackendAPISIX implements ADCSDK.Backend {
 
   public sync(
     events: Array<ADCSDK.Event>,
+    opts: ADCSDK.BackendSyncOptions = { exitOnFailure: true },
   ): Observable<ADCSDK.BackendSyncResult> {
     return forkJoin([from(this.version()), from(this.defaultValue())]).pipe(
       switchMap(([version]) => {
@@ -112,7 +113,7 @@ export class BackendAPISIX implements ADCSDK.Backend {
           client: this.client,
           version,
           eventSubject: this.subject,
-        }).sync(events);
+        }).sync(events, opts);
       }),
     );
   }

--- a/libs/backend-apisix/src/operator.ts
+++ b/libs/backend-apisix/src/operator.ts
@@ -104,7 +104,10 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
-                if (opts.exitOnFailure) throw error;
+                if (opts.exitOnFailure)
+                  throw new Error(
+                    `Error: ${axios.isAxiosError(error) && error.response ? error.response.data?.error_msg : error.message}, `,
+                  );
                 return of({
                   success: false,
                   event,

--- a/libs/backend-apisix/src/operator.ts
+++ b/libs/backend-apisix/src/operator.ts
@@ -6,15 +6,12 @@ import {
   Subject,
   catchError,
   concatMap,
-  filter,
   from,
   map,
   mergeMap,
   of,
   reduce,
-  switchMap,
   tap,
-  toArray,
 } from 'rxjs';
 import { SemVer, gte as semVerGTE, lt as semVerLT } from 'semver';
 
@@ -48,7 +45,6 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
       this.client.request({
         method: 'DELETE',
         url: path,
-        validateStatus: () => true,
         ...(isUpdate && {
           method: 'PUT',
           data: this.fromADC(event, this.opts.version),
@@ -57,7 +53,10 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
     );
   }
 
-  public sync(events: Array<ADCSDK.Event>) {
+  public sync(
+    events: Array<ADCSDK.Event>,
+    opts: ADCSDK.BackendSyncOptions = { exitOnFailure: true },
+  ) {
     return this.syncPreprocessEvents(events).pipe(
       concatMap((group) =>
         from(group).pipe(
@@ -93,37 +92,29 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
             logger(taskStateEvent('TASK_START'));
             return from(this.operate(event)).pipe(
               tap((resp) => logger(this.debugLogEvent(resp))),
-              map<AxiosResponse, ADCSDK.BackendSyncResult>((response) => {
-                if (response.status >= 400)
-                  throw new Error(response.data.error_msg);
-
-                return {
-                  success: true,
-                  event,
-                  axiosResponse: response,
-                  ...(response?.data?.error_msg && {
-                    success: false,
-                    error: new Error(response.data.error_msg),
-                  }),
-                } satisfies ADCSDK.BackendSyncResult;
-              }),
+              map<AxiosResponse, ADCSDK.BackendSyncResult>(
+                (response) =>
+                  ({
+                    success: true,
+                    event,
+                    axiosResponse: response,
+                  }) satisfies ADCSDK.BackendSyncResult,
+              ),
               catchError<
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
-                if (axios.isAxiosError(error)) {
-                  //TODO exitOnFailed if (opts.exitOnFailed) throw error;
-                  return of({
-                    success: false,
-                    event,
-                    axiosResponse: error.response,
-                    error,
-                  } satisfies ADCSDK.BackendSyncResult);
-                }
+                if (opts.exitOnFailure) throw error;
                 return of({
                   success: false,
                   event,
                   error,
+                  ...(axios.isAxiosError(error) && {
+                    axiosResponse: error.response,
+                    ...(error.response?.data?.error_msg && {
+                      error: new Error(error.response.data.error_msg),
+                    }),
+                  }),
                 } satisfies ADCSDK.BackendSyncResult);
               }),
               tap(() => logger(taskStateEvent('TASK_DONE'))),

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -48,6 +48,10 @@ export interface BackendEventAxiosDebug {
   description?: string;
 }
 
+export interface BackendSyncOptions {
+  exitOnFailure?: boolean;
+}
+
 export interface BackendSyncResult {
   success: boolean;
   event: ADCSDK.Event;
@@ -61,7 +65,10 @@ export interface Backend {
   version: () => Promise<SemVer>;
   defaultValue: () => Promise<ADCSDK.DefaultValue>;
   dump: () => Observable<ADCSDK.Configuration>;
-  sync: (events: Array<ADCSDK.Event>) => Observable<BackendSyncResult>;
+  sync: (
+    events: Array<ADCSDK.Event>,
+    opts?: BackendSyncOptions,
+  ) => Observable<BackendSyncResult>;
 
   supportValidate?: () => Promise<boolean>;
   supportStreamRoute?: () => Promise<boolean>;


### PR DESCRIPTION
### Description

Improved error handling in API7 and APISIX backends, which can now run in continue-on-failure and exit-on-failure modes.
In the ADC CLI mod, it will continue to run in fail-on-exit mode as in previous versions, while Ingress mode allows errors to be logged and returned instead of interrupting synchronization.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
