### PR TITLE
feat(apisix-standalone): use one of servers when no XLM header

### DIFF
--- a/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
@@ -404,10 +404,6 @@ describe('Cache - Multiple APISIX (Partial new instances)', () => {
 
       expect(configCache.size).toEqual(1);
       expect(rawConfigCache.size).toEqual(1);
-      // For versions where last modified is not available (e.g. less than or equal to 3.13.0), the cache cannot be initialized.
-      // The cache will be empty so that the ADC will perform a full synchronization.
-      expect(configCache.get(cacheKey)).toEqual({});
-      expect(rawConfigCache.get(cacheKey)).toEqual({});
     },
   );
 

--- a/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
@@ -58,8 +58,16 @@ describe('Cache - Single APISIX', () => {
     expect(rawConfigCache.size).toEqual(1);
     // APISIX does not report when it was last updated (it has not yet gotten configured),
     // so fetcher will automatically populate empty objects as a default.
-    expect(configCache.get(cacheKey)).toEqual({});
-    expect(rawConfigCache.get(cacheKey)).toEqual({});
+    expect(configCache.get(cacheKey)).toMatchObject({
+      services: [],
+      ssls: [],
+      consumers: [],
+      global_rules: {},
+      plugin_metadata: {},
+    });
+    Object.values(
+      rawConfigCache.get(cacheKey) as Record<string, unknown>,
+    ).forEach((item) => expect(item).toEqual(0));
   });
 
   it('dump again (should use cache)', async () => {
@@ -207,8 +215,16 @@ describe('Cache - Multiple APISIX (completely new instances)', () => {
     expect(rawConfigCache.size).toEqual(1);
     // APISIX does not report when it was last updated (it has not yet gotten configured),
     // so fetcher will automatically populate empty objects as a default.
-    expect(configCache.get(cacheKey)).toEqual({});
-    expect(rawConfigCache.get(cacheKey)).toEqual({});
+    expect(configCache.get(cacheKey)).toMatchObject({
+      services: [],
+      ssls: [],
+      consumers: [],
+      global_rules: {},
+      plugin_metadata: {},
+    });
+    Object.values(
+      rawConfigCache.get(cacheKey) as Record<string, unknown>,
+    ).forEach((item) => expect(item).toEqual(0));
   });
 
   const config = {

--- a/libs/backend-apisix-standalone/e2e/resources/service-inline-upstream.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/service-inline-upstream.e2e-spec.ts
@@ -66,12 +66,11 @@ describe('Service E2E - inline upstream', () => {
     expect(rawConfig?.upstreams?.[0].modifiedIndex).toEqual(100);
     expect(rawConfig?.services_conf_version).toEqual(100);
     expect(rawConfig?.upstreams_conf_version).toEqual(100);
-    expect(rawConfig?.consumers_conf_version).toBeUndefined();
-    expect(rawConfig?.global_rules_conf_version).toBeUndefined();
-    expect(rawConfig?.plugin_metadata_conf_version).toBeUndefined();
-    expect(rawConfig?.routes_conf_version).toBeUndefined();
-    expect(rawConfig?.ssls_conf_version).toBeUndefined();
-    expect(rawConfig?.stream_routes_conf_version).toBeUndefined();
+    expect(rawConfig?.consumers_conf_version).toEqual(0);
+    expect(rawConfig?.global_rules_conf_version).toEqual(0);
+    expect(rawConfig?.plugin_metadata_conf_version).toEqual(0);
+    expect(rawConfig?.routes_conf_version).toEqual(0);
+    expect(rawConfig?.ssls_conf_version).toEqual(0);
 
     const config = configCache.get(cacheKey);
     expect(config?.services).not.toBeUndefined();
@@ -100,12 +99,11 @@ describe('Service E2E - inline upstream', () => {
     expect(rawConfig?.services?.[0].modifiedIndex).toEqual(100);
     expect(rawConfig?.upstreams_conf_version).toEqual(200);
     expect(rawConfig?.services_conf_version).toEqual(100);
-    expect(rawConfig?.consumers_conf_version).toBeUndefined();
-    expect(rawConfig?.global_rules_conf_version).toBeUndefined();
-    expect(rawConfig?.plugin_metadata_conf_version).toBeUndefined();
-    expect(rawConfig?.routes_conf_version).toBeUndefined();
-    expect(rawConfig?.ssls_conf_version).toBeUndefined();
-    expect(rawConfig?.stream_routes_conf_version).toBeUndefined();
+    expect(rawConfig?.consumers_conf_version).toEqual(0);
+    expect(rawConfig?.global_rules_conf_version).toEqual(0);
+    expect(rawConfig?.plugin_metadata_conf_version).toEqual(0);
+    expect(rawConfig?.routes_conf_version).toEqual(0);
+    expect(rawConfig?.ssls_conf_version).toEqual(0);
   });
 
   it('Update inlined upstream again', async () => {
@@ -131,12 +129,11 @@ describe('Service E2E - inline upstream', () => {
     expect(rawConfig?.services?.[0].modifiedIndex).toEqual(100);
     expect(rawConfig?.upstreams_conf_version).toEqual(300);
     expect(rawConfig?.services_conf_version).toEqual(100);
-    expect(rawConfig?.consumers_conf_version).toBeUndefined();
-    expect(rawConfig?.global_rules_conf_version).toBeUndefined();
-    expect(rawConfig?.plugin_metadata_conf_version).toBeUndefined();
-    expect(rawConfig?.routes_conf_version).toBeUndefined();
-    expect(rawConfig?.ssls_conf_version).toBeUndefined();
-    expect(rawConfig?.stream_routes_conf_version).toBeUndefined();
+    expect(rawConfig?.consumers_conf_version).toEqual(0);
+    expect(rawConfig?.global_rules_conf_version).toEqual(0);
+    expect(rawConfig?.plugin_metadata_conf_version).toEqual(0);
+    expect(rawConfig?.routes_conf_version).toEqual(0);
+    expect(rawConfig?.ssls_conf_version).toEqual(0);
   });
 
   it('Delete service', async () => {

--- a/libs/backend-apisix-standalone/src/fetcher.ts
+++ b/libs/backend-apisix-standalone/src/fetcher.ts
@@ -43,18 +43,22 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
     logger(taskStateEvent('TASK_START'));
     return from(this.findLatest()).pipe(
       switchMap((server) => {
-        if (!server) return of([{}, {}] as result);
+        if (!server) server = this.opts.serverTokenMap.keys().next().value;
         return from(
           this.opts.client.get<typing.APISIXStandalone>(
             `${server}${ENDPOINT_CONFIG}`,
             {
               headers: {
-                [HEADER_CREDENTIAL]: this.opts.serverTokenMap.get(server),
+                [HEADER_CREDENTIAL]: this.opts.serverTokenMap.get(
+                  server as string,
+                ),
               },
             },
           ),
         ).pipe(
-          tap((resp) => logger(this.debugLogEvent(resp))),
+          tap((resp) =>
+            logger(this.debugLogEvent(resp, 'Initialize configuration cache')),
+          ),
           map((resp) => [toADC(resp.data), resp.data] as result),
         );
       }),
@@ -78,7 +82,9 @@ export class Fetcher extends ADCSDK.backend.BackendEventSource {
             headers: { [HEADER_CREDENTIAL]: token },
           }),
         ).pipe(
-          tap((resp) => logger(this.debugLogEvent(resp))),
+          tap((resp) =>
+            logger(this.debugLogEvent(resp, 'Get latest updated instance')),
+          ),
           map((res) => ({
             server,
             timestamp: parseInt(res.headers[HEADER_LAST_MODIFIED] ?? 0),

--- a/libs/backend-apisix-standalone/src/fetcher.ts
+++ b/libs/backend-apisix-standalone/src/fetcher.ts
@@ -7,7 +7,6 @@ import {
   map,
   max,
   mergeMap,
-  of,
   switchMap,
   tap,
 } from 'rxjs';

--- a/libs/backend-apisix-standalone/src/index.ts
+++ b/libs/backend-apisix-standalone/src/index.ts
@@ -170,7 +170,7 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
           serverTokenMap: this.serverTokenMap,
           version,
           eventSubject: this.subject,
-          oldRawConfiguration: rawConfigCache.get(this.opts.cacheKey)!,
+          oldRawConfiguration: rawConfigCache.get(this.opts.cacheKey) ?? {},
         }).sync(events, opts);
       }),
     );


### PR DESCRIPTION
### Description

Currently, if APISIX does not return the `X-Last-Modified` response header, the ADC will not use it to initialize the cache.
This results in poor compatibility with 3.13, causing the dump to fail. Furthermore, if the cache cannot be initialized, APISIX will automatically increment `conf_version`, which is not the intended behavior.

This PR makes a minor modification: if no nodes return XLM, it selects one server node as the target node to initialize the cache.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
