### PR TITLE
fix(apisix-standalone): upstream populate default empty nodes

### DIFF
--- a/libs/backend-apisix-standalone/src/operator.ts
+++ b/libs/backend-apisix-standalone/src/operator.ts
@@ -439,7 +439,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
       type: res.type,
       hash_on: res.hash_on,
       key: res.key,
-      nodes: res.nodes ?? [], // fix optional to required convert
+      nodes: res.nodes,
       scheme: res.scheme,
       retries: res.retries,
       retry_timeout: res.retry_timeout,

--- a/libs/backend-apisix-standalone/src/typing.ts
+++ b/libs/backend-apisix-standalone/src/typing.ts
@@ -26,7 +26,22 @@ const RouteSchema = z.strictObject({
   ...Metadata,
   uris: z.array(z.string()).min(1),
   hosts: z.array(z.string()).min(1).optional(),
-  methods: z.array(z.string()).optional(),
+  methods: z
+    .array(
+      z.enum([
+        'GET',
+        'POST',
+        'PUT',
+        'DELETE',
+        'PATCH',
+        'HEAD',
+        'OPTIONS',
+        'CONNECT',
+        'TRACE',
+        'PURGE',
+      ]),
+    )
+    .optional(),
   remote_addrs: z.array(z.string()).min(1).optional(),
   vars: z.array(z.unknown()).optional(),
   filter_func: z.string().optional(),
@@ -65,15 +80,17 @@ const upstreamHealthCheckType = z
 const UpstreamSchema = z.strictObject({
   ...ModifiedIndex,
   ...Metadata,
-  nodes: z.array(
-    z.strictObject({
-      host: z.string(),
-      port: Port,
-      weight: z.int(),
-      priority: z.int().optional(),
-      metadata: z.record(z.string(), z.unknown()).optional(),
-    }),
-  ),
+  nodes: z
+    .array(
+      z.strictObject({
+        host: z.string(),
+        port: Port,
+        weight: z.int(),
+        priority: z.int().optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+      }),
+    )
+    .optional(),
   scheme: z
     .union([
       z.literal('http'),


### PR DESCRIPTION
### Description

ADC populates the nodes field in the upstreams of the apisix-standalone backend even when they do not exist in the original configuration, which hinders service discovery configuration. Although I absolutely believe people should not use it.

This PR fixes the issue and adds tests to ensure this behavior no longer occurs, making it more compliant with the original configuration input.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
