### PR TITLE
feat(apisix): support multiple upstream of service

### DIFF
--- a/apps/cli/src/differ/differv3.ts
+++ b/apps/cli/src/differ/differv3.ts
@@ -318,7 +318,7 @@ export class DifferV3 {
 
     const checkedRemoteId: Array<ADCSDK.ResourceId> = [];
     remote.forEach(([remoteName, remoteId, remoteItem]) => {
-      remoteItem = structuredClone(remoteItem); //TODO handle potentially immutable objects systematically
+      remoteItem = cloneDeep(remoteItem); //TODO handle potentially immutable objects systematically
       unset(remoteItem, 'metadata');
       unset(remoteItem, 'id');
 

--- a/apps/cli/src/differ/differv3.ts
+++ b/apps/cli/src/differ/differv3.ts
@@ -318,6 +318,7 @@ export class DifferV3 {
 
     const checkedRemoteId: Array<ADCSDK.ResourceId> = [];
     remote.forEach(([remoteName, remoteId, remoteItem]) => {
+      remoteItem = structuredClone(remoteItem); //TODO handle potentially immutable objects systematically
       unset(remoteItem, 'metadata');
       unset(remoteItem, 'id');
 

--- a/apps/cli/src/differ/specs/basic.spec.ts
+++ b/apps/cli/src/differ/specs/basic.spec.ts
@@ -768,7 +768,7 @@ describe('Differ V3 - basic', () => {
           { kind: 'E', lhs: true, path: ['strip_path_prefix'], rhs: false },
         ],
         newValue: service,
-        oldValue: oldService,
+        oldValue: { ...service, strip_path_prefix: true },
         resourceId: ADCSDK.utils.generateId(service.name),
         resourceName: service.name,
         resourceType: ADCSDK.ResourceType.SERVICE,

--- a/apps/cli/src/differ/specs/usecase.spec.ts
+++ b/apps/cli/src/differ/specs/usecase.spec.ts
@@ -93,8 +93,14 @@ describe('Differ V3 - usecase', () => {
           description: '',
           name: 'HTTPBIN Service',
           routes: [
-            { methods: ['GET'], name: 'Anything', uris: ['/anything'] },
             {
+              id: ADCSDK.utils.generateId('HTTPBIN Service.Anything'),
+              methods: ['GET'],
+              name: 'Anything',
+              uris: ['/anything'],
+            },
+            {
+              id: ADCSDK.utils.generateId('HTTPBIN Service.Generate UUID'),
               name: 'Generate UUID',
               methods: ['GET'],
               uris: ['/uuid'],

--- a/libs/backend-apisix/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/service-upstream.e2e-spec.ts
@@ -36,8 +36,6 @@ describe('Service-Upstreams E2E', () => {
           },
         ],
       },
-      path_prefix: '/test',
-      strip_path_prefix: true,
     } satisfies ADCSDK.Service;
     const upstreamND1Name = 'nd-upstream1';
     const upstreamND1 = {

--- a/libs/backend-apisix/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/service-upstream.e2e-spec.ts
@@ -1,151 +1,141 @@
 import * as ADCSDK from '@api7/adc-sdk';
-import { gte } from 'semver';
 
 import { BackendAPISIX } from '../../src';
 import { server, token } from '../support/constants';
 import {
-  conditionalDescribe,
   createEvent,
   deleteEvent,
   dumpConfiguration,
-  semverCondition,
   sortResult,
   syncEvents,
   updateEvent,
 } from '../support/utils';
 
-conditionalDescribe(semverCondition(gte, '3.5.0'))(
-  'Service-Upstreams E2E',
-  () => {
-    let backend: BackendAPISIX;
+describe('Service-Upstreams E2E', () => {
+  let backend: BackendAPISIX;
 
-    beforeAll(() => {
-      backend = new BackendAPISIX({
-        server,
-        token,
-        tlsSkipVerify: true,
-      });
+  beforeAll(() => {
+    backend = new BackendAPISIX({
+      server,
+      token,
+      tlsSkipVerify: true,
     });
+  });
 
-    describe('Service multiple upstreams', () => {
-      const serviceName = 'test';
-      const service = {
-        name: serviceName,
-        upstream: {
-          type: 'roundrobin',
-          nodes: [
-            {
-              host: 'httpbin.org',
-              port: 443,
-              weight: 100,
-            },
-          ],
+  describe('Service multiple upstreams', () => {
+    const serviceName = 'test';
+    const service = {
+      name: serviceName,
+      upstream: {
+        type: 'roundrobin',
+        nodes: [
+          {
+            host: 'httpbin.org',
+            port: 443,
+            weight: 100,
+          },
+        ],
+      },
+      path_prefix: '/test',
+      strip_path_prefix: true,
+    } satisfies ADCSDK.Service;
+    const upstreamND1Name = 'nd-upstream1';
+    const upstreamND1 = {
+      name: upstreamND1Name,
+      type: 'roundrobin',
+      scheme: 'https',
+      nodes: [
+        {
+          host: '1.1.1.1',
+          port: 443,
+          weight: 100,
         },
-        path_prefix: '/test',
-        strip_path_prefix: true,
-      } satisfies ADCSDK.Service;
-      const upstreamND1Name = 'nd-upstream1';
-      const upstreamND1 = {
-        name: upstreamND1Name,
-        type: 'roundrobin',
-        scheme: 'https',
-        nodes: [
-          {
-            host: '1.1.1.1',
-            port: 443,
-            weight: 100,
-          },
-        ],
-      } satisfies ADCSDK.Upstream;
-      const upstreamND2Name = 'nd-upstream2';
-      const upstreamND2 = {
-        name: upstreamND2Name,
-        type: 'roundrobin',
-        scheme: 'https',
-        nodes: [
-          {
-            host: '1.0.0.1',
-            port: 443,
-            weight: 100,
-          },
-        ],
-      } satisfies ADCSDK.Upstream;
+      ],
+    } satisfies ADCSDK.Upstream;
+    const upstreamND2Name = 'nd-upstream2';
+    const upstreamND2 = {
+      name: upstreamND2Name,
+      type: 'roundrobin',
+      scheme: 'https',
+      nodes: [
+        {
+          host: '1.0.0.1',
+          port: 443,
+          weight: 100,
+        },
+      ],
+    } satisfies ADCSDK.Upstream;
 
-      it('Create service and upstreams', async () =>
-        syncEvents(backend, [
-          createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
-          createEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND1Name,
-            upstreamND1,
-            serviceName,
-          ),
-          createEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND2Name,
-            upstreamND2,
-            serviceName,
-          ),
-        ]));
+    it('Create service and upstreams', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
+        createEvent(
+          ADCSDK.ResourceType.UPSTREAM,
+          upstreamND1Name,
+          upstreamND1,
+          serviceName,
+        ),
+        createEvent(
+          ADCSDK.ResourceType.UPSTREAM,
+          upstreamND2Name,
+          upstreamND2,
+          serviceName,
+        ),
+      ]));
 
-      it('Dump', async () => {
-        const result = await dumpConfiguration(backend);
-        expect(result.services).toHaveLength(1);
-        expect(result.services[0]).toMatchObject(service);
-        expect(result.services[0].upstreams).toHaveLength(2);
+    it('Dump', async () => {
+      const result = await dumpConfiguration(backend);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0]).toMatchObject(service);
+      expect(result.services[0].upstreams).toHaveLength(2);
 
-        const upstreams = sortResult(result.services[0].upstreams, 'name');
-        expect(upstreams[0]).toMatchObject(upstreamND1);
-        expect(upstreams[1]).toMatchObject(upstreamND2);
-      });
-
-      const newUpstreamND1 = {
-        ...structuredClone(upstreamND1),
-        retry_timeout: 100,
-      } as ADCSDK.Upstream;
-      it('Update service non-default upstream 1', async () =>
-        syncEvents(backend, [
-          updateEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND1Name,
-            newUpstreamND1,
-            serviceName,
-          ),
-        ]));
-
-      it('Dump (updated non-default upstream 1)', async () => {
-        const result = await dumpConfiguration(backend);
-        expect(result.services).toHaveLength(1);
-
-        const upstreams = sortResult(result.services[0].upstreams, 'name');
-        expect(upstreams[0]).toMatchObject(newUpstreamND1);
-      });
-
-      it('Delete non-default upstream 2', async () =>
-        syncEvents(backend, [
-          deleteEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND2Name,
-            serviceName,
-          ),
-        ]));
-
-      it('Dump (non-default upstream 2 should not exist)', async () => {
-        const result = await dumpConfiguration(backend);
-        expect(result.services).toHaveLength(1);
-        expect(result.services[0].upstreams).toHaveLength(1);
-        expect(result.services[0].upstreams[0]).toMatchObject(newUpstreamND1);
-      });
-
-      it('Delete', async () =>
-        syncEvents(backend, [
-          deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
-        ]));
-
-      it('Dump again (service should not exist)', async () => {
-        const result = await dumpConfiguration(backend);
-        expect(result.services).toHaveLength(0);
-      });
+      const upstreams = sortResult(result.services[0].upstreams, 'name');
+      expect(upstreams[0]).toMatchObject(upstreamND1);
+      expect(upstreams[1]).toMatchObject(upstreamND2);
     });
-  },
-);
+
+    const newUpstreamND1 = {
+      ...structuredClone(upstreamND1),
+      retry_timeout: 100,
+    } as ADCSDK.Upstream;
+    it('Update service non-default upstream 1', async () =>
+      syncEvents(backend, [
+        updateEvent(
+          ADCSDK.ResourceType.UPSTREAM,
+          upstreamND1Name,
+          newUpstreamND1,
+          serviceName,
+        ),
+      ]));
+
+    it('Dump (updated non-default upstream 1)', async () => {
+      const result = await dumpConfiguration(backend);
+      expect(result.services).toHaveLength(1);
+
+      const upstreams = sortResult(result.services[0].upstreams, 'name');
+      expect(upstreams[0]).toMatchObject(newUpstreamND1);
+    });
+
+    it('Delete non-default upstream 2', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.UPSTREAM, upstreamND2Name, serviceName),
+      ]));
+
+    it('Dump (non-default upstream 2 should not exist)', async () => {
+      const result = await dumpConfiguration(backend);
+      expect(result.services).toHaveLength(1);
+      expect(result.services[0].upstreams).toHaveLength(1);
+      expect(result.services[0].upstreams[0]).toMatchObject(newUpstreamND1);
+    });
+
+    it('Delete', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
+      ]));
+
+    it('Dump again (service should not exist)', async () => {
+      const result = await dumpConfiguration(backend);
+      expect(result.services).toHaveLength(0);
+    });
+  });
+});

--- a/libs/backend-apisix/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/resources/service-upstream.e2e-spec.ts
@@ -1,0 +1,151 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import { gte } from 'semver';
+
+import { BackendAPISIX } from '../../src';
+import { server, token } from '../support/constants';
+import {
+  conditionalDescribe,
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  semverCondition,
+  sortResult,
+  syncEvents,
+  updateEvent,
+} from '../support/utils';
+
+conditionalDescribe(semverCondition(gte, '3.5.0'))(
+  'Service-Upstreams E2E',
+  () => {
+    let backend: BackendAPISIX;
+
+    beforeAll(() => {
+      backend = new BackendAPISIX({
+        server,
+        token,
+        tlsSkipVerify: true,
+      });
+    });
+
+    describe('Service multiple upstreams', () => {
+      const serviceName = 'test';
+      const service = {
+        name: serviceName,
+        upstream: {
+          type: 'roundrobin',
+          nodes: [
+            {
+              host: 'httpbin.org',
+              port: 443,
+              weight: 100,
+            },
+          ],
+        },
+        path_prefix: '/test',
+        strip_path_prefix: true,
+      } satisfies ADCSDK.Service;
+      const upstreamND1Name = 'nd-upstream1';
+      const upstreamND1 = {
+        name: upstreamND1Name,
+        type: 'roundrobin',
+        scheme: 'https',
+        nodes: [
+          {
+            host: '1.1.1.1',
+            port: 443,
+            weight: 100,
+          },
+        ],
+      } satisfies ADCSDK.Upstream;
+      const upstreamND2Name = 'nd-upstream2';
+      const upstreamND2 = {
+        name: upstreamND2Name,
+        type: 'roundrobin',
+        scheme: 'https',
+        nodes: [
+          {
+            host: '1.0.0.1',
+            port: 443,
+            weight: 100,
+          },
+        ],
+      } satisfies ADCSDK.Upstream;
+
+      it('Create service and upstreams', async () =>
+        syncEvents(backend, [
+          createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
+          createEvent(
+            ADCSDK.ResourceType.UPSTREAM,
+            upstreamND1Name,
+            upstreamND1,
+            serviceName,
+          ),
+          createEvent(
+            ADCSDK.ResourceType.UPSTREAM,
+            upstreamND2Name,
+            upstreamND2,
+            serviceName,
+          ),
+        ]));
+
+      it('Dump', async () => {
+        const result = await dumpConfiguration(backend);
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0]).toMatchObject(service);
+        expect(result.services[0].upstreams).toHaveLength(2);
+
+        const upstreams = sortResult(result.services[0].upstreams, 'name');
+        expect(upstreams[0]).toMatchObject(upstreamND1);
+        expect(upstreams[1]).toMatchObject(upstreamND2);
+      });
+
+      const newUpstreamND1 = {
+        ...structuredClone(upstreamND1),
+        retry_timeout: 100,
+      } as ADCSDK.Upstream;
+      it('Update service non-default upstream 1', async () =>
+        syncEvents(backend, [
+          updateEvent(
+            ADCSDK.ResourceType.UPSTREAM,
+            upstreamND1Name,
+            newUpstreamND1,
+            serviceName,
+          ),
+        ]));
+
+      it('Dump (updated non-default upstream 1)', async () => {
+        const result = await dumpConfiguration(backend);
+        expect(result.services).toHaveLength(1);
+
+        const upstreams = sortResult(result.services[0].upstreams, 'name');
+        expect(upstreams[0]).toMatchObject(newUpstreamND1);
+      });
+
+      it('Delete non-default upstream 2', async () =>
+        syncEvents(backend, [
+          deleteEvent(
+            ADCSDK.ResourceType.UPSTREAM,
+            upstreamND2Name,
+            serviceName,
+          ),
+        ]));
+
+      it('Dump (non-default upstream 2 should not exist)', async () => {
+        const result = await dumpConfiguration(backend);
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].upstreams).toHaveLength(1);
+        expect(result.services[0].upstreams[0]).toMatchObject(newUpstreamND1);
+      });
+
+      it('Delete', async () =>
+        syncEvents(backend, [
+          deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
+        ]));
+
+      it('Dump again (service should not exist)', async () => {
+        const result = await dumpConfiguration(backend);
+        expect(result.services).toHaveLength(0);
+      });
+    });
+  },
+);

