### PR TITLE
fix(backend): failed to report operation error

### DIFF
--- a/apps/cli/webpack.config.js
+++ b/apps/cli/webpack.config.js
@@ -1,5 +1,6 @@
 const { composePlugins, withNx } = require('@nx/webpack');
 const { DefinePlugin, optimize } = require('webpack');
+const TerserPlugin = require("terser-webpack-plugin");
 
 // Nx plugins for webpack.
 module.exports = composePlugins(
@@ -7,9 +8,11 @@ module.exports = composePlugins(
     target: 'node',
   }),
   (config) => {
+    config.devtool = 'inline-source-map';
+    config.output.devtoolModuleFilenameTemplate = "[absolute-resource-path]";
     config.externals = {
       '*': false
-    }
+    };
     config.plugins.push(...[
       new DefinePlugin({
         'process.env.NODE_ENV': `'${process.env.NODE_ENV ?? 'development'}'`
@@ -17,7 +20,19 @@ module.exports = composePlugins(
       new optimize.LimitChunkCountPlugin({
         maxChunks: 1
       }),
-    ])
+    ]);
+    config.optimization = {
+      minimize: true,
+      minimizer: [new TerserPlugin({
+        parallel: true,
+        extractComments: false,
+        terserOptions: {
+          compress: true,
+          mangle: false,
+          sourceMap: true,
+        },
+      })],
+    };
     return config;
   }
 );

--- a/libs/backend-api7/src/operator.ts
+++ b/libs/backend-api7/src/operator.ts
@@ -14,6 +14,7 @@ import {
   reduce,
   switchMap,
   tap,
+  throwError,
   toArray,
 } from 'rxjs';
 import { SemVer } from 'semver';
