### PR TITLE
feat(core): allow keep var syntax in yaml via escaping chars

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,6 +23,7 @@ jobs:
           - 3.9.1
           - 3.10.0
           - 3.11.0
+          - 3.12.0
     env:
       BACKEND_APISIX_VERSION: ${{ matrix.version }}
       BACKEND_APISIX_IMAGE: ${{ matrix.version }}-debian

--- a/apps/cli/src/command/utils.spec.ts
+++ b/apps/cli/src/command/utils.spec.ts
@@ -267,6 +267,9 @@ describe('CLI utils', () => {
               },
             ],
           },
+          {
+            name: 'Test escape \\${NAME}',
+          },
         ],
         consumers: [
           {
@@ -321,6 +324,9 @@ describe('CLI utils', () => {
           {
             name: 'Test name',
             routes: [{ name: 'Test name', uris: ['/test/name'] }],
+          },
+          {
+            name: 'Test escape ${NAME}',
           },
         ],
         ssls: [

--- a/apps/cli/src/command/utils.ts
+++ b/apps/cli/src/command/utils.ts
@@ -284,14 +284,21 @@ export const recursiveReplaceEnvVars = (
   dataSource = process.env,
 ): ADCSDK.Configuration => {
   const envVarRegex = /\$\{(\w+)\}/g;
+  const escapedVarRegex = /\\\$\{(\w+)\}/g;
+  const placeholder = '__ESCAPED_ENV__';
   const replaceValue = (value: unknown): unknown => {
-    if (typeof value === 'string')
-      return value.replace(
-        envVarRegex,
-        (_, envVar) => dataSource?.[envVar] || '',
-      );
+    if (typeof value !== 'string') return value;
 
-    return value;
+    const escaped = value.replace(escapedVarRegex, (_, envVar) => {
+      return `${placeholder}${envVar}${placeholder}`;
+    });
+    const replaced = escaped.replace(envVarRegex, (_, envVar) => {
+      return dataSource?.[envVar] || '';
+    });
+    return replaced.replace(
+      new RegExp(`${placeholder}(\\w+)${placeholder}`, 'g'),
+      (_, envVar) => `\${${envVar}}`,
+    );
   };
 
   const recurseReplace = (value: unknown): unknown =>

--- a/apps/cli/src/command/utils.ts
+++ b/apps/cli/src/command/utils.ts
@@ -285,7 +285,7 @@ export const recursiveReplaceEnvVars = (
 ): ADCSDK.Configuration => {
   const envVarRegex = /\$\{(\w+)\}/g;
   const escapedVarRegex = /\\\$\{(\w+)\}/g;
-  const placeholder = '__ESCAPED_ENV__';
+  const placeholder = '__ESCAPED_ENV_VAR_PLACEHOLDER__';
   const replaceValue = (value: unknown): unknown => {
     if (typeof value !== 'string') return value;
 


### PR DESCRIPTION
### Description

Previously, `${X}` in a YAML value would be unconditionally parsed as an environment variable, or replaced with an empty string if the environment variable did not exist.
It is difficult to represent APISIX variables (like `${http_x_api_key}`) in YAML if they are required in some plugin configurations.
So this PR introduces an escape `\\` so that when you use `\\${X}`, the `${X}` will be left as is and not replaced, and the escape character will be discarded.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
