### PR TITLE
feat(core): configurable ingress server listen

### DIFF
--- a/apps/cli/src/command/helper.ts
+++ b/apps/cli/src/command/helper.ts
@@ -70,18 +70,21 @@ export class BackendCommand<
     this.addBackendOptions();
   }
 
-  public handle(cb: (opts: OPTS, command: Command) => void | Promise<void>) {
-    const opts = this.opts<OPTS>();
-
-    if (!has(opts, 'tlsClientCertFile') || !has(opts, 'tlsClientKeyFile')) {
-      console.log(
-        chalk.red(
-          'TLS client certificate and key must be provided at the same time',
-        ),
-      );
-      return this;
-    }
-    return super.handle(cb);
+  public handle(func: (opts: OPTS, command: Command) => void | Promise<void>) {
+    return super.handle(async (opts, command) => {
+      if (
+        (has(opts, 'tlsClientCertFile') && !has(opts, 'tlsClientKeyFile')) ||
+        (!has(opts, 'tlsClientCertFile') && has(opts, 'tlsClientKeyFile'))
+      ) {
+        console.log(
+          chalk.red(
+            'TLS client certificate and key must be provided at the same time',
+          ),
+        );
+        return;
+      }
+      await func(opts, command);
+    });
   }
 
   private addBackendOptions() {

--- a/apps/cli/src/command/ingress-server.command.ts
+++ b/apps/cli/src/command/ingress-server.command.ts
@@ -1,9 +1,22 @@
 import { ADCServer } from '../server';
-import { BaseCommand } from './helper';
+import { BaseCommand, BaseOptions } from './helper';
 
-export const IngressServerCommand = new BaseCommand('server').handle(
-  async () => {
-    await new ADCServer().start();
-    console.log('ADC server is running on: http://127.0.0.1:3000');
-  },
-);
+type IngressServerOptions = {
+  listen?: URL;
+} & BaseOptions;
+
+export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
+  'server',
+)
+  .option<URL>(
+    '--listen <listen>',
+    'listen address of ADC server, the format is scheme://host:port',
+    (val) => new URL(val),
+    new URL('http://127.0.0.1:3000'),
+  )
+  .handle(async ({ listen }) => {
+    await new ADCServer({
+      listen,
+    }).start();
+    console.log(`ADC server is running on: ${listen.origin}`);
+  });

--- a/apps/cli/src/command/ingress-server.command.ts
+++ b/apps/cli/src/command/ingress-server.command.ts
@@ -1,3 +1,5 @@
+import commander from 'commander';
+
 import { ADCServer } from '../server';
 import { BaseCommand, BaseOptions } from './helper';
 
@@ -11,7 +13,13 @@ export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
   .option<URL>(
     '--listen <listen>',
     'listen address of ADC server, the format is scheme://host:port',
-    (val) => new URL(val),
+    (val) => {
+      try {
+        return new URL(val);
+      } catch (err) {
+        throw new commander.InvalidArgumentError(err);
+      }
+    },
     new URL('http://127.0.0.1:3000'),
   )
   .handle(async ({ listen }) => {

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -30,6 +30,16 @@ export class ADCServer {
     });
   }
 
+  public async stop() {
+    return new Promise<void>((resolve) => {
+      if (this.server) {
+        this.server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
   public TEST_ONLY_getExpress() {
     return this.express;
   }

--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -4,11 +4,16 @@ import type { Server } from 'node:http';
 
 import { syncHandler } from './sync';
 
+interface ADCServerOptions {
+  listen: URL;
+}
 export class ADCServer {
   private readonly express: Express;
+  private listen: URL;
   private server?: Server;
 
-  constructor() {
+  constructor(opts: ADCServerOptions) {
+    this.listen = opts.listen;
     this.express = express();
     this.express.disable('x-powered-by');
     this.express.use(express.json({ limit: '100mb' }));
@@ -17,7 +22,11 @@ export class ADCServer {
 
   public async start() {
     return new Promise<void>((resolve) => {
-      this.server = this.express.listen(3000, '127.0.0.1', () => resolve());
+      this.server = this.express.listen(
+        parseInt(this.listen.port),
+        this.listen.hostname,
+        () => resolve(),
+      );
     });
   }
 


### PR DESCRIPTION
### Description

Support for configuring the ingress server to listen on hostnames and ports via `--listen`.
(e.g., `--listen http://1.1.1.1:5432`)
It does not support TLS at this time.

Fix a bug introduced by #305.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
