### PR TITLE
feat: bump to 0.19.1

### DIFF
--- a/apps/cli/src/command/index.ts
+++ b/apps/cli/src/command/index.ts
@@ -12,7 +12,7 @@ import { PingCommand } from './ping.command';
 import { SyncCommand } from './sync.command';
 import { configurePluralize } from './utils';
 
-const versionCode = '0.19.0';
+const versionCode = '0.19.1';
 
 // initialize dotenv
 dotenv.config();

--- a/libs/backend-apisix/README.md
+++ b/libs/backend-apisix/README.md
@@ -25,6 +25,7 @@
 | 3.9.x    | ✅         | Full        |
 | 3.10.x   | ✅         | Full        |
 | 3.11.x   | ✅         | Full        |
+| 3.12.x   | ✅         | Full        |
 
 1. The stream routes will be skipped during synchronization because they cannot be associated to the service on these versions.
 2. The `name` field is lost when the stream route is dumped and synchronized, because it is not defined in the APISIX schema.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api7/adc",
   "version": "0.0.0",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {},
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
### Description

Bump version to 0.19.1.

It contains some fixes on the APISIX backend.

It also corrects a documented error in `package.json`, namely the license section, which has always been the Apache-2.0 open source used by ADC based on the LICENSE file in its root directory, not the MIT in package.json.
We don't publish the package separately to npm, so this doesn't involve changing the license, which used to be Apache-2.0 and still is.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
