### PR TITLE
fix(api7): use exact search to determine gateway group

### DIFF
--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -185,6 +185,7 @@ export class BackendAPI7 implements ADCSDK.Backend {
       {
         params: {
           search: this.gatewayGroupName,
+          name: this.gatewayGroupName,
         },
       },
     );


### PR DESCRIPTION
### Description

Currently, gateway group id uses fuzzy search on the `name`, which may select the wrong gateway group when prefixes are the same.

This PR addresses this issue. When users employ API7 versions supporting exact search, the ADC will perform an exact match search for gateway groups to verify the ID. For versions lacking exact search capability, it automatically falls back to the current implementation, continuing to use fuzzy search to determine the gateway group.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
