### PR TITLE
fix(apisix-standalone): remove path_prefix and strip_path_prefix

### DIFF
--- a/libs/backend-apisix-standalone/src/transformer.ts
+++ b/libs/backend-apisix-standalone/src/transformer.ts
@@ -105,14 +105,6 @@ export const toADC = (config: typing.APISIXStandaloneType) =>
                     }),
                   )
                   .map(ADCSDK.utils.recursiveOmitUndefined);
-
-                // fill in placeholder for path prefix
-                // these properties are not implemented on APISIX, so they must be
-                // populated to cope with the local defaults populated by zod
-                if (draft.routes?.length > 0) {
-                  draft.path_prefix = '/';
-                  draft.strip_path_prefix = true;
-                }
               }),
             )
             .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],


### PR DESCRIPTION
### Description

APISIX does not support these configuration items and should not output them when dumping.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
