### PR TITLE
fix(backend-api7): duplicate removal of upstream and credentials

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -115,7 +115,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
       matrix:
-        version: [3.5.5, 3.6.1, 3.7.8, 3.8.10]
+        version: [3.5.5, 3.6.1, 3.7.8, 3.8.13]
     env:
       BACKEND_API7_VERSION: ${{ matrix.version }}
       BACKEND_API7_DOWNLOAD_URL: https://run.api7.ai/api7-ee/api7-ee-v${{ matrix.version }}.tar.gz

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -115,7 +115,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
       matrix:
-        version: [3.5.5, 3.6.1, 3.7.8, 3.8.13]
+        version: [3.5.5, 3.6.1, 3.7.8, 3.8.10]
     env:
       BACKEND_API7_VERSION: ${{ matrix.version }}
       BACKEND_API7_DOWNLOAD_URL: https://run.api7.ai/api7-ee/api7-ee-v${{ matrix.version }}.tar.gz

--- a/libs/backend-api7/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-api7/e2e/resources/service-upstream.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { Differ } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
+import { unset } from 'lodash';
 import { gte } from 'semver';
 
 import { BackendAPI7 } from '../../src';
@@ -83,7 +84,9 @@ conditionalDescribe(semverCondition(gte, '3.5.0'))(
       it('Dump', async () => {
         const result = await dumpConfiguration(backend);
         expect(result.services).toHaveLength(1);
-        expect(result.services![0]).toMatchObject(service);
+        const testService = service;
+        unset(testService, 'upstreams');
+        expect(result.services![0]).toMatchObject(testService);
         expect(result.services![0].upstreams).toHaveLength(2);
 
         const upstreams = sortResult(result.services![0].upstreams!, 'name');

--- a/libs/backend-api7/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-api7/e2e/resources/service-upstream.e2e-spec.ts
@@ -75,10 +75,8 @@ conditionalDescribe(semverCondition(gte, '3.5.0'))(
         syncEvents(
           backend,
           Differ.diff(
-            {
-              services: [service],
-            },
-            {},
+            { services: [service] },
+            await dumpConfiguration(backend),
           ),
         ));
 

--- a/libs/backend-api7/e2e/resources/service-upstream.e2e-spec.ts
+++ b/libs/backend-api7/e2e/resources/service-upstream.e2e-spec.ts
@@ -1,16 +1,14 @@
+import { Differ } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
 import { gte } from 'semver';
 
 import { BackendAPI7 } from '../../src';
 import {
   conditionalDescribe,
-  createEvent,
-  deleteEvent,
   dumpConfiguration,
   semverCondition,
   sortResult,
   syncEvents,
-  updateEvent,
 } from '../support/utils';
 
 conditionalDescribe(semverCondition(gte, '3.5.0'))(
@@ -20,30 +18,15 @@ conditionalDescribe(semverCondition(gte, '3.5.0'))(
 
     beforeAll(() => {
       backend = new BackendAPI7({
-        server: process.env.SERVER,
-        token: process.env.TOKEN,
+        server: process.env.SERVER!,
+        token: process.env.TOKEN!,
         tlsSkipVerify: true,
         gatewayGroup: process.env.GATEWAY_GROUP,
+        cacheKey: 'e2e-service-upstream',
       });
     });
 
     describe('Service multiple upstreams', () => {
-      const serviceName = 'test';
-      const service = {
-        name: serviceName,
-        upstream: {
-          type: 'roundrobin',
-          nodes: [
-            {
-              host: 'httpbin.org',
-              port: 443,
-              weight: 100,
-            },
-          ],
-        },
-        path_prefix: '/test',
-        strip_path_prefix: true,
-      } satisfies ADCSDK.Service;
       const upstreamND1Name = 'nd-upstream1';
       const upstreamND1 = {
         name: upstreamND1Name,
@@ -70,31 +53,42 @@ conditionalDescribe(semverCondition(gte, '3.5.0'))(
           },
         ],
       } satisfies ADCSDK.Upstream;
+      const serviceName = 'test';
+      const service = {
+        name: serviceName,
+        upstream: {
+          type: 'roundrobin',
+          nodes: [
+            {
+              host: 'httpbin.org',
+              port: 443,
+              weight: 100,
+            },
+          ],
+        },
+        path_prefix: '/test',
+        strip_path_prefix: true,
+        upstreams: [upstreamND1, upstreamND2],
+      } satisfies ADCSDK.Service;
 
       it('Create service and upstreams', async () =>
-        syncEvents(backend, [
-          createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
-          createEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND1Name,
-            upstreamND1,
-            serviceName,
+        syncEvents(
+          backend,
+          Differ.diff(
+            {
+              services: [service],
+            },
+            {},
           ),
-          createEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND2Name,
-            upstreamND2,
-            serviceName,
-          ),
-        ]));
+        ));
 
       it('Dump', async () => {
         const result = await dumpConfiguration(backend);
         expect(result.services).toHaveLength(1);
-        expect(result.services[0]).toMatchObject(service);
-        expect(result.services[0].upstreams).toHaveLength(2);
+        expect(result.services![0]).toMatchObject(service);
+        expect(result.services![0].upstreams).toHaveLength(2);
 
-        const upstreams = sortResult(result.services[0].upstreams, 'name');
+        const upstreams = sortResult(result.services![0].upstreams!, 'name');
         expect(upstreams[0]).toMatchObject(upstreamND1);
         expect(upstreams[1]).toMatchObject(upstreamND2);
       });
@@ -104,43 +98,55 @@ conditionalDescribe(semverCondition(gte, '3.5.0'))(
         retry_timeout: 100,
       } as ADCSDK.Upstream;
       it('Update service non-default upstream 1', async () =>
-        syncEvents(backend, [
-          updateEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND1Name,
-            newUpstreamND1,
-            serviceName,
+        syncEvents(
+          backend,
+          Differ.diff(
+            {
+              services: [
+                {
+                  ...service,
+                  upstreams: [newUpstreamND1, upstreamND2],
+                },
+              ],
+            },
+            await dumpConfiguration(backend),
           ),
-        ]));
+        ));
 
       it('Dump (updated non-default upstream 1)', async () => {
         const result = await dumpConfiguration(backend);
         expect(result.services).toHaveLength(1);
 
-        const upstreams = sortResult(result.services[0].upstreams, 'name');
+        const upstreams = sortResult(result.services![0].upstreams!, 'name');
         expect(upstreams[0]).toMatchObject(newUpstreamND1);
       });
 
-      it('Delete non-default upstream 2', async () =>
-        syncEvents(backend, [
-          deleteEvent(
-            ADCSDK.ResourceType.UPSTREAM,
-            upstreamND2Name,
-            serviceName,
+      it('Delete non-default upstream 2', async () => {
+        await syncEvents(
+          backend,
+          Differ.diff(
+            {
+              services: [
+                {
+                  ...service,
+                  upstreams: [newUpstreamND1],
+                },
+              ],
+            },
+            await dumpConfiguration(backend),
           ),
-        ]));
+        );
+      });
 
       it('Dump (non-default upstream 2 should not exist)', async () => {
         const result = await dumpConfiguration(backend);
         expect(result.services).toHaveLength(1);
-        expect(result.services[0].upstreams).toHaveLength(1);
-        expect(result.services[0].upstreams[0]).toMatchObject(newUpstreamND1);
+        expect(result.services![0].upstreams).toHaveLength(1);
+        expect(result.services![0].upstreams![0]).toMatchObject(newUpstreamND1);
       });
 
       it('Delete', async () =>
-        syncEvents(backend, [
-          deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
-        ]));
+        syncEvents(backend, Differ.diff({}, await dumpConfiguration(backend))));
 
       it('Dump again (service should not exist)', async () => {
         const result = await dumpConfiguration(backend);

--- a/libs/backend-api7/package.json
+++ b/libs/backend-api7/package.json
@@ -9,7 +9,8 @@
     }
   },
   "devDependencies": {
-    "@api7/adc-sdk": "workspace:*"
+    "@api7/adc-sdk": "workspace:*",
+    "@api7/adc-differ": "workspace:*"
   },
   "nx": {
     "name": "backend-api7",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "yaml": "^2.4.2",
     "zod": "^4.0.10"
   },
-  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
+  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
   "pnpm": {
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
 
   libs/backend-api7:
     devDependencies:
+      '@api7/adc-differ':
+        specifier: workspace:*
+        version: link:../differ
       '@api7/adc-sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
### Description

Due to inherent differences between API7 and APISIX, such as the association between upstreams and services, and between credentials and consumers, we encounter issues if resource updates and deletions are still handled according to APISIX's rules.

For instance, APISIX requires deleting a service referencing an upstream ID before removing that upstream. In API7, deleting a service automatically removes all associated upstreams. This would cause 404 errors.

This PR introduces a workaround: if an upstream is deleted due to service removal, it no longer triggers sequential deletion. Instead, the server automatically performs cascading deletion. Consumers and credentials follow this same logic.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
