### PR TITLE
fix(apisix): log scope typo

### DIFF
--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -65,6 +65,12 @@ export class BackendAPI7 implements ADCSDK.Backend {
     this.gatewayGroupName = opts.gatewayGroup;
   }
 
+  public metadata() {
+    return {
+      logScope: BackendAPI7.logScope,
+    };
+  }
+
   public async ping() {
     await this.client.get('/api/gateway_groups');
   }

--- a/libs/backend-apisix/src/index.ts
+++ b/libs/backend-apisix/src/index.ts
@@ -17,6 +17,7 @@ import { Fetcher } from './fetcher';
 import { Operator } from './operator';
 
 export class BackendAPISIX implements ADCSDK.Backend {
+  private static logScope = ['APISIX'];
   private readonly client: Axios;
   private readonly subject = new Subject<ADCSDK.BackendEvent>();
 
@@ -56,6 +57,12 @@ export class BackendAPISIX implements ADCSDK.Backend {
     if (opts.timeout) config.timeout = opts.timeout;
 
     this.client = axios.create(config);
+  }
+
+  public metadata() {
+    return {
+      logScope: BackendAPISIX.logScope,
+    };
   }
 
   public async defaultValue() {

--- a/libs/converter-openapi/src/index.ts
+++ b/libs/converter-openapi/src/index.ts
@@ -166,7 +166,7 @@ export class OpenAPIConverter implements ADCSDK.Converter {
 
   private buildDebugOutput(messages: Array<string>) {
     return JSON.stringify({
-      type: 'debug',
+      type: 'DEBUG',
       messages,
     });
   }

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -59,7 +59,13 @@ export interface BackendSyncResult {
   error?: Error;
 }
 
+export interface BackendMetadata {
+  logScope: string[];
+}
+
 export interface Backend {
+  metadata: () => BackendMetadata;
+
   ping: () => Promise<void>;
 
   version: () => Promise<SemVer>;


### PR DESCRIPTION
### Description

According to the report in #251, log scope on the APISIX backend are incorrectly displayed as API7, I fix it in this PR.

Fixes #251

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
