### PR TITLE
fix(apisix-standalone): conflict between upstream nodes and service discovery

### DIFF
--- a/libs/backend-apisix-standalone/src/transformer.ts
+++ b/libs/backend-apisix-standalone/src/transformer.ts
@@ -28,14 +28,18 @@ export const toADC = (input: typing.APISIXStandalone) => {
     pass_host: upstream.pass_host,
     upstream_host: upstream.upstream_host,
 
-    // Empty Lua tables will be encoded as "{}" rather than "[]" by cjson,
-    // so this must be handled separately to prevent unexpected diff results.
-    nodes: !isEmpty(upstream.nodes) ? upstream.nodes : [],
-
     checks: upstream.checks,
     discovery_type: upstream.discovery_type,
     service_name: upstream.service_name,
     discovery_args: upstream.discovery_args,
+
+    ...(upstream.nodes
+      ? {
+          // Empty Lua tables will be encoded as "{}" rather than "[]" by cjson,
+          // so this must be handled separately to prevent unexpected diff results.
+          nodes: !isEmpty(upstream.nodes) ? upstream.nodes : [],
+        }
+      : {}),
   });
   return {
     services:


### PR DESCRIPTION
### Description

When using upstream service discovery in apisix standalone, nodes will conflict with them.

This PR fixes the issue by performing the conversion during the dump only when nodes exist.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
