### PR TITLE
feat(converter-openapi): move to new openapi parser

### DIFF
--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -28,21 +28,6 @@
         "production": {}
       }
     },
-    "serve": {
-      "executor": "@nx/js:node",
-      "defaultConfiguration": "development",
-      "options": {
-        "buildTarget": "cli:build"
-      },
-      "configurations": {
-        "development": {
-          "buildTarget": "cli:build:development"
-        },
-        "production": {
-          "buildTarget": "cli:build:production"
-        }
-      }
-    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": [

--- a/libs/converter-openapi/package.json
+++ b/libs/converter-openapi/package.json
@@ -9,7 +9,10 @@
     }
   },
   "devDependencies": {
-    "@api7/adc-sdk": "workspace:*"
+    "@api7/adc-sdk": "workspace:*",
+    "@scalar/openapi-parser": "^0.19.0",
+    "@scalar/openapi-types": "^0.3.7",
+    "slugify": "^1.6.6"
   },
   "nx": {
     "name": "converter-openapi",

--- a/libs/converter-openapi/src/extension.ts
+++ b/libs/converter-openapi/src/extension.ts
@@ -19,6 +19,9 @@ export const parseExtPlugins = (context: object) => {
       )
       .map(([key, plugin]) => [key.replace(ExtKey.PLUGIN_PREFIX, ''), plugin]),
   );
-  const plugins = { ...context[ExtKey.PLUGINS], ...separatePlugins };
+  const plugins = {
+    ...(context as unknown as Record<string, object>)[ExtKey.PLUGINS],
+    ...separatePlugins,
+  };
   return !isEmpty(plugins) ? plugins : undefined;
 };

--- a/libs/converter-openapi/src/index.ts
+++ b/libs/converter-openapi/src/index.ts
@@ -1,96 +1,81 @@
 import * as ADCSDK from '@api7/adc-sdk';
-import { Listr } from 'listr2';
-import { isEmpty } from 'lodash';
-import { OpenAPIV3 } from 'openapi-types';
+import { dereference, upgrade } from '@scalar/openapi-parser';
+import { OpenAPIV3_1 } from '@scalar/openapi-types';
+import { isEmpty, unset } from 'lodash';
+import { Observable, from, map, of, switchMap, tap } from 'rxjs';
 import slugify from 'slugify';
 import { z } from 'zod';
 
 import { ExtKey, parseExtPlugins } from './extension';
-import { parseSeprateService, parseUpstream } from './parser';
+import { parseSeprateService, transformUpstream } from './parser';
 import { schema } from './schema';
 
 const pathVariableRegex = /{[^}]+}/g;
