### PR TITLE
feat(core): ingress server status endpoint

### DIFF
--- a/apps/cli/e2e/server/basic.e2e-spec.ts
+++ b/apps/cli/e2e/server/basic.e2e-spec.ts
@@ -268,6 +268,8 @@ describe('Server - Basic', () => {
     );
     expect(status).toEqual(200);
     expect(data).toEqual('OK');
+
+    await server.stop();
   });
 
   it('test status listen (custom port)', async () => {
@@ -282,5 +284,7 @@ describe('Server - Basic', () => {
     );
     expect(status).toEqual(200);
     expect(data).toEqual('OK');
+
+    await server.stop();
   });
 });

--- a/apps/cli/e2e/server/basic.e2e-spec.ts
+++ b/apps/cli/e2e/server/basic.e2e-spec.ts
@@ -16,7 +16,10 @@ describe('Server - Basic', () => {
 
   beforeAll(async () => {
     mockedBackend = jestMockBackend();
-    server = new ADCServer({ listen: new URL('http://127.0.1:3000') });
+    server = new ADCServer({
+      listen: new URL('http://127.0.1:3000'),
+      listenStatus: 3001,
+    });
   });
 
   it('test mocked load backend', async () => {
@@ -85,7 +88,7 @@ describe('Server - Basic', () => {
 
   it('test server listen', async () => {
     const url = new URL(`http://127.0.0.1:48562`);
-    const server = new ADCServer({ listen: url });
+    const server = new ADCServer({ listen: url, listenStatus: 3001 });
     await server.start();
 
     const { status, data } = await axios.put(`${url.origin}/sync`, {
@@ -108,6 +111,7 @@ describe('Server - Basic', () => {
     const url = new URL(`https://127.0.0.1:48562`);
     const server = new ADCServer({
       listen: url,
+      listenStatus: 3001,
       tlsCert: readFileSync(
         join(__dirname, '../assets/tls/server.cer'),
         'utf-8',
@@ -145,6 +149,7 @@ describe('Server - Basic', () => {
       readFileSync(join(__dirname, '../assets/tls/', fileName), 'utf-8');
     const server = new ADCServer({
       listen: url,
+      listenStatus: 3001,
       tlsCert: readCert('server.cer'),
       tlsKey: readCert('server.key'),
       tlsCACert: readCert('ca.cer'),
@@ -198,7 +203,7 @@ describe('Server - Basic', () => {
 
   it('test server listen (with UDS)', async () => {
     const url = new URL(`unix:///tmp/adc-test.sock`);
-    const server = new ADCServer({ listen: url });
+    const server = new ADCServer({ listen: url, listenStatus: 3001 });
     await server.start();
 
     const { status, data } = await new Promise<{
@@ -249,5 +254,33 @@ describe('Server - Basic', () => {
     expect(data.status).toEqual('success');
 
     await server.stop();
+  });
+
+  it('test status listen', async () => {
+    const server = new ADCServer({
+      listen: new URL(`http://127.0.0.1:3000`),
+      listenStatus: 3001,
+    });
+    await server.start();
+
+    const { status, data } = await axios.get(
+      `http://127.0.0.1:3001/healthz/ready`,
+    );
+    expect(status).toEqual(200);
+    expect(data).toEqual('OK');
+  });
+
+  it('test status listen (custom port)', async () => {
+    const server = new ADCServer({
+      listen: new URL(`http://127.0.0.1:3000`),
+      listenStatus: 30001,
+    });
+    await server.start();
+
+    const { status, data } = await axios.get(
+      `http://127.0.0.1:30001/healthz/ready`,
+    );
+    expect(status).toEqual(200);
+    expect(data).toEqual('OK');
   });
 });

--- a/apps/cli/src/command/ingress-server.command.ts
+++ b/apps/cli/src/command/ingress-server.command.ts
@@ -98,6 +98,7 @@ export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
       process.on('SIGINT', () => {
         console.log('Stopping, see you next time!');
         server.stop();
+        process.exit(0);
       });
     },
   );

--- a/apps/cli/src/command/ingress-server.command.ts
+++ b/apps/cli/src/command/ingress-server.command.ts
@@ -7,6 +7,7 @@ import { BaseCommand, BaseOptions, processCertificateFile } from './helper';
 
 type IngressServerOptions = {
   listen?: URL;
+  listenStatus?: number;
   caCertFile?: string;
   tlsCertFile?: string;
   tlsKeyFile?: string;
@@ -16,7 +17,7 @@ export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
   'server',
 )
   .option<URL>(
-    '--listen <listen>',
+    '--listen <string>',
     'listen address of ADC server, the format is scheme://host:port',
     (val) => {
       try {
@@ -26,6 +27,19 @@ export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
       }
     },
     new URL('http://127.0.0.1:3000'),
+  )
+  .option<number>(
+    '--listen-status <number>',
+    'status listen port',
+    (val) => {
+      const port = parseInt(val, 10);
+      if (!port || isNaN(port) || port < 1 || port > 65535)
+        throw new commander.InvalidArgumentError(
+          'The status listen port must be a number between 1 and 65535',
+        );
+      return port;
+    },
+    3001,
   )
   .addOption(
     new Option(
@@ -60,28 +74,30 @@ export const IngressServerCommand = new BaseCommand<IngressServerOptions>(
       ),
     ),
   )
-  .handle(async ({ listen, tlsCertFile, tlsKeyFile, caCertFile }) => {
-    if (listen.protocol === 'https:' && (!tlsCertFile || !tlsKeyFile)) {
-      console.error(
-        chalk.red(
-          'Error: When using HTTPS, both --tls-cert-file and --tls-key-file must be provided',
-        ),
+  .handle(
+    async ({ listen, listenStatus, tlsCertFile, tlsKeyFile, caCertFile }) => {
+      if (listen.protocol === 'https:' && (!tlsCertFile || !tlsKeyFile)) {
+        console.error(
+          chalk.red(
+            'Error: When using HTTPS, both --tls-cert-file and --tls-key-file must be provided',
+          ),
+        );
+        return;
+      }
+      const server = new ADCServer({
+        listen,
+        listenStatus,
+        tlsCert: tlsCertFile ? readFileSync(tlsCertFile, 'utf-8') : undefined,
+        tlsKey: tlsKeyFile ? readFileSync(tlsKeyFile, 'utf-8') : undefined,
+        tlsCACert: caCertFile ? readFileSync(caCertFile, 'utf-8') : undefined,
+      });
+      await server.start();
+      console.log(
+        `ADC server is running on: ${listen.protocol === 'unix:' ? listen.pathname : listen.origin}`,
       );
-      return;
-    }
-
-    const server = new ADCServer({
-      listen,
-      tlsCert: tlsCertFile ? readFileSync(tlsCertFile, 'utf-8') : undefined,
-      tlsKey: tlsKeyFile ? readFileSync(tlsKeyFile, 'utf-8') : undefined,
-      tlsCACert: caCertFile ? readFileSync(caCertFile, 'utf-8') : undefined,
-    });
-    await server.start();
-    console.log(
-      `ADC server is running on: ${listen.protocol === 'unix:' ? listen.pathname : listen.origin}`,
-    );
-    process.on('SIGINT', () => {
-      console.log('Stopping, see you next time!');
-      server.stop();
-    });
-  });
+      process.on('SIGINT', () => {
+        console.log('Stopping, see you next time!');
+        server.stop();
+      });
+    },
+  );


### PR DESCRIPTION
### Description

Add the health/ready endpoint for Kubernetes probes.

```
--listen-status 3001
```

```
curl http://127.0.0.1:3001/healthz/ready -i
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
Content-Length: 2
Connection: keep-alive
Keep-Alive: timeout=5

OK
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
