### PR TITLE
fix(apisix-standalone): consumer sync exception

### DIFF
--- a/apps/cli/src/differ/differv3.ts
+++ b/apps/cli/src/differ/differv3.ts
@@ -351,7 +351,13 @@ export class DifferV3 {
                 ? {
                     consumers: (remoteItem as ADCSDK.ConsumerGroup).consumers,
                   }
-                : {},
+                : resourceType ===
+                    (ADCSDK.ResourceType.CONSUMER as ADCSDK.ResourceType)
+                  ? {
+                      consumer_credentials: (remoteItem as ADCSDK.Consumer)
+                        .credentials,
+                    }
+                  : {},
             this.defaultValue,
             resourceType === ADCSDK.ResourceType.SERVICE
               ? remoteName

--- a/apps/cli/src/differ/specs/consumer.spec.ts
+++ b/apps/cli/src/differ/specs/consumer.spec.ts
@@ -122,4 +122,65 @@ describe('Differ V3 - consumer', () => {
       },
     ]);
   });
+
+  it('should delete consumer credentials when consumer is deleting', () => {
+    const consumerName = 'jack';
+    const changeme = 'changeme';
+    expect(
+      DifferV3.diff(
+        {
+          consumers: [],
+        },
+        {
+          consumers: [
+            {
+              username: consumerName,
+              credentials: [
+                {
+                  id: ADCSDK.utils.generateId(
+                    `${consumerName}.${ADCSDK.EventType.DELETE}`,
+                  ),
+                  name: ADCSDK.EventType.DELETE,
+                  type: 'jwt-auth',
+                  config: { key: consumerName, secret: changeme },
+                },
+              ],
+            },
+          ],
+        },
+      ),
+    ).toEqual([
+      {
+        oldValue: {
+          credentials: [
+            {
+              config: { key: consumerName, secret: changeme },
+              id: '86a4d8fbeda9c3de3705a7ba087a8ec741cd1c17',
+              name: ADCSDK.EventType.DELETE,
+              type: 'jwt-auth',
+            },
+          ],
+          username: consumerName,
+        },
+        resourceId: consumerName,
+        resourceName: consumerName,
+        resourceType: ADCSDK.ResourceType.CONSUMER,
+        type: ADCSDK.EventType.DELETE,
+      },
+      {
+        oldValue: {
+          config: { key: consumerName, secret: changeme },
+          name: ADCSDK.EventType.DELETE,
+          type: 'jwt-auth',
+        },
+        parentId: consumerName,
+        resourceId: ADCSDK.utils.generateId(
+          `${consumerName}.${ADCSDK.EventType.DELETE}`,
+        ),
+        resourceName: ADCSDK.EventType.DELETE,
+        resourceType: ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
+        type: ADCSDK.EventType.DELETE,
+      },
+    ]);
+  });
 });