+const httpMethods: Array<OpenAPIV3_1.HttpMethods> = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+];
 
 export class OpenAPIConverter implements ADCSDK.Converter {
-  public toADC(
-    oas: OpenAPIV3.Document,
-  ): Listr<{ local: ADCSDK.Configuration }> {
-    return new Listr<{ local: ADCSDK.Configuration }>([
-      {
-        title: 'Validate OpenAPI document',
-        task: (ctx, task) => {
-          const result = schema.safeParse(oas);
-
-          if (!result.success) {
-            const err = `Validate OpenAPI document\nThe following errors were found in OpenAPI document:\n${z.prettifyError(result.error)}`;
-            const error = new Error(err);
-            error.stack = '';
-            throw error;
-          }
-        },
-      },
-      {
-        title: 'Generate main service',
-        task: (ctx) => {
-          ctx.local.services = [
-            {
+  public toADC(content: string): Observable<ADCSDK.Configuration> {
+    return from(this.parseOAS(content)).pipe(
+      switchMap((oas) => {
+        return of([] as Array<ADCSDK.Service>).pipe(
+          // Generate main service
+          tap((services) => {
+            const { path_prefix, upstream } = transformUpstream(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- checked by schema
+              oas.servers!,
+              oas[ExtKey.UPSTREAM_DEFAULTS],
+            );
+            services.push({
               name: oas[ExtKey.NAME]
                 ? oas[ExtKey.NAME]
-                : oas.info.title
+                : oas.info?.title
                   ? oas.info.title
                   : 'Untitled service',
-              description: oas.info.description,
+              description: oas.info?.description,
               labels: oas[ExtKey.LABELS],
               plugins: parseExtPlugins(oas),
               routes: [],
-            },
-          ];
-
-          parseUpstream(
-            ctx.local.services[0],
-            oas.servers,
-            oas[ExtKey.UPSTREAM_DEFAULTS],
-          );
-
-          ctx.local.services[0] = {
-            ...ctx.local.services[0],
-            ...(oas[ExtKey.SERVICE_DEFAULTS] ?? {}),
-          };
-        },
-      },
-      {
-        title: 'Generate routes',
-        task: (ctx, task) => {
-          const mainService = ctx.local.services[0];
-          const services: Array<ADCSDK.Service> = [];
-          Object.entries(oas.paths).forEach(([path, operations]) => {
-            const httpMethods = Object.values(OpenAPIV3.HttpMethods);
-
-            const separateService = parseSeprateService(
-              mainService,
-              operations,
-              [mainService.name, path].map((item) => slugify(item)).join('_'),
-            );
-            const pathPlugins = parseExtPlugins(operations);
-            const routes = Object.entries(operations)
-              .filter(([key]) =>
-                httpMethods.includes(key as OpenAPIV3.HttpMethods),
+              path_prefix,
+              upstream,
+              ...(oas[ExtKey.SERVICE_DEFAULTS] ?? {}),
+            });
+          }),
+          // Check those paths with special upstream configurations and generate split services
+          tap((services) => {
+            const mainService = services[0];
+            Object.entries(oas.paths!).forEach(([path, operations]) => {
+              const separateService = parseSeprateService(
+                mainService,
+                [mainService.name, path].map((item) => slugify(item)).join('_'),
+                operations,
+              );
+              const pathPlugins = operations ? parseExtPlugins(operations) : {};
+              const routes = Object.entries<OpenAPIV3_1.OperationObject>(
+                operations ?? {},
               )
-              .map(
-                ([method, operation]: [
-                  OpenAPIV3.HttpMethods,
-                  OpenAPIV3.OperationObject,
-                ]) => {
+                .filter(([method]) =>
+                  httpMethods.includes(method as OpenAPIV3_1.HttpMethods),
+                )
+                .map(([method, operation]) => {
                   const separateService = parseSeprateService(
                     mainService,
-                    operation,
-                    [oas.info.title, path, method]
+                    [oas.info!.title!, path, method]
                       .map((item) => slugify(item))
                       .join('_'),
-                    operations[ExtKey.SERVICE_DEFAULTS],
+                    operation,
+                    operations![ExtKey.SERVICE_DEFAULTS],
                     {
                       ...oas[ExtKey.UPSTREAM_DEFAULTS],
-                      ...operations[ExtKey.UPSTREAM_DEFAULTS],
+                      ...operations![ExtKey.UPSTREAM_DEFAULTS],
                     },
                   );
 
@@ -103,7 +88,7 @@ export class OpenAPIConverter implements ADCSDK.Converter {
                       ? operation[ExtKey.NAME]
                       : operation.operationId
                         ? operation.operationId
-                        : [oas.info.title, path, method]
+                        : [oas.info!.title!, path, method]
                             .map((item) => slugify(item))
                             .join('_'),
                     description: operation.summary ?? operation.description,
@@ -116,46 +101,83 @@ export class OpenAPIConverter implements ADCSDK.Converter {
                     ],
                     plugins: !isEmpty(plugins) ? plugins : undefined,
                     ...structuredClone(oas[ExtKey.ROUTE_DEFAULTS]),
-                    ...structuredClone(operations[ExtKey.ROUTE_DEFAULTS]),
+                    ...structuredClone(operations![ExtKey.ROUTE_DEFAULTS]),
                     ...structuredClone(operation[ExtKey.ROUTE_DEFAULTS]),
                   } as ADCSDK.Route);
 
                   if (separateService) {
                     separateService.routes = [route];
                     services.push(separateService);
-                    task.output = this.buildDebugOutput([
+                    //TODO use event subscription
+                    console.log(
                       `${method.toUpperCase()} "${path}" contains the service or upstream defaults, so it will be included to the separate service`,
-                    ]);
+                    );
                   } else {
                     return route;
                   }
-                },
-              )
-              .filter((item) => !!item);
-            if (separateService) {
-              if (routes?.length <= 0) return;
-              separateService.routes = routes;
-              services.push(separateService);
-              task.output = this.buildDebugOutput([
-                `Path "${path}" contains the service or upstream defaults, so it will be included to the separate service`,
-              ]);
-            } else {
-              mainService.routes.push(...routes);
-            }
-          });
-          ctx.local.services = ctx.local.services
-            .concat(...services)
-            .filter((service) => service?.routes?.length > 0)
-            .map((service) => ADCSDK.utils.recursiveOmitUndefined(service));
-        },
-      },
-    ]);
+                })
+                .filter((item) => !!item);
+              if (separateService) {
+                if (routes?.length <= 0) return;
+                separateService.routes = routes;
+                services.unshift(separateService);
+                //TODO use event subscription
+                console.log(
+                  `Path "${path}" contains the service or upstream defaults, so it will be included to the separate service`,
+                );
+              } else {
+                mainService.routes!.push(...routes);
+              }
+            });
+          }),
+          // Always inline path prefix to support APISIX
+          tap((services) =>
+            services.map((service) => {
+              if (!service.path_prefix) return service;
+              service.routes = service.routes!.map((route) => {
+                route.uris = route.uris.map(
+                  (uri) => `${service.path_prefix}${uri}`,
+                );
+                return route;
+              });
+              unset(service, 'path_prefix');
+              return service;
+            }),
+          ),
+          map((services) =>
+            services
+              .filter((service) => service.routes && service.routes?.length > 0)
+              .map((service) => ADCSDK.utils.recursiveOmitUndefined(service)),
+          ),
+          map((services) => ({ services }) as ADCSDK.Configuration),
+        );
+      }),
+    );
   }
 
-  private buildDebugOutput(messages: Array<string>) {
-    return JSON.stringify({
-      type: 'DEBUG',
-      messages,
-    });
+  private parseOAS(content: string): Observable<OpenAPIV3_1.Document> {
+    return from(dereference(content)).pipe(
+      map((res) => {
+        if (res.errors?.length)
+          throw new Error(
+            `Failed to dereference OpenAPI document: ${res.errors
+              .map((error) => error.message)
+              .join(', ')}`,
+          );
+        if (!res.schema) throw new Error('No schema found in OpenAPI document');
+        return res.schema;
+      }),
+      map((schema) => upgrade(schema).specification),
+      tap((specification) => {
+        const result = schema.safeParse(specification);
+
+        if (!result.success) {
+          const err = `Validate OpenAPI document\nThe following errors were found in OpenAPI document:\n${z.prettifyError(result.error)}`;
+          const error = new Error(err);
+          error.stack = '';
+          throw error;
+        }
+      }),
+    );
   }
 }

--- a/libs/converter-openapi/src/schema.ts
+++ b/libs/converter-openapi/src/schema.ts
@@ -2,14 +2,14 @@ import { z } from 'zod';
 
 import { ExtKey } from './extension';
 
-const xNameSchema = z.optional(z.string().min(1));
-const xLabelsSchmea = z.optional(
-  z.record(z.string(), z.union([z.string(), z.array(z.string())])),
-);
-const xPluginsSchema = z.optional(z.record(z.string(), z.any()));
-const xDefaults = z.optional(z.record(z.string(), z.any()));
-const pathOperationSchema = z.optional(
-  z.object({
+const xNameSchema = z.string().min(1).optional();
+const xLabelsSchmea = z
+  .record(z.string(), z.union([z.string(), z.array(z.string())]))
+  .optional();
+const xPluginsSchema = z.record(z.string(), z.any()).optional();
+const xDefaults = z.record(z.string(), z.any()).optional();
+const pathOperationSchema = z
+  .looseObject({
     [ExtKey.NAME]: xNameSchema,
     [ExtKey.LABELS]: xLabelsSchmea,
     [ExtKey.PLUGINS]: xPluginsSchema,
@@ -20,10 +20,10 @@ const pathOperationSchema = z.optional(
     operationId: z.optional(z.string()),
     summary: z.optional(z.string()),
     description: z.optional(z.string()),
-  }),
-);
-export const schema = z.object({
-  info: z.object({
+  })
+  .optional();
+export const schema = z.looseObject({
+  info: z.looseObject({
     title: z.string(),
     description: z.optional(z.string()),
   }),
@@ -36,7 +36,7 @@ export const schema = z.object({
   [ExtKey.ROUTE_DEFAULTS]: xDefaults,
   servers: z
     .array(
-      z.object({
+      z.looseObject({
         url: z
           .string()
           .regex(
@@ -57,7 +57,7 @@ export const schema = z.object({
     .min(1),
   paths: z.record(
     z.string(),
-    z.object({
+    z.looseObject({
       [ExtKey.PLUGINS]: xPluginsSchema,
       // [ExtKey.PLUGIN_PREFIX]: ignore
       [ExtKey.SERVICE_DEFAULTS]: xDefaults,

--- a/libs/converter-openapi/test/utils.ts
+++ b/libs/converter-openapi/test/utils.ts
@@ -1,6 +1,9 @@
 import { Listr, SilentRenderer } from 'listr2';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { lastValueFrom } from 'rxjs';
+
+import { OpenAPIConverter } from '../src';
 
 export const loadAsset = (fileName: string) =>
   readFileSync(join(__dirname, `assets/${fileName}`)).toString('utf-8');
@@ -11,3 +14,6 @@ export const runTask = async (tasks: Listr) => {
   await tasks.run({ local: {} });
   return tasks.ctx.local;
 };
+
+export const convert = async (oas: string) =>
+  await lastValueFrom(new OpenAPIConverter().toADC(oas));

--- a/libs/converter-openapi/tsconfig.spec.json
+++ b/libs/converter-openapi/tsconfig.spec.json
@@ -29,7 +29,8 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "test/**/*.ts"
   ],
   "references": [
     {

--- a/libs/sdk/src/converter/index.ts
+++ b/libs/sdk/src/converter/index.ts
@@ -1,9 +1,7 @@
-import { Listr } from 'listr2';
+import { Observable } from 'rxjs';
 
 import { Configuration } from '../core';
 
 export interface Converter {
-  toADC: (input: unknown) => Listr<{
-    local: Configuration;
-  }>;
+  toADC: (input: string) => Observable<Configuration>;
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "rxjs": "^7.8.1",
     "semver": "^7.6.3",
     "signale": "^1.4.0",
-    "slugify": "^1.6.6",
     "source-map-support": "^0.5.21",
     "tslib": "^2.6.2",
     "yaml": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
       signale:
         specifier: ^1.4.0
         version: 1.4.0
-      slugify:
-        specifier: ^1.6.6
-        version: 1.6.6
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -268,6 +265,15 @@ importers:
       '@api7/adc-sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@scalar/openapi-parser':
+        specifier: ^0.19.0
+        version: 0.19.0
+      '@scalar/openapi-types':
+        specifier: ^0.3.7
+        version: 0.3.7
+      slugify:
+        specifier: ^1.6.6
+        version: 1.6.6
 
   libs/differ:
     devDependencies:
@@ -276,12 +282,6 @@ importers:
         version: link:../sdk
 
   libs/sdk: {}
-
-  libs/tstetsetse:
-    dependencies:
-      tslib:
-        specifier: ^2.3.0
-        version: 2.6.3
 
 packages:
 
@@ -1969,6 +1969,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@scalar/openapi-parser@0.19.0':
+    resolution: {integrity: sha512-U1FDug4NFK+o1ib93L2MerW13s61sEDPDgrmO14mp5qAV5iYkC2l0KqKQLMIbt3sWw6fDy900eXNKIgUuge4BA==}
+    engines: {node: '>=20'}
+
+  '@scalar/openapi-types@0.3.7':
+    resolution: {integrity: sha512-QHSvHBVDze3+dUwAhIGq6l1iOev4jdoqdBK7QpfeN1Q4h+6qpVEw3EEqBiH0AXUSh/iWwObBv4uMgfIx0aNZ5g==}
+    engines: {node: '>=20'}
+
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
@@ -2648,6 +2656,14 @@ packages:
       ajv:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -2663,6 +2679,9 @@ packages:
 
   ajv@8.14.0:
     resolution: {integrity: sha512-oYs1UUtO97ZO2lJ4bwnWeQW8/zvOIQLGKcvPTsWmvc2SYgBb+upuNS5NxoLaMU4h8Ju3Nbj6Cq8mD2LQoqVKFA==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -3635,6 +3654,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -4382,6 +4404,10 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  leven@4.0.0:
+    resolution: {integrity: sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -6313,6 +6339,9 @@ packages:
   yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
+
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zod@4.0.10:
     resolution: {integrity: sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==}
@@ -8347,6 +8376,20 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.46.2':
     optional: true
 
+  '@scalar/openapi-parser@0.19.0':
+    dependencies:
+      '@scalar/openapi-types': 0.3.7
+      ajv: 8.17.1
+      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      jsonpointer: 5.0.1
+      leven: 4.0.0
+      yaml: 2.8.0
+
+  '@scalar/openapi-types@0.3.7':
+    dependencies:
+      zod: 3.24.1
+
   '@sinclair/typebox@0.27.8': {}
 
   '@sinclair/typebox@0.34.38': {}
@@ -9100,9 +9143,17 @@ snapshots:
     optionalDependencies:
       ajv: 8.14.0
 
+  ajv-draft-04@1.0.0(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv-formats@2.1.1(ajv@8.14.0):
     optionalDependencies:
       ajv: 8.14.0
+
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -9126,6 +9177,13 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -10211,6 +10269,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-uri@3.0.6: {}
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -11128,6 +11188,8 @@ snapshots:
       source-map: 0.6.1
 
   leven@3.1.0: {}
+
+  leven@4.0.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -13165,5 +13227,7 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.0.0: {}
+
+  zod@3.24.1: {}
 
   zod@4.0.10: {}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "target": "esnext",
     "module": "nodenext",
     "lib": [
-      "es2020"
+      "esnext"
     ]
   }
 }


### PR DESCRIPTION
### Description

Moves the OpenAPI parser to the @scalar implementation, thanks to which this library was created.
This library has better code quality than the old, poorly maintained library and is based entirely on TypeScript.

Now that this ADC converter also supports the Swagger format (also known as OpenAPI 2.0), you don't need to do anything; it will do its best to upgrade your old OAS documentation and perform the conversion.

For those of you who are using the ADC OpenAPI converter now: 
We've now introduced a slight break change where your server's URL will no longer emit a `service.path_prefix` regardless of whether it contains a path suffix or not, and every path will be inlined as a prefix in the uri of every route.
The value of `path_prefix` is still resolved from the first server's URL as before.

The reason for this change is that APISIX does not support `path_prefix` and `strip_path_prefix`, and we had to choose a more widely compatible way to achieve a similar effect.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
