### PR TITLE
fix: modify frozen immutable objects

### DIFF
--- a/apps/cli/src/tasks/load_remote.ts
+++ b/apps/cli/src/tasks/load_remote.ts
@@ -30,6 +30,7 @@ export const LoadRemoteConfigurationTask = ({
           ctx.remote = await lastValueFrom(
             (ctx.backend as ADCSDK.Backend).dump(),
           );
+          ctx.remote = structuredClone(ctx.remote); //TODO: refactor this to immer produce
           cancel();
         },
       },


### PR DESCRIPTION
### Description

When the label selector is used during synchronization, the ADC performs filtering on the dump results to exclude those resources that should be ignored before discrepancy checking, which requires modification of the dump results.
However, some ADC backend implementations return an immutable object to avoid accidental modifications at runtime, which is implemented via Object.frozen, which results in an error when ADC tries to modify the data.

This PR will fix it by using a deep copy to unfreeze the object, which acts as a quick fix. After that, it will be refactored to be completely immutable.

Fixes #263 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