--- a/libs/backend-apisix/src/transformer.ts
+++ b/libs/backend-apisix/src/transformer.ts
@@ -48,6 +48,7 @@ export class ToADC {
       hosts: service.hosts,
 
       upstream: service.upstream,
+      upstreams: service.upstreams,
       plugins: service.plugins,
     } as ADCSDK.Service);
   }
@@ -196,10 +197,15 @@ export class ToADC {
             };
           })
       : undefined;
+    const labels = ADCSDK.utils.recursiveOmitUndefined({
+      ...upstream.labels,
+      [typing.ADC_UPSTREAM_SERVICE_ID_LABEL]: undefined,
+    });
     return ADCSDK.utils.recursiveOmitUndefined({
+      id: upstream.id,
       name: upstream.name ?? upstream.id,
       description: upstream.desc,
-      labels: upstream.labels,
+      labels: Object.keys(labels).length > 0 ? labels : undefined,
 
       type: upstream.type,
       hash_on: upstream.hash_on,

--- a/libs/backend-apisix/src/typing.ts
+++ b/libs/backend-apisix/src/typing.ts
@@ -14,6 +14,8 @@ import {
   UpstreamTimeout,
 } from '@api7/adc-sdk';
 
+export const ADC_UPSTREAM_SERVICE_ID_LABEL = '__ADC_UPSTREAM_SERVICE_ID';
+
 export interface Route {
   id: string;
   name?: string;
@@ -58,6 +60,9 @@ export interface Service {
   plugins?: Plugins;
   script?: string;
   enable_websocket?: boolean;
+
+  // internal use only
+  upstreams?: Array<ADCUpstream>;
 }
 export interface ConsumerCredential {
   id?: string;


### PR DESCRIPTION
### Description

As a successor to #252, similar functionality is supported on APISIX.

Since APISIX does not natively support multiple upstreams associated with the service, this is simulated by core upstream resource objects and a specific label field. They have the same effect.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
