### PR TITLE
fix(release): build binary using node.js 22.17.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,9 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       # Build and test ADC CLI
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "lts/*"
+          node-version: "22.17.0"
       - uses: pnpm/action-setup@v4
       - name: Build ADC
         env:
@@ -62,11 +62,11 @@ jobs:
       # Build and test ADC CLI
       - uses: actions/setup-node@v4
         with:
-          node-version: "lts/*"
+          node-version: "22.17.0"
       - uses: pnpm/action-setup@v2
       - name: Build ADC
         env:
-          NODE_VERSION: 22.20.0
+          NODE_VERSION: 22.17.0
         run: |
           pnpm install
           NODE_ENV=production npx nx build cli


### PR DESCRIPTION
### Description

I've noticed that the SEA module in `Node.js 22.20.0` generates corrupted blob files. Subsequently, regardless of which Node.js version this file is inlined into (I've tested `20.15.0`, `22.17.0`, `22.18.0`, and `22.20.0`), it causes crashes.

Conversely, if I generate the blob file using `Node.js 22.17.0`, the error does not occur when inlined into `22.17.0` or any higher version. Therefore, I suspect `22.20.0` introduced some unknown bug that breaks the SEA build functionality.

This PR reverts the build base to `22.17.0` to restore our release workflow.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