--- a/libs/backend-apisix-standalone/e2e/resources/consumer.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/consumer.e2e-spec.ts
@@ -1,0 +1,119 @@
+import * as ADCSDK from '@api7/adc-sdk';
+
+import { BackendAPISIXStandalone } from '../../src';
+import { server, token } from '../support/constants';
+import {
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  syncEvents,
+  updateEvent,
+} from '../support/utils';
+
+describe('Consumer E2E', () => {
+  let backend: BackendAPISIXStandalone;
+
+  beforeAll(() => {
+    backend = new BackendAPISIXStandalone({
+      server,
+      token,
+      tlsSkipVerify: true,
+    });
+  });
+
+  describe('Sync and dump consumers (with credential support)', () => {
+    const consumer1Name = 'consumer1';
+    const consumer1Key = 'consumer1-key';
+    const consumer1Cred = {
+      name: consumer1Key,
+      type: 'key-auth',
+      config: { key: consumer1Key },
+    };
+    const consumer1Key2 = 'consumer1-key2';
+    const consumer1Cred2 = {
+      name: consumer1Key2,
+      type: 'key-auth',
+      config: { key: consumer1Key2 },
+    };
+    const consumer1 = {
+      username: consumer1Name,
+      credentials: [consumer1Cred, consumer1Cred2],
+    } as ADCSDK.Consumer;
+
+    it('Create consumers', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name, consumer1),
+        createEvent(
+          ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
+          consumer1Key,
+          consumer1Cred,
+          consumer1Name,
+        ),
+        createEvent(
+          ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
+          consumer1Key2,
+          consumer1Cred2,
+          consumer1Name,
+        ),
+      ]));
+
+    it('Dump', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.consumers).toHaveLength(1);
+      expect(result.consumers[0]).toMatchObject(consumer1);
+      expect(result.consumers[0].credentials).toHaveLength(2);
+      expect(result.consumers[0].credentials).toMatchObject(
+        consumer1.credentials,
+      );
+    });
+
+    it('Update consumer credential1', async () => {
+      consumer1.credentials[0].config.key = 'new-key';
+      await syncEvents(backend, [
+        updateEvent(
+          ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
+          consumer1Key,
+          consumer1Cred,
+          consumer1Name,
+        ),
+      ]);
+    });
+
+    it('Dump again (consumer credential updated)', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.consumers[0]).toMatchObject(consumer1);
+      expect(result.consumers[0].credentials[0].config.key).toEqual('new-key');
+    });
+
+    it('Delete consumer credential1', async () =>
+      syncEvents(backend, [
+        deleteEvent(
+          ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
+          consumer1Key,
+          consumer1Name,
+        ),
+      ]));
+
+    it('Dump again (consumer credential should only keep credential2)', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.consumers).toHaveLength(1);
+      expect(result.consumers[0].credentials).toHaveLength(1);
+      expect(result.consumers[0].credentials[0]).toMatchObject(consumer1Cred2);
+    });
+
+    it('Delete consumer', async () =>
+      syncEvents(backend, [
+        deleteEvent(ADCSDK.ResourceType.CONSUMER, consumer1Name),
+        deleteEvent(
+          ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
+          consumer1Key2,
+          consumer1Name,
+        ),
+      ]));
+
+    it('Dump again (consumer should not exist)', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      expect(result.consumers).toHaveLength(0);
+    });
+  });
+});

--- a/libs/backend-apisix-standalone/e2e/resources/consumer.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/consumer.e2e-spec.ts
@@ -6,6 +6,7 @@ import {
   createEvent,
   deleteEvent,
   dumpConfiguration,
+  refreshDumpCache,
   syncEvents,
   updateEvent,
 } from '../support/utils';
@@ -20,6 +21,8 @@ describe('Consumer E2E', () => {
       tlsSkipVerify: true,
     });
   });
