### PR TITLE
fix(apisix): transform upstream nodes to array

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -23,6 +23,8 @@ jobs:
         run: npx nx run sdk:test
       - name: Run CLI unit tests
         run: npx nx run cli:test
+      - name: Run APISIX Backend unit tests
+        run: npx nx run backend-apisix:test
       - name: Run API7 Backend unit tests
         run: npx nx run backend-api7:test
       - name: Run OpenAPI Converter unit tests

--- a/libs/backend-apisix/src/transformer.ts
+++ b/libs/backend-apisix/src/transformer.ts
@@ -47,7 +47,7 @@ export class ToADC {
 
       hosts: service.hosts,
 
-      upstream: service.upstream,
+      upstream: this.transformUpstream(service.upstream),
       upstreams: service.upstreams,
       plugins: service.plugins,
     } as ADCSDK.Service);
@@ -173,7 +173,9 @@ export class ToADC {
     } as ADCSDK.StreamRoute);
   }
 
-  public transformUpstream(upstream: typing.Upstream): ADCSDK.Upstream {
+  public transformUpstream(
+    upstream: typing.Upstream | typing.InlineUpstream,
+  ): ADCSDK.Upstream {
     const defaultPortMap: Record<string, number> = {
       http: 80,
       https: 443,
@@ -202,8 +204,8 @@ export class ToADC {
       [typing.ADC_UPSTREAM_SERVICE_ID_LABEL]: undefined,
     });
     return ADCSDK.utils.recursiveOmitUndefined({
-      id: upstream.id,
-      name: upstream.name ?? upstream.id,
+      ...{ id: 'id' in upstream ? upstream.id : undefined },
+      name: upstream.name,
       description: upstream.desc,
       labels: Object.keys(labels).length > 0 ? labels : undefined,
 
@@ -280,7 +282,7 @@ export class FromADC {
       name: service.name,
       desc: service.description,
       labels: FromADC.transformLabels(service.labels),
-      upstream: service.upstream,
+      upstream: this.transformUpstream(service.upstream),
       plugins: service.plugins,
       hosts: service.hosts,
     });

--- a/libs/backend-apisix/src/typing.ts
+++ b/libs/backend-apisix/src/typing.ts
@@ -1,7 +1,6 @@
 import {
   GlobalRule as ADCGlobalRule,
   PluginMetadata as ADCPluginMetadata,
-  Upstream as ADCUpstream,
   Expr,
   Labels,
   Plugins,
@@ -38,7 +37,7 @@ export interface Route {
   script_id?: string;
   plugins?: Plugins;
   plugin_config_id?: string;
-  upstream?: ADCUpstream;
+  upstream?: InlineUpstream;
   upstream_id?: string;
   service_id?: string;
   timeout?: UpstreamTimeout;
@@ -55,14 +54,14 @@ export interface Service {
   labels?: Labels;
 
   hosts?: Array<string>;
-  upstream?: ADCUpstream;
+  upstream?: InlineUpstream;
   upstream_id?: string;
   plugins?: Plugins;
   script?: string;
   enable_websocket?: boolean;
 
   // internal use only
-  upstreams?: Array<ADCUpstream>;
+  upstreams?: Array<InlineUpstream>;
 }
 export interface ConsumerCredential {
   id?: string;
@@ -128,7 +127,7 @@ export interface StreamRoute {
   server_addr?: string;
   server_port?: number;
   sni?: string;
-  upstream?: ADCUpstream;
+  upstream?: InlineUpstream;
   upstream_id?: string;
   service_id?: string;
 
@@ -170,7 +169,7 @@ export interface Upstream {
     client_cert_id?: string;
     client_cert?: string;
     client_key?: string;
-    verify: boolean;
+    verify?: boolean;
   };
   keepalive_pool?: {
     size: number;
@@ -178,6 +177,7 @@ export interface Upstream {
     requests: number;
   };
 }
+export type InlineUpstream = Omit<Upstream, 'id'>;
 
 export interface ListResponse<T> {
   list: Array<{

--- a/libs/backend-apisix/test/transformer.spec.ts
+++ b/libs/backend-apisix/test/transformer.spec.ts
@@ -1,0 +1,14 @@
+import { ToADC } from '../src/transformer';
+
+describe('Transformer', () => {
+  it('should transform upstream nodes to array', () => {
+    const toADC = new ToADC();
+    expect(
+      toADC.transformUpstream({
+        nodes: {
+          '127.0.0.1:5432': 100,
+        },
+      }),
+    ).toEqual({ nodes: [{ host: '127.0.0.1', port: 5432, weight: 100 }] });
+  });
+});


### PR DESCRIPTION
### Description

APISIX upstream nodes in object format were not correctly rewritten as an array. Fix this problem.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
