### PR TITLE
chore(core): remove ingress server etag header

### DIFF
--- a/apps/cli/src/server/index.ts
+++ b/apps/cli/src/server/index.ts
@@ -19,6 +19,7 @@ export class ADCServer {
   constructor(private readonly opts: ADCServerOptions) {
     this.express = express();
     this.express.disable('x-powered-by');
+    this.express.disable('etag');
     this.express.use(express.json({ limit: '100mb' }));
     this.express.put('/sync', syncHandler);
   }


### PR DESCRIPTION
### Description

Let the ingress server not return the ETag response header. It makes no sense for that scene and increases the response size.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
