### PR TITLE
fix(apisix-standalone): remove zod-based transformer

### DIFF
--- a/libs/backend-apisix-standalone/src/transformer.ts
+++ b/libs/backend-apisix-standalone/src/transformer.ts
@@ -3,185 +3,179 @@ import { produce } from 'immer';
 
 import * as typing from './typing';
 
-export const toADC = (config: typing.APISIXStandaloneType) =>
-  typing.APISIXStandaloneWithConfVersion.transform<ADCSDK.Configuration>(
-    (input: typing.APISIXStandaloneType) => {
-      const consumerCredentials = input.consumers?.filter(
-        (consumerOrConsumerCredential) =>
-          'name' in consumerOrConsumerCredential,
-      );
-      return {
-        services:
-          input.services
-            ?.map((service) =>
-              produce<ADCSDK.Service>({} as ADCSDK.Service, (draft) => {
-                draft.id = service.id;
-                draft.name = service.name;
-                draft.description = service.desc;
-                draft.labels = service.labels;
-                const upstream = service.upstream;
-                draft.upstream = ADCSDK.utils.recursiveOmitUndefined(
-                  produce({} as ADCSDK.Upstream, (draft) => {
-                    draft.name = upstream.name;
-                    draft.description = upstream.desc;
-                    draft.labels = upstream.labels;
-                    draft.type = upstream.type;
-                    draft.hash_on = upstream.hash_on;
-                    draft.key = upstream.key;
-                    draft.nodes = upstream.nodes;
-                    draft.scheme = upstream.scheme;
-                    draft.retries = upstream.retries;
-                    draft.retry_timeout = upstream.retry_timeout;
-                    draft.timeout = upstream.timeout;
-                    draft.tls = upstream.tls;
-                    draft.keepalive_pool = upstream.keepalive_pool;
-                    draft.pass_host = upstream.pass_host;
-                    draft.upstream_host = upstream.upstream_host;
-                  }),
-                );
-                draft.plugins = service.plugins;
-                draft.hosts = service.hosts;
-                draft.routes = input.routes
-                  ?.filter((route) => route.service_id === service.id)
-                  .map((route) =>
-                    produce({} as ADCSDK.Route, (draft) => {
-                      draft.id = route.id;
-                      draft.name = route.name;
-                      draft.description = route.desc;
-                      draft.labels = route.labels;
-                      draft.uris = route.uris;
-                      draft.hosts = route.hosts;
-                      draft.priority = route.priority;
-                      draft.timeout = route.timeout;
-                      draft.vars = route.vars;
-                      draft.methods = route.methods;
-                      draft.enable_websocket = route.enable_websocket;
-                      draft.remote_addrs = route.remote_addrs;
-                      draft.plugins = route.plugins;
-                      draft.filter_func = route.filter_func;
-                    }),
-                  )
-                  .map(ADCSDK.utils.recursiveOmitUndefined);
-                draft.stream_routes = input.stream_routes
-                  ?.filter((route) => route.service_id === service.id)
-                  .map((route) =>
-                    produce({} as ADCSDK.StreamRoute, (draft) => {
-                      draft.id = route.id;
-                      draft.name = route.name;
-                      draft.description = route.desc;
-                      draft.labels = route.labels;
-                      draft.remote_addr = route.remote_addr;
-                      draft.server_addr = route.server_addr;
-                      draft.server_port = route.server_port;
-                      draft.sni = route.sni;
-                      draft.plugins = route.plugins;
-                    }),
-                  )
-                  .map(ADCSDK.utils.recursiveOmitUndefined);
-                draft.upstreams = input.upstreams
-                  ?.filter(
-                    (upstream) =>
-                      upstream.labels[typing.ADC_UPSTREAM_SERVICE_ID_LABEL] ===
-                      service.id,
-                  )
-                  .map((upstream) =>
-                    produce({} as ADCSDK.Upstream, (draft) => {
-                      draft.id = upstream.id;
-                      draft.name = upstream.name;
-                      draft.description = upstream.desc;
-                      draft.labels = upstream.labels;
-                      draft.type = upstream.type;
-                      draft.hash_on = upstream.hash_on;
-                      draft.key = upstream.key;
-                      draft.nodes = upstream.nodes;
-                      draft.scheme = upstream.scheme;
-                      draft.retries = upstream.retries;
-                      draft.retry_timeout = upstream.retry_timeout;
-                      draft.timeout = upstream.timeout;
-                      draft.tls = upstream.tls;
-                      draft.keepalive_pool = upstream.keepalive_pool;
-                      draft.pass_host = upstream.pass_host;
-                      draft.upstream_host = upstream.upstream_host;
-                    }),
-                  )
-                  .map(ADCSDK.utils.recursiveOmitUndefined);
+export const toADC = (input: typing.APISIXStandaloneType) => {
+  const consumerCredentials = input.consumers?.filter(
+    (consumerOrConsumerCredential) => 'name' in consumerOrConsumerCredential,
+  );
+  return {
+    services:
+      input.services
+        ?.map((service) =>
+          produce<ADCSDK.Service>({} as ADCSDK.Service, (draft) => {
+            draft.id = service.id;
+            draft.name = service.name;
+            draft.description = service.desc;
+            draft.labels = service.labels;
+            const upstream = service.upstream;
+            draft.upstream = ADCSDK.utils.recursiveOmitUndefined(
+              produce({} as ADCSDK.Upstream, (draft) => {
+                draft.name = upstream.name;
+                draft.description = upstream.desc;
+                draft.labels = upstream.labels;
+                draft.type = upstream.type;
+                draft.hash_on = upstream.hash_on;
+                draft.key = upstream.key;
+                draft.nodes = upstream.nodes;
+                draft.scheme = upstream.scheme;
+                draft.retries = upstream.retries;
+                draft.retry_timeout = upstream.retry_timeout;
+                draft.timeout = upstream.timeout;
+                draft.tls = upstream.tls;
+                draft.keepalive_pool = upstream.keepalive_pool;
+                draft.pass_host = upstream.pass_host;
+                draft.upstream_host = upstream.upstream_host;
               }),
-            )
-            .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
-        ssls:
-          input.ssls
-            ?.map((ssl) =>
-              produce<ADCSDK.SSL>({} as ADCSDK.SSL, (draft) => {
-                draft.id = ssl.id;
-                draft.labels = ssl.labels;
-                draft.type = ssl.type;
-                draft.snis = ssl.snis;
-                draft.certificates = [
-                  {
-                    certificate: ssl.cert,
-                    key: ssl.key,
-                  },
-                  ...(ssl.certs ?? []).map((cert, idx) => ({
-                    certificate: cert,
-                    key: ssl.keys[idx],
-                  })),
-                ] as Array<ADCSDK.SSLCertificate>;
-                draft.client = ssl.client;
-                draft.ssl_protocols = ssl.ssl_protocols;
-              }),
-            )
-            .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
-        consumers:
-          input.consumers
-            ?.filter(
-              (consumerOrConsumerCredential) =>
-                'username' in consumerOrConsumerCredential,
-            )
-            .map((consumer) =>
-              produce<ADCSDK.Consumer>({} as ADCSDK.Consumer, (draft) => {
-                draft.username = consumer.username;
-                draft.description = consumer.desc;
-                draft.labels = consumer.labels;
-                draft.plugins = consumer.plugins;
-                draft.credentials = consumerCredentials
-                  ?.filter((credential) =>
-                    credential.id.startsWith(
-                      `${consumer.username}/credentials/`,
-                    ),
-                  )
-                  .map(
-                    (credential) =>
-                      produce<ADCSDK.ConsumerCredential>(
-                        {} as ADCSDK.ConsumerCredential,
-                        (draft) => {
-                          draft.id = credential.id;
-                          draft.name = credential.name;
-                          draft.description = credential.desc;
-                          draft.labels = credential.labels;
-                          const plugin = Object.entries(credential.plugins)[0];
-                          draft.type =
-                            plugin[0] as ADCSDK.ConsumerCredential['type'];
-                          draft.config = plugin[1];
-                        },
-                      ) as ADCSDK.ConsumerCredential,
-                  )
-                  .map(ADCSDK.utils.recursiveOmitUndefined);
-              }),
-            )
-            .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
-        global_rules: Object.fromEntries(
-          input.global_rules
-            ?.map((globalRule) => [globalRule.id, globalRule.plugins[0]])
-            .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
-        ),
-        plugin_metadata: Object.fromEntries(
-          input.plugin_metadata
-            ?.map((pluginMetadata) => {
-              const { id, ...rest } = pluginMetadata;
-              return [id, rest];
-            })
-            .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
-        ),
-      } satisfies ADCSDK.Configuration as ADCSDK.Configuration;
-    },
-  ).parse(config);
+            );
+            draft.plugins = service.plugins;
+            draft.hosts = service.hosts;
+            draft.routes = input.routes
+              ?.filter((route) => route.service_id === service.id)
+              .map((route) =>
+                produce({} as ADCSDK.Route, (draft) => {
+                  draft.id = route.id;
+                  draft.name = route.name;
+                  draft.description = route.desc;
+                  draft.labels = route.labels;
+                  draft.uris = route.uris;
+                  draft.hosts = route.hosts;
+                  draft.priority = route.priority;
+                  draft.timeout = route.timeout;
+                  draft.vars = route.vars;
+                  draft.methods = route.methods;
+                  draft.enable_websocket = route.enable_websocket;
+                  draft.remote_addrs = route.remote_addrs;
+                  draft.plugins = route.plugins;
+                  draft.filter_func = route.filter_func;
+                }),
+              )
+              .map(ADCSDK.utils.recursiveOmitUndefined);
+            draft.stream_routes = input.stream_routes
+              ?.filter((route) => route.service_id === service.id)
+              .map((route) =>
+                produce({} as ADCSDK.StreamRoute, (draft) => {
+                  draft.id = route.id;
+                  draft.name = route.name;
+                  draft.description = route.desc;
+                  draft.labels = route.labels;
+                  draft.remote_addr = route.remote_addr;
+                  draft.server_addr = route.server_addr;
+                  draft.server_port = route.server_port;
+                  draft.sni = route.sni;
+                  draft.plugins = route.plugins;
+                }),
+              )
+              .map(ADCSDK.utils.recursiveOmitUndefined);
+            draft.upstreams = input.upstreams
+              ?.filter(
+                (upstream) =>
+                  upstream.labels[typing.ADC_UPSTREAM_SERVICE_ID_LABEL] ===
+                  service.id,
+              )
+              .map((upstream) =>
+                produce({} as ADCSDK.Upstream, (draft) => {
+                  draft.id = upstream.id;
+                  draft.name = upstream.name;
+                  draft.description = upstream.desc;
+                  draft.labels = upstream.labels;
+                  draft.type = upstream.type;
+                  draft.hash_on = upstream.hash_on;
+                  draft.key = upstream.key;
+                  draft.nodes = upstream.nodes;
+                  draft.scheme = upstream.scheme;
+                  draft.retries = upstream.retries;
+                  draft.retry_timeout = upstream.retry_timeout;
+                  draft.timeout = upstream.timeout;
+                  draft.tls = upstream.tls;
+                  draft.keepalive_pool = upstream.keepalive_pool;
+                  draft.pass_host = upstream.pass_host;
+                  draft.upstream_host = upstream.upstream_host;
+                }),
+              )
+              .map(ADCSDK.utils.recursiveOmitUndefined);
+          }),
+        )
+        .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
+    ssls:
+      input.ssls
+        ?.map((ssl) =>
+          produce<ADCSDK.SSL>({} as ADCSDK.SSL, (draft) => {
+            draft.id = ssl.id;
+            draft.labels = ssl.labels;
+            draft.type = ssl.type;
+            draft.snis = ssl.snis;
+            draft.certificates = [
+              {
+                certificate: ssl.cert,
+                key: ssl.key,
+              },
+              ...(ssl.certs ?? []).map((cert, idx) => ({
+                certificate: cert,
+                key: ssl.keys[idx],
+              })),
+            ] as Array<ADCSDK.SSLCertificate>;
+            draft.client = ssl.client;
+            draft.ssl_protocols = ssl.ssl_protocols;
+          }),
+        )
+        .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
+    consumers:
+      input.consumers
+        ?.filter(
+          (consumerOrConsumerCredential) =>
+            'username' in consumerOrConsumerCredential,
+        )
+        .map((consumer) =>
+          produce<ADCSDK.Consumer>({} as ADCSDK.Consumer, (draft) => {
+            draft.username = consumer.username;
+            draft.description = consumer.desc;
+            draft.labels = consumer.labels;
+            draft.plugins = consumer.plugins;
+            draft.credentials = consumerCredentials
+              ?.filter((credential) =>
+                credential.id.startsWith(`${consumer.username}/credentials/`),
+              )
+              .map(
+                (credential) =>
+                  produce<ADCSDK.ConsumerCredential>(
+                    {} as ADCSDK.ConsumerCredential,
+                    (draft) => {
+                      draft.id = credential.id;
+                      draft.name = credential.name;
+                      draft.description = credential.desc;
+                      draft.labels = credential.labels;
+                      const plugin = Object.entries(credential.plugins)[0];
+                      draft.type =
+                        plugin[0] as ADCSDK.ConsumerCredential['type'];
+                      draft.config = plugin[1];
+                    },
+                  ) as ADCSDK.ConsumerCredential,
+              )
+              .map(ADCSDK.utils.recursiveOmitUndefined);
+          }),
+        )
+        .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
+    global_rules: Object.fromEntries(
+      input.global_rules
+        ?.map((globalRule) => [globalRule.id, globalRule.plugins[0]])
+        .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
+    ),
+    plugin_metadata: Object.fromEntries(
+      input.plugin_metadata
+        ?.map((pluginMetadata) => {
+          const { id, ...rest } = pluginMetadata;
+          return [id, rest];
+        })
+        .map(ADCSDK.utils.recursiveOmitUndefined) ?? [],
+    ),
+  } satisfies ADCSDK.Configuration as ADCSDK.Configuration;
+};

--- a/libs/backend-apisix-standalone/src/transformer.ts
+++ b/libs/backend-apisix-standalone/src/transformer.ts
@@ -9,11 +9,6 @@ export const toADC = (input: typing.APISIXStandaloneType) => {
     (consumerOrConsumerCredential) => 'name' in consumerOrConsumerCredential,
   );
 
-  type g = Omit<
-    typing.APISIXStandaloneType['upstreams'][number],
-    'id' | 'modifiedIndex'
-  > & { name?: string };
-
   const transformUpstream = (
     upstream: Omit<
       typing.APISIXStandaloneType['upstreams'][number],


### PR DESCRIPTION
### Description

Move the zod-based transformer to a regular function.
Zod cannot perform fault-tolerant conversions, meaning that if the input source data does not match the schema, the conversion will fail. This is unacceptable, so we cannot continue to use zod as a transformer.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
