### PR TITLE
fix(apisix-standalone): debug log when requests fail

### DIFF
--- a/libs/backend-apisix-standalone/src/operator.ts
+++ b/libs/backend-apisix-standalone/src/operator.ts
@@ -120,6 +120,10 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                 ADCSDK.BackendSyncResult,
                 ObservableInput<ADCSDK.BackendSyncResult>
               >((error: Error | AxiosError) => {
+                // Log the error response when error
+                if (axios.isAxiosError(error) && error.response)
+                  logger(this.debugLogEvent(error.response));
+
                 if (opts.exitOnFailure) {
                   if (axios.isAxiosError(error) && error.response)
                     return throwError(
@@ -144,9 +148,11 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
                   server,
                 } satisfies ADCSDK.BackendSyncResult);
               }),
-              tap(() => {
-                configCache.set(this.opts.cacheKey, toADC(newConfig));
-                rawConfigCache.set(this.opts.cacheKey, newConfig);
+              tap((res) => {
+                if (res.success) {
+                  configCache.set(this.opts.cacheKey, toADC(newConfig));
+                  rawConfigCache.set(this.opts.cacheKey, newConfig);
+                }
                 logger(taskStateEvent('TASK_DONE'));
               }),
             ),


### PR DESCRIPTION
### Description

Since Axios will directly throw errors, when a request fails (e.g., 400 Bad Request), the tap will not trigger and instead directly enter the catchError. This prevents request and response body information used for debugging from being logged.

The underlying reason is that rxjs tap does not subscribe to rxjs error. Therefore, once the stream data source directly throws an error, it will enter the first error subscriber, which is the catchError operator.

This PR ensures that debug information is printed in catchError whenever possible, even when requests fail. This applies unless the error itself is not an Axios error and the original response information cannot be obtained.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
