### PR TITLE
feat(apisix-standalone): add server field to sync result

### DIFF
--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -119,7 +119,8 @@ export const syncHandler: RequestHandler<
       success_count: successes.length,
       failed_count: faileds.length,
       success: [
-        ...successes.map(({ event, axiosResponse }) => ({
+        ...successes.map(({ event, axiosResponse, server }) => ({
+          server,
           event: simplifyEvent(event),
           synced_at: new Date(
             axiosResponse?.headers?.date ?? new Date(),
@@ -127,7 +128,8 @@ export const syncHandler: RequestHandler<
         })),
       ],
       failed: [
-        ...faileds.map(({ event, error, axiosResponse }) => ({
+        ...faileds.map(({ event, error, axiosResponse, server }) => ({
+          server,
           event: simplifyEvent(event),
           failed_at: new Date(
             axiosResponse?.headers?.date ?? new Date(),

--- a/libs/backend-apisix-standalone/src/index.ts
+++ b/libs/backend-apisix-standalone/src/index.ts
@@ -10,7 +10,7 @@ import {
   type AgentOptions as httpsAgentOptions,
 } from 'node:https';
 import { type Observable, Subject, from, map, of, switchMap } from 'rxjs';
-import semver, { SemVer } from 'semver';
+import semver, { SemVer, eq as semverEQ } from 'semver';
 
 import {
   config as configCache,
@@ -100,7 +100,8 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
       event: { response: resp, description: `Get APISIX version` },
     });
 
-    let version = new SemVer('999.999.999');
+    const mockVersion = '999.999.999';
+    let version = new SemVer(mockVersion);
     if (resp.headers.server) {
       const parsedVersion = (resp.headers.server as string).match(
         /APISIX\/(.*)/,
@@ -108,7 +109,10 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
       if (parsedVersion) version = semver.coerce(parsedVersion[1]) ?? version;
     }
 
-    versionCache.set(this.opts.cacheKey, version);
+    // Only cache it when the actual value is obtained
+    if (!semverEQ(version, mockVersion))
+      versionCache.set(this.opts.cacheKey, version);
+
     return version;
   }
 

--- a/libs/backend-apisix-standalone/src/operator.ts
+++ b/libs/backend-apisix-standalone/src/operator.ts
@@ -113,6 +113,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                     success: true,
                     event: {} as ADCSDK.Event, // keep empty
                     axiosResponse: response,
+                    server,
                   }) satisfies ADCSDK.BackendSyncResult,
               ),
               catchError<
@@ -140,6 +141,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                       error: new Error(error.response.data.error_msg),
                     }),
                   }),
+                  server,
                 } satisfies ADCSDK.BackendSyncResult);
               }),
               tap(() => {

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -60,6 +60,7 @@ export interface BackendSyncResult {
   event: ADCSDK.Event;
   axiosResponse?: AxiosResponse;
   error?: Error;
+  server?: string;
 }
 
 export interface BackendMetadata {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "yaml": "^2.4.2",
     "zod": "^4.0.10"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",


### PR DESCRIPTION
### Description

We have implemented single-batch synchronization for multiple servers on the apisix-standalone backend. Consequently, the final synchronization result will pertain to all servers collectively, and currently, no field indicates which server succeeded or failed.

This PR adds an optional server field to the synchronization result and populates it in the apisix-standalone backend.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