+
+  beforeEach(() => refreshDumpCache(backend)); // override dump cache for modifiedIndex
 
   describe('Sync and dump consumers (with credential support)', () => {
     const consumer1Name = 'consumer1';
@@ -68,20 +71,20 @@ describe('Consumer E2E', () => {
     });
 
     it('Update consumer credential1', async () => {
-      consumer1.credentials[0].config.key = 'new-key';
+      const newCred = structuredClone(consumer1Cred);
+      newCred.config.key = 'new-key';
       await syncEvents(backend, [
         updateEvent(
           ADCSDK.ResourceType.CONSUMER_CREDENTIAL,
           consumer1Key,
-          consumer1Cred,
+          newCred,
           consumer1Name,
         ),
       ]);
     });
 
-    it('Dump again (consumer credential updated)', async () => {
+    it('Dump again (consumer credential1 updated)', async () => {
       const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
-      expect(result.consumers[0]).toMatchObject(consumer1);
       expect(result.consumers[0].credentials[0].config.key).toEqual('new-key');
     });
 

--- a/libs/backend-apisix-standalone/src/transformer.ts
+++ b/libs/backend-apisix-standalone/src/transformer.ts
@@ -14,8 +14,8 @@ export const toADC = (input: typing.APISIXStandaloneType) => {
       typing.APISIXStandaloneType['upstreams'][number],
       'id' | 'name' | 'modifiedIndex'
     > & { name?: string },
-  ) => {
-    return produce({} as ADCSDK.Upstream, (draft) => {
+  ) =>
+    produce({} as ADCSDK.Upstream, (draft) => {
       draft.name = upstream.name;
       draft.description = upstream.desc;
       draft.labels = upstream.labels;
@@ -35,7 +35,6 @@ export const toADC = (input: typing.APISIXStandaloneType) => {
       // so this must be handled separately to prevent unexpected diff results.
       draft.nodes = !isEmpty(upstream.nodes) ? upstream.nodes : [];
     });
-  };
   return {
     services:
       input.services
@@ -142,7 +141,10 @@ export const toADC = (input: typing.APISIXStandaloneType) => {
                   produce<ADCSDK.ConsumerCredential>(
                     {} as ADCSDK.ConsumerCredential,
                     (draft) => {
-                      draft.id = credential.id;
+                      draft.id = credential.id.replace(
+                        `${consumer.username}/credentials/`,
+                        '',
+                      );
                       draft.name = credential.name;
                       draft.description = credential.desc;
                       draft.labels = credential.labels;

--- a/libs/backend-apisix-standalone/src/typing.ts
+++ b/libs/backend-apisix-standalone/src/typing.ts
@@ -240,7 +240,7 @@ export const ResourceLevelConfVersion = {
   secrets_conf_version: z.int().optional(),
 };
 
-export const APISIXStandalone = z.strictObject({
+const Resources = {
   [APISIXStandaloneKeyMap[ADCSDK.ResourceType.ROUTE]]: z
     .array(Route)
     .optional(),
@@ -263,13 +263,15 @@ export const APISIXStandalone = z.strictObject({
   [APISIXStandaloneKeyMap[ADCSDK.ResourceType.STREAM_ROUTE]]: z
     .array(StreamRoute)
     .optional(),
-});
+};
 
-export const APISIXStandaloneWithConfVersion = APISIXStandalone.extend(
-  ResourceLevelConfVersion,
-);
-
+export const APISIXStandalone = z.strictObject(Resources);
 export type APISIXStandaloneType = z.infer<typeof APISIXStandalone>;
+
+export const APISIXStandaloneWithConfVersion = z.strictObject({
+  ...Resources,
+  ...ResourceLevelConfVersion,
+});
 export type APISIXStandaloneWithConfVersionType = z.infer<
   typeof APISIXStandaloneWithConfVersion
 >;


### PR DESCRIPTION
### Description

1. The consumer can't be removed correctly

The consumer uses `username` as the ID instead of `id`, and the current code doesn't handle this fact correctly, so the consumer can't be deleted correctly.

2. Consumer credentials cannot be removed correctly & consumer's `conf_version` unexpected updates

Consumers use a specific ID format, `{consumer_username}/credentials/{cred_id}`, which is not handled correctly by the current code, so the modification and deletion will be unsuccessful.
On top of that, because the remote IDs of these credentials are not handled correctly, the IDs will always be treated as changed (so the ADC will emit a delete and a create event), which makes the conf_version always change.

The current implementation of differ does not raise the consumer_credential delete event if the consumer is deleted. This doesn't matter for the Admin API, since correlation deletion is always implicit on the server side. But standalone doesn't contain similar logic and we have to explicitly handle its deletion.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
6. Always add/update tests for any changes unless you have a good reason.
7. Always update the documentation to reflect the changes made in the PR.
8. Make a new commit to resolve conversations instead of `push -f`.
9. To resolve merge conflicts, merge master instead of rebasing.
10. Use "request review" to notify the reviewer after making changes.
11. Only a reviewer can mark a conversation as resolved.

-->
