### PR TITLE
fix(apisix-standalone): handle inline upstream update and delete

### DIFF
--- a/libs/backend-apisix-standalone/e2e/resources/service-inline-upstream.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/service-inline-upstream.e2e-spec.ts
@@ -22,46 +22,109 @@ describe('Service E2E - inline upstream', () => {
     });
   });
 
+  afterEach(() => vi.useRealTimers());
+
   it('Initialize cache', () =>
     expect(dumpConfiguration(backend)).resolves.not.toThrow());
 
   const serviceName = 'test';
-  it('Create service', async () => {
-    const events = DifferV3.diff(
+  const config = {
+    services: [
       {
-        services: [
-          {
-            name: serviceName,
-            upstream: {
-              nodes: [
-                {
-                  host: '127.0.0.1',
-                  port: 9180,
-                  weight: 100,
-                },
-              ],
+        name: serviceName,
+        upstream: {
+          nodes: [
+            {
+              host: '127.0.0.1',
+              port: 9180,
+              weight: 100,
             },
-          },
-        ],
+          ],
+        },
       },
-      await dumpConfiguration(backend),
-    );
+    ],
+  };
+  it('Create service', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100);
+    const events = DifferV3.diff(config, await dumpConfiguration(backend));
     return syncEvents(backend, events);
   });
 
   it('Check configuration', () => {
-    expect(rawConfigCache.get(cacheKey)?.upstreams).not.toBeUndefined();
-    expect(rawConfigCache.get(cacheKey)!.upstreams).toHaveLength(1);
-    expect(rawConfigCache.get(cacheKey)!.upstreams![0].id).toEqual(
+    const rawConfig = rawConfigCache.get(cacheKey);
+    expect(rawConfig?.services?.[0].id).toEqual(
       ADCSDK.utils.generateId(serviceName),
     );
-    expect(rawConfigCache.get(cacheKey)!.upstreams![0].name).toEqual(
-      serviceName,
+    expect(rawConfig?.services?.[0].modifiedIndex).toEqual(100);
+    expect(rawConfig?.upstreams).not.toBeUndefined();
+    expect(rawConfig?.upstreams).toHaveLength(1);
+    expect(rawConfig?.upstreams?.[0].id).toEqual(
+      ADCSDK.utils.generateId(serviceName),
     );
+    expect(rawConfig?.upstreams?.[0].name).toEqual(serviceName);
+    expect(rawConfig?.upstreams?.[0].modifiedIndex).toEqual(100);
+    expect(rawConfig?.services_conf_version).toEqual(100);
+    expect(rawConfig?.upstreams_conf_version).toEqual(100);
+    expect(rawConfig?.consumers_conf_version).toBeUndefined();
+    expect(rawConfig?.global_rules_conf_version).toBeUndefined();
+    expect(rawConfig?.plugin_metadata_conf_version).toBeUndefined();
+    expect(rawConfig?.routes_conf_version).toBeUndefined();
+    expect(rawConfig?.ssls_conf_version).toBeUndefined();
+    expect(rawConfig?.stream_routes_conf_version).toBeUndefined();
 
-    expect(configCache.get(cacheKey)?.services).not.toBeUndefined();
-    expect(
-      configCache.get(cacheKey)?.services![0].upstream,
-    ).not.toBeUndefined();
+    const config = configCache.get(cacheKey);
+    expect(config?.services).not.toBeUndefined();
+    expect(config?.services?.[0].upstream).not.toBeUndefined();
+  });
+
+  it('Update inlined upstream', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(200);
+
+    const newConfig = structuredClone(config);
+    newConfig.services[0].upstream.nodes[0].port = 19080;
+
+    const events = DifferV3.diff(newConfig, await dumpConfiguration(backend));
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toEqual(ADCSDK.EventType.UPDATE);
+    expect(events[0].resourceType).toEqual(ADCSDK.ResourceType.SERVICE);
+    expect(events[0].diff?.[0].path?.[0]).toEqual('upstream');
+
+    return syncEvents(backend, events);
+  });
+
+  it('Check configuration', () => {
+    const rawConfig = rawConfigCache.get(cacheKey);
+    expect(rawConfig?.upstreams?.[0].modifiedIndex).toEqual(200);
+    expect(rawConfig?.services?.[0].modifiedIndex).toEqual(100);
+    expect(rawConfig?.upstreams_conf_version).toEqual(200);
+    expect(rawConfig?.services_conf_version).toEqual(100);
+    expect(rawConfig?.consumers_conf_version).toBeUndefined();
+    expect(rawConfig?.global_rules_conf_version).toBeUndefined();
+    expect(rawConfig?.plugin_metadata_conf_version).toBeUndefined();
+    expect(rawConfig?.routes_conf_version).toBeUndefined();
+    expect(rawConfig?.ssls_conf_version).toBeUndefined();
+    expect(rawConfig?.stream_routes_conf_version).toBeUndefined();
+  });
+
+  it('Delete service', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(300);
+
+    const events = DifferV3.diff({}, await dumpConfiguration(backend));
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toEqual(ADCSDK.EventType.DELETE);
+    expect(events[0].resourceType).toEqual(ADCSDK.ResourceType.SERVICE);
+
+    return syncEvents(backend, events);
+  });
+
+  it('Check configuration', () => {
+    const rawConfig = rawConfigCache.get(cacheKey);
+    expect(rawConfig?.upstreams).toHaveLength(0);
+    expect(rawConfig?.services).toHaveLength(0);
+    expect(rawConfig?.upstreams_conf_version).toEqual(300);
+    expect(rawConfig?.services_conf_version).toEqual(300);
   });
 });


### PR DESCRIPTION
### Description

I implemented inline upstream splitting in #319, but there seem to be some issues with the update and delete logic, specifically:
1. The split upstream may not be updated correctly.
2. When only the inline upstream is updated in the service, the service conf version is incorrectly increased.

This PR thoroughly reorganized this section and optimized the code.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
4. Always update the documentation to reflect the changes made in the PR.
5. Make a new commit to resolve conversations instead of `push -f`.
6. To resolve merge conflicts, merge master instead of rebasing.
7. Use "request review" to notify the reviewer after making changes.
8. Only a reviewer can mark a conversation as resolved.

-->
