### PR TITLE
fix(core): ingress server listen no TLS endpoint

### DIFF
--- a/apps/cli/src/command/ingress-server.command.ts
+++ b/apps/cli/src/command/ingress-server.command.ts
@@ -72,8 +72,8 @@ export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
 
     const server = new ADCServer({
       listen,
-      tlsCert: readFileSync(tlsCertFile, 'utf-8'),
-      tlsKey: readFileSync(tlsKeyFile, 'utf-8'),
+      tlsCert: tlsCertFile ? readFileSync(tlsCertFile, 'utf-8') : undefined,
+      tlsKey: tlsKeyFile ? readFileSync(tlsKeyFile, 'utf-8') : undefined,
       tlsCACert: caCertFile ? readFileSync(caCertFile, 'utf-8') : undefined,
     });
     await server.start();


### PR DESCRIPTION
### Description

The ingress server mode will now try to read the TLS certificate when it starts and report an error if it is not provided.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
