### PR TITLE
feat(core): add sync request concurrent option

### DIFF
--- a/apps/cli/src/command/helper.ts
+++ b/apps/cli/src/command/helper.ts
@@ -33,7 +33,7 @@ export class BaseCommand extends Command {
   }
 
   // Appends the provided examples to description
-  public addExamples(examples: Array<{ title: string, command: string }>) {
+  public addExamples(examples: Array<{ title: string; command: string }>) {
     this.examples.push(...examples);
 
     // Title of each example is a comment which describes the actual command
@@ -105,17 +105,15 @@ export class BackendCommand<OPTS extends object = object> extends BaseCommand {
         .default('apisix'),
     )
       .addOption(
-        new Option(
-          '--server <string>',
-          'HTTP address of the backend',
-        )
+        new Option('--server <string>', 'HTTP address of the backend')
           .env('ADC_SERVER')
           .default('http://localhost:9180'),
       )
       .addOption(
-        new Option('--token <string>', 'token for ADC to connect to the backend').env(
-          'ADC_TOKEN',
-        ),
+        new Option(
+          '--token <string>',
+          'token for ADC to connect to the backend',
+        ).env('ADC_TOKEN'),
       )
       .addOption(
         new Option(
@@ -212,3 +210,14 @@ export class BackendCommand<OPTS extends object = object> extends BaseCommand {
 }
 
 export const NoLintOption = new Option('--no-lint', 'disable lint check');
+export const RequestConcurrentOption = new Option(
+  '--request-concurrent <integer>',
+  'number of concurrent requests to the backend',
+)
+  .default(10, '10')
+  .argParser((val) => {
+    const int = parseInt(val);
+    if (!Number.isInteger(int))
+      throw new InvalidArgumentError('Not an integer');
+    return int;
+  });

--- a/apps/cli/src/command/sync.command.ts
+++ b/apps/cli/src/command/sync.command.ts
@@ -11,13 +11,18 @@ import {
 import { InitializeBackendTask } from '../tasks/init_backend';
 import { SignaleRenderer } from '../utils/listr';
 import { TaskContext } from './diff.command';
-import { BackendCommand, NoLintOption } from './helper';
+import {
+  BackendCommand,
+  NoLintOption,
+  RequestConcurrentOption,
+} from './helper';
 import { BackendOptions } from './typing';
 import { addBackendEventListener } from './utils';
 
-type SyncOption = BackendOptions & {
+export type SyncOption = BackendOptions & {
   file: Array<string>;
   lint: boolean;
+  requestConcurrent?: number;
 
   // experimental feature
   remoteStateFile: string;
@@ -34,6 +39,7 @@ export const SyncCommand = new BackendCommand<SyncOption>(
     (filePath, files: Array<string> = []) => files.concat(filePath),
   )
   .addOption(NoLintOption)
+  .addOption(RequestConcurrentOption)
   .addExamples([
     {
       title: 'Synchronize configuration from a single file',
@@ -95,7 +101,10 @@ export const SyncCommand = new BackendCommand<SyncOption>(
             const cancel = addBackendEventListener(ctx.backend, task);
             await lastValueFrom(
               ctx.backend
-                .sync(ctx.diff, { exitOnFailure: true })
+                .sync(ctx.diff, {
+                  exitOnFailure: true,
+                  concurrent: opts.requestConcurrent,
+                })
                 .pipe(toArray()),
             );
             cancel();

--- a/libs/backend-api7/src/operator.ts
+++ b/libs/backend-api7/src/operator.ts
@@ -102,7 +102,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
               }),
               tap(() => logger(taskStateEvent('TASK_DONE'))),
             );
-          }),
+          }, opts.concurrent),
         ),
       ),
     );

--- a/libs/backend-apisix/src/operator.ts
+++ b/libs/backend-apisix/src/operator.ts
@@ -123,7 +123,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
               }),
               tap(() => logger(taskStateEvent('TASK_DONE'))),
             );
-          }),
+          }, opts.concurrent),
         ),
       ),
     );

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -49,6 +49,7 @@ export interface BackendEventAxiosDebug {
 }
 
 export interface BackendSyncOptions {
+  concurrent?: number;
   exitOnFailure?: boolean;
 }
 


### PR DESCRIPTION
### Description

In 0.18 and 0.19, we've parallelized requests as much as possible when synchronizing, but there is a problem in that it doesn't limit the maximum concurrency limit, so when you synchronize a YAML with hundreds or thousands of resources, or if the Admin API is slow, the ADC may time out, which will interrupt the ADC from continuing, which will cause part of the operation to fail.

This behavior is inappropriate, so we have introduced a new `--request-concurrent` option to the sync command, which allows you to finely control potential concurrent requests. It now has a default value of 10.

This utilizes rxjs' own parallel control capabilities, so no additional testing seems to be needed.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
