### PR TITLE
fix(apisix-standalone): duplicate upstreams when use service multiple upstreams

### DIFF
--- a/libs/backend-apisix-standalone/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/resources/service-upstream.e2e-spec.ts
@@ -1,0 +1,187 @@
+import { Differ } from '@api7/adc-differ';
+import * as ADCSDK from '@api7/adc-sdk';
+
+import { BackendAPISIXStandalone } from '../../src';
+import {
+  config as configCache,
+  rawConfig as rawConfigCache,
+} from '../../src/cache';
+import * as typing from '../../src/typing';
+import { server1, token1 } from '../support/constants';
+import {
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  restartAPISIX,
+  syncEvents,
+  updateEvent,
+} from '../support/utils';
+
+const cacheKey = 'default';
+describe('Service-Upstreams E2E', () => {
+  let backend: BackendAPISIXStandalone;
+
+  beforeAll(async () => {
+    await restartAPISIX();
+    backend = new BackendAPISIXStandalone({
+      server: server1,
+      token: token1,
+      tlsSkipVerify: true,
+      cacheKey,
+    });
+  });
+
+  describe('Sync and dump service with multiple upstreams', () => {
+    const upstreamND1Name = 'nd-upstream1';
+    const upstreamND1 = {
+      name: upstreamND1Name,
+      type: 'roundrobin',
+      scheme: 'https',
+      nodes: [
+        {
+          host: '1.1.1.1',
+          port: 443,
+          weight: 100,
+        },
+      ],
+    } satisfies ADCSDK.Upstream;
+    const upstreamND2Name = 'nd-upstream2';
+    const upstreamND2 = {
+      //@ts-expect-error custom id
+      id: upstreamND2Name,
+      name: upstreamND2Name,
+      type: 'roundrobin',
+      scheme: 'https',
+      nodes: [
+        {
+          host: '1.0.0.1',
+          port: 443,
+          weight: 100,
+        },
+      ],
+    } satisfies ADCSDK.Upstream;
+    const serviceName = 'test';
+    const service = {
+      name: serviceName,
+      upstream: {
+        type: 'roundrobin',
+        nodes: [
+          {
+            host: 'httpbin.org',
+            port: 443,
+            weight: 100,
+          },
+        ],
+      },
+      upstreams: [upstreamND1, upstreamND2],
+    } satisfies ADCSDK.Service;
+
+    it('Initialize cache', () =>
+      expect(dumpConfiguration(backend)).resolves.not.toThrow());
+
+    it('Create', async () =>
+      syncEvents(
+        backend,
+        Differ.diff(
+          {
+            services: [service],
+          },
+          await dumpConfiguration(backend),
+        ),
+      ));
+
+    const checkOriginalConfig = () => {
+      const rawConfig = rawConfigCache.get(cacheKey);
+      expect(rawConfig?.services?.[0].id).toEqual(
+        ADCSDK.utils.generateId(serviceName),
+      );
+      expect(rawConfig?.upstreams).not.toBeUndefined();
+      expect(rawConfig?.upstreams).toHaveLength(3);
+      expect(rawConfig?.upstreams?.[0].name).toEqual(serviceName);
+      expect(rawConfig?.upstreams?.[1].name).toEqual(upstreamND1Name);
+      expect(rawConfig?.upstreams?.[2].name).toEqual(upstreamND2Name);
+      expect(rawConfig?.upstreams?.[0].labels).toBeUndefined();
+      expect(
+        rawConfig?.upstreams?.[1].labels?.[
+          typing.ADC_UPSTREAM_SERVICE_ID_LABEL
+        ],
+      ).toEqual(ADCSDK.utils.generateId(serviceName));
+      expect(
+        rawConfig?.upstreams?.[2].labels?.[
+          typing.ADC_UPSTREAM_SERVICE_ID_LABEL
+        ],
+      ).toEqual(ADCSDK.utils.generateId(serviceName));
+
+      const config = configCache.get(cacheKey);
+      expect(config?.services).not.toBeUndefined();
+      expect(config?.services).toHaveLength(1);
+      expect(config?.services?.[0].upstreams).toHaveLength(2);
+      expect(
+        config?.services?.[0].upstreams?.[0].labels?.[
+          typing.ADC_UPSTREAM_SERVICE_ID_LABEL
+        ],
+      ).toBeUndefined();
+      expect(
+        config?.services?.[0].upstreams?.[1].labels?.[
+          typing.ADC_UPSTREAM_SERVICE_ID_LABEL
+        ],
+      ).toBeUndefined();
+    };
+    it('Check cache', checkOriginalConfig);
+
+    it('Try update (without any change)', async () =>
+      syncEvents(
+        backend,
+        Differ.diff(
+          {
+            services: [service],
+          },
+          await dumpConfiguration(backend),
+        ),
+      ));
+
+    it('Check cache 2', checkOriginalConfig);
+
+    it('Try update', async () => {
+      const newService = structuredClone(service);
+      newService.upstreams[0].nodes[0].host = '8.8.8.8';
+      await syncEvents(
+        backend,
+        Differ.diff(
+          {
+            services: [newService],
+          },
+          await dumpConfiguration(backend),
+        ),
+      );
+    });
+
+    it('Check updated cache', () => {
+      const rawConfig = rawConfigCache.get(cacheKey);
+      expect(rawConfig?.services?.[0].id).toEqual(
+        ADCSDK.utils.generateId(serviceName),
+      );
+      expect(rawConfig?.upstreams).not.toBeUndefined();
+      expect(rawConfig?.upstreams).toHaveLength(3);
+      expect(
+        rawConfig?.upstreams?.[1].labels?.[
+          typing.ADC_UPSTREAM_SERVICE_ID_LABEL
+        ],
+      ).toEqual(ADCSDK.utils.generateId(serviceName));
+      expect(rawConfig?.upstreams?.[1].nodes[0].host).toEqual('8.8.8.8');
+
+      const config = configCache.get(cacheKey);
+      expect(config?.services).not.toBeUndefined();
+      expect(config?.services).toHaveLength(1);
+      expect(config?.services?.[0].upstreams).toHaveLength(2);
+      expect(
+        config?.services?.[0].upstreams?.[0].labels?.[
+          typing.ADC_UPSTREAM_SERVICE_ID_LABEL
+        ],
+      ).toBeUndefined();
+      expect(config?.services?.[0].upstreams?.[0].nodes?.[0].host).toEqual(
+        '8.8.8.8',
+      );
+    });
+  });
+});

--- a/libs/differ/src/index.ts
+++ b/libs/differ/src/index.ts
@@ -1,1 +1,1 @@
-export { DifferV3 } from './differv3.js';
+export { DifferV3, DifferV3 as Differ } from './differv3.js';


### PR DESCRIPTION
### Description

The APISIX standalone backend has some potential issues when handling multiple upstreams, as it may generate duplicate upstreams. APISIX rejects such configuration inputs.
This blocks improvements to the APISIX Ingress Controller regarding upstreams and traffic splitting, necessitating enhancement. This issue does not affect released Ingress Controller versions, as that functionality is not utilized in those releases.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
