### PR TITLE
feat(apisix-standalone): use millisecond timestamp as conf version

### DIFF
--- a/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
@@ -110,7 +110,7 @@ describe('Cache - Single APISIX', () => {
   it('check if the cache is updated', async () => {
     expect(configCache.get(cacheKey)).toMatchObject(config);
 
-    const timestamp = Math.ceil(now.getTime() / 1000);
+    const timestamp = now.getTime();
     expect(rawConfigCache.get(cacheKey)).toMatchObject({
       services: [
         {

--- a/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
@@ -310,7 +310,7 @@ describe('Cache - Multiple APISIX (Partial new instances)', () => {
         .filter((item) => item === ADCSDK.EventType.CREATE),
     ).toHaveLength(2);
 
-    vi.setSystemTime(100 * 1000);
+    vi.setSystemTime(100);
 
     return syncEvents(
       new BackendAPISIXStandalone({
@@ -350,7 +350,7 @@ describe('Cache - Multiple APISIX (Partial new instances)', () => {
         .filter((item) => item === ADCSDK.EventType.CREATE),
     ).toHaveLength(2);
 
-    vi.setSystemTime(200 * 1000);
+    vi.setSystemTime(200);
 
     return syncEvents(
       new BackendAPISIXStandalone({

--- a/libs/backend-apisix-standalone/e2e/resources/service.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/service.e2e-spec.ts
@@ -9,10 +9,9 @@ import {
   dumpConfiguration,
   restartAPISIX,
   syncEvents,
-  updateEvent,
 } from '../support/utils';
 
-describe('Sync and Dump - 1', () => {
+describe('Service E2E', () => {
   let backend: BackendAPISIXStandalone;
 
   beforeAll(async () => {

--- a/libs/backend-apisix-standalone/src/operator.ts
+++ b/libs/backend-apisix-standalone/src/operator.ts
@@ -60,7 +60,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
     const taskStateEvent = this.taskStateEvent(taskName);
     logger(taskStateEvent('TASK_START'));
 
-    const timestamp = Math.ceil(Date.now() / 1000);
+    const timestamp = Date.now();
     return from(events).pipe(
       // derive the latest configuration from the old config
       tap((event) => {

--- a/libs/backend-apisix-standalone/src/transformer.ts
+++ b/libs/backend-apisix-standalone/src/transformer.ts
@@ -41,13 +41,14 @@ export const toADC = (input: typing.APISIXStandalone) => {
           description: service.desc,
           labels: service.labels,
           ...(service.upstream_id && {
-            upstream: ADCSDK.utils.recursiveOmitUndefined(
-              transformUpstream(
+            upstream: ADCSDK.utils.recursiveOmitUndefined({
+              ...transformUpstream(
                 input.upstreams!.find(
                   (item) => item.id === service.upstream_id,
                 )!,
               ),
-            ),
+              name: undefined,
+            }),
           }),
           plugins: service.plugins,
           hosts: service.hosts,


### PR DESCRIPTION
### Description

Currently, ADC uses timestamps with second precision as the conf version, which may not be sufficient if the ingress controller sends requests quickly.

This PR changes the timestamp to millisecond precision, which is expected to be sufficient. Its value range will be within the numeric range of JavaScript and LuaJIT, `2^53-1`, which is not a concern.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
