### PR TITLE
fix(backend): add max sockets limitation

### DIFF
--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -32,6 +32,7 @@ export class BackendAPI7 implements ADCSDK.Backend {
     const keepAlive: httpAgentOptions = {
       keepAlive: true,
       keepAliveMsecs: 60000,
+      maxSockets: 256, // per host
     };
     const config: CreateAxiosDefaults = {
       baseURL: `${opts.server}`,

--- a/libs/backend-apisix-standalone/src/index.ts
+++ b/libs/backend-apisix-standalone/src/index.ts
@@ -44,6 +44,7 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
     const keepAlive: httpAgentOptions = {
       keepAlive: true,
       keepAliveMsecs: 60000,
+      maxSockets: 10, // per host
     };
     const config: CreateAxiosDefaults = {
       headers: { 'Content-Type': 'application/json' },

--- a/libs/backend-apisix/src/index.ts
+++ b/libs/backend-apisix/src/index.ts
@@ -26,6 +26,7 @@ export class BackendAPISIX implements ADCSDK.Backend {
     const keepAlive: httpAgentOptions = {
       keepAlive: true,
       keepAliveMsecs: 60000,
+      maxSockets: 256, // per host
     };
     const config: CreateAxiosDefaults = {
       baseURL: `${opts.server}`,


### PR DESCRIPTION
### Description

Add a socket limit per host to ensure connections do not grow indefinitely without being released.

Initial value (cannot be modified via configuration):

- API7: 256
- APISIX: 256
- APISIX (Standalone): 10

If necessary, we will adjust it again in the future.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
