### PR TITLE
fix(core): ingress server sync API server option accept multiple endpoints

### DIFF
--- a/apps/cli/src/server/schema.ts
+++ b/apps/cli/src/server/schema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 const SyncTask = z.strictObject({
   opts: z.looseObject({
     backend: z.string().min(1),
-    server: z.url().min(1),
+    server: z.string().min(1),
     token: z.string().min(1),
     lint: z.boolean().optional().default(true),
     includeResourceType: z.array(z.enum(ADCSDK.ResourceType)).optional(),

--- a/apps/cli/src/server/schema.ts
+++ b/apps/cli/src/server/schema.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 const SyncTask = z.strictObject({
   opts: z.looseObject({
     backend: z.string().min(1),
-    server: z.string().min(1),
+    server: z.union([z.url().min(1), z.array(z.url().min(1))]),
     token: z.string().min(1),
     lint: z.boolean().optional().default(true),
     includeResourceType: z.array(z.enum(ADCSDK.ResourceType)).optional(),

--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -1,3 +1,4 @@
+import { DifferV3 } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
 import type { RequestHandler } from 'express';
 import { omit, toString } from 'lodash';
@@ -9,7 +10,6 @@ import {
   filterResourceType,
   loadBackend,
 } from '../command/utils';
-import { DifferV3 } from '@api7/adc-differ';
 import { check } from '../linter';
 import { SyncInput, type SyncInputType } from './schema';
 
@@ -46,7 +46,12 @@ export const syncHandler: RequestHandler<
 
     // load and filter remote configuration
     //TODO: merged with the listr task
-    const backend = loadBackend(task.opts.backend, { ...task.opts });
+    const backend = loadBackend(task.opts.backend, {
+      ...task.opts,
+      server: Array.isArray(task.opts.server)
+        ? task.opts.server.join(',')
+        : task.opts.server,
+    });
     let remote = await lastValueFrom(backend.dump());
     remote = filterResourceType(
       remote,


### PR DESCRIPTION
### Description

The server option of the ingress server sync API should accept multiple URLs.
It now accepts string or array.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
