### PR TITLE
fix(apisix-standalone): incorrect desc field in service inlined upstream

### DIFF
--- a/libs/backend-apisix-standalone/README.md
+++ b/libs/backend-apisix-standalone/README.md
@@ -45,3 +45,9 @@ Their update logic are:
    2. A created resource's modifiedIndex will be incremented from the `conf_version` of the current resource type;
    3. A deleted resource will have the `conf_version` of the current resource type updated.
 4. Recalculates the resource-type level `conf_version`. its rule is: find the maximum value of the old `conf_version` and the `modifiedIndex` in all such resources, and if that value is equal to the old `conf_version`, add one. This means that if there is any resource change (no matter what the operation is), the `conf_version` at the resource-type level will always increase; but the `modifiedIndex` on the resource will only change on the resource that was changed. This minimizes the impact of cache invalidation "noise" on APISIX due to unrelated resource updates.
+
+### Differences in upstream
+
+This backend's upstream converter will not support the configuration of the APISIX health checker or service discovery.
+
+The reason for this is that this backend will primarily be used in an Ingress Controller scenario. In this scenario, the Kubernetes Endpoints mechanism and probes will implement these two capabilities.

--- a/libs/backend-apisix-standalone/e2e/resources/service.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/service.e2e-spec.ts
@@ -22,6 +22,7 @@ describe('Sync and Dump - 1', () => {
 
   describe('Sync and dump empty service', () => {
     const upstream = {
+      description: 'test upstream',
       scheme: 'https',
       nodes: [
         {
@@ -30,7 +31,7 @@ describe('Sync and Dump - 1', () => {
           weight: 100,
         },
       ],
-    };
+    } as ADCSDK.Upstream;
     const service1Name = 'service1';
     const service1 = {
       name: service1Name,

--- a/libs/backend-apisix-standalone/src/operator.ts
+++ b/libs/backend-apisix-standalone/src/operator.ts
@@ -254,7 +254,6 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
       }
       case ADCSDK.ResourceType.SERVICE: {
         type T = typing.APISIXStandaloneType['services'][number];
-        type TU = typing.APISIXStandaloneType['upstreams'][number];
         const res = event.newValue as ADCSDK.Service;
         return {
           modifiedIndex: event.modifiedIndex,
@@ -263,7 +262,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
           desc: res.description,
           labels: this.fromADCLabels(res.labels),
           hosts: res.hosts,
-          upstream: res.upstream as TU,
+          upstream: this.fromADCUpstream(event.newValue as ADCSDK.Upstream),
           plugins: res.plugins,
         } satisfies T as T;
       }
@@ -336,22 +335,14 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
       }
       case ADCSDK.ResourceType.UPSTREAM: {
         type T = typing.APISIXStandaloneType['upstreams'][number];
-        const res = event.newValue as ADCSDK.Upstream;
-        const upstream = {
-          ...res,
+        return {
+          ...this.fromADCUpstream(
+            event.newValue as ADCSDK.Upstream,
+            event.parentId,
+          ),
           modifiedIndex: event.modifiedIndex,
           id: event.resourceId,
-          name: res.name,
-          desc: res.description,
-          labels: this.fromADCLabels(res.labels),
-          nodes: res.nodes ?? [], // fix optional to required convert
         } satisfies T as T;
-        if (event.parentId)
-          upstream.labels = {
-            ...upstream.labels,
-            [typing.ADC_UPSTREAM_SERVICE_ID_LABEL]: event.parentId,
-          };
-        return upstream;
       }
       case ADCSDK.ResourceType.STREAM_ROUTE: {
         type T = typing.APISIXStandaloneType['stream_routes'][number];
@@ -379,5 +370,37 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
       pv[key] = typeof value === 'string' ? value : JSON.stringify(value);
       return pv;
     }, {});
+  }
+
+  private fromADCUpstream(
+    res: ADCSDK.Upstream,
+    parentId?: string,
+  ): typing.APISIXStandaloneType['upstreams'][number] {
+    type T = ReturnType<typeof this.fromADCUpstream>;
+    const upstream = {
+      modifiedIndex: undefined, // fill in later
+      id: undefined, // fill in later
+      name: res.name,
+      desc: res.description,
+      labels: this.fromADCLabels(res.labels),
+      type: res.type,
+      hash_on: res.hash_on,
+      key: res.key,
+      nodes: res.nodes ?? [], // fix optional to required convert
+      scheme: res.scheme,
+      retries: res.retries,
+      retry_timeout: res.retry_timeout,
+      timeout: res.timeout,
+      tls: res.tls,
+      keepalive_pool: res.keepalive_pool,
+      pass_host: res.pass_host,
+      upstream_host: res.upstream_host,
+    } satisfies T as T;
+    if (parentId)
+      upstream.labels = {
+        ...upstream.labels,
+        [typing.ADC_UPSTREAM_SERVICE_ID_LABEL]: parentId,
+      };
+    return upstream;
   }
 }


### PR DESCRIPTION
### Description

The description in the upstream was converted incorrectly, it should be converted to `desc` instead of leaving it as is.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
