### PR TITLE
test(api7): fix flaky test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -114,7 +114,6 @@ jobs:
         run: npx nx run backend-apisix-standalone:test
   api7:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
       matrix:
@@ -137,7 +136,3 @@ jobs:
       # Run API7 E2E tests
       - name: Run E2E tests
         run: npx nx run backend-api7:test
-
-      - name: Setup tmate session
-        if: failure()
-        uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

I ran multiple tests on the ADC API7 test suite and encountered an intermittent "socket hang up" issue.
After setting the test request agent's `keepAlive` to `false`, the problem was resolved.

I ran each of the four versions individually three times, no issues.
Then I ran all four versions together three times, still no issues.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