@@ -84,10 +85,19 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
-                if (opts.exitOnFailure)
-                  throw new Error(
-                    `Error: ${axios.isAxiosError(error) && error.response ? error.response.data?.error_msg : error.message}, `,
-                  );
+                if (opts.exitOnFailure) {
+                  if (axios.isAxiosError(error)) {
+                    if (error.response)
+                      throwError(
+                        () =>
+                          new Error(
+                            error.response?.data?.error_msg ??
+                              JSON.stringify(error.response?.data),
+                          ),
+                      );
+                    else throwError(() => error);
+                  }
+                }
                 return of({
                   success: false,
                   event,

--- a/libs/backend-api7/src/operator.ts
+++ b/libs/backend-api7/src/operator.ts
@@ -86,17 +86,15 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
                 if (opts.exitOnFailure) {
-                  if (axios.isAxiosError(error)) {
-                    if (error.response)
-                      throwError(
-                        () =>
-                          new Error(
-                            error.response?.data?.error_msg ??
-                              JSON.stringify(error.response?.data),
-                          ),
-                      );
-                    else throwError(() => error);
-                  }
+                  if (axios.isAxiosError(error) && error.response)
+                    return throwError(
+                      () =>
+                        new Error(
+                          error.response?.data?.error_msg ??
+                            JSON.stringify(error.response?.data),
+                        ),
+                    );
+                  return throwError(() => error);
                 }
                 return of({
                   success: false,

--- a/libs/backend-apisix/src/operator.ts
+++ b/libs/backend-apisix/src/operator.ts
@@ -107,17 +107,15 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
                 if (opts.exitOnFailure) {
-                  if (axios.isAxiosError(error)) {
-                    if (error.response)
-                      return throwError(
-                        () =>
-                          new Error(
-                            error.response?.data?.error_msg ??
-                              JSON.stringify(error.response?.data),
-                          ),
-                      );
-                    else return throwError(() => error);
-                  }
+                  if (axios.isAxiosError(error) && error.response)
+                    return throwError(
+                      () =>
+                        new Error(
+                          error.response?.data?.error_msg ??
+                            JSON.stringify(error.response?.data),
+                        ),
+                    );
+                  return throwError(() => error);
                 }
                 return of({
                   success: false,

--- a/libs/backend-apisix/src/operator.ts
+++ b/libs/backend-apisix/src/operator.ts
@@ -12,6 +12,7 @@ import {
   of,
   reduce,
   tap,
+  throwError,
 } from 'rxjs';
 import { SemVer, gte as semVerGTE, lt as semVerLT } from 'semver';
 
@@ -105,10 +106,19 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
-                if (opts.exitOnFailure)
-                  throw new Error(
-                    `Error: ${axios.isAxiosError(error) && error.response ? error.response.data?.error_msg : error.message}, `,
-                  );
+                if (opts.exitOnFailure) {
+                  if (axios.isAxiosError(error)) {
+                    if (error.response)
+                      return throwError(
+                        () =>
+                          new Error(
+                            error.response?.data?.error_msg ??
+                              JSON.stringify(error.response?.data),
+                          ),
+                      );
+                    else return throwError(() => error);
+                  }
+                }
                 return of({
                   success: false,
                   event,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "yaml": "^2.4.2",
     "zod": "^3.23.8"
   },
-  "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "openapi-types": "^12.1.3",
     "prettier": "^3.2.5",
     "qs": "^6.12.1",
+    "terser-webpack-plugin": "^5.3.14",
     "ts-jest": "^29.1.3",
     "ts-node": "^10.9.2",
     "typescript": "5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       qs:
         specifier: ^6.12.1
         version: 6.12.1
+      terser-webpack-plugin:
+        specifier: ^5.3.14
+        version: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
       ts-jest:
         specifier: ^29.1.3
         version: 29.1.3(@babel/core@7.24.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.6))(esbuild@0.19.12)(jest@29.7.0(@types/node@18.16.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.7(@swc/helpers@0.5.12))(@types/node@18.16.9)(typescript@5.7.3)))(typescript@5.7.3)
@@ -4662,6 +4665,10 @@ packages:
     resolution: {integrity: sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==}
     engines: {node: '>= 12.13.0'}
 
+  schema-utils@4.3.2:
+    resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
+    engines: {node: '>= 10.13.0'}
+
   select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
 
@@ -4928,8 +4935,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  terser-webpack-plugin@5.3.10:
-    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
+  terser-webpack-plugin@5.3.14:
+    resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -4944,8 +4951,8 @@ packages:
       uglify-js:
         optional: true
 
-  terser@5.31.0:
-    resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
+  terser@5.39.1:
+    resolution: {integrity: sha512-Mm6+uad0ZuDtcV8/4uOZQDQ8RuiC5Pu+iZRedJtF7yA/27sPL7d++In/AJKpWZlU3SYMPPkVfwetn6sgZ66pUA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6796,7 +6803,7 @@ snapshots:
       style-loader: 3.3.4(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
       stylus: 0.64.0
       stylus-loader: 7.1.3(stylus@0.64.0)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
       ts-loader: 9.5.1(typescript@5.7.3)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.6.3
@@ -10438,6 +10445,13 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.14.0)
       ajv-keywords: 5.1.0(ajv@8.14.0)
 
+  schema-utils@4.3.2:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.14.0
+      ajv-formats: 2.1.1(ajv@8.14.0)
+      ajv-keywords: 5.1.0(ajv@8.14.0)
+
   select-hose@2.0.0: {}
 
   selfsigned@2.4.1:
@@ -10740,19 +10754,19 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
-      schema-utils: 3.3.0
+      schema-utils: 4.3.2
       serialize-javascript: 6.0.2
-      terser: 5.31.0
+      terser: 5.39.1
       webpack: 5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)
     optionalDependencies:
       '@swc/core': 1.5.7(@swc/helpers@0.5.12)
       esbuild: 0.19.12
 
-  terser@5.31.0:
+  terser@5.39.1:
     dependencies:
       '@jridgewell/source-map': 0.3.6
       acorn: 8.11.3
@@ -11055,7 +11069,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12)(webpack@5.91.0(@swc/core@1.5.7(@swc/helpers@0.5.12))(esbuild@0.19.12))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
### Description

Errors may occur when the backend calls the API, which then reports the error and exits, some of the code used to generate the error message contains errors that are not displayed correctly, and the error stack is not clear because the project does not include a source map release.

This PR improves the error reporting code and provides source map export, now it works out of the box.

Fixes #261 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
