### PR TITLE
feat(sdk): prefer to use upstream.tls.client_cert_id

### DIFF
--- a/libs/sdk/src/core/schema.ts
+++ b/libs/sdk/src/core/schema.ts
@@ -163,10 +163,8 @@ const upstreamSchema = (extend?: ZodRawShape) =>
           verify: z.boolean().optional(),
         })
         .refine(
-          (data) =>
-            (data.client_cert && data.client_key && !data.client_cert_id) ||
-            (data.client_cert_id && !data.client_cert && !data.client_key),
-          'The client_cert and client_key certificate pair or client_cert_id SSL reference ID must be set',
+          (data) => data.client_cert || data.client_key,
+          'Please replace `client_cert` and `client_key` with SSL resources and `client_cert_id`.',
         )
         .optional(),
       keepalive_pool: z


### PR DESCRIPTION
### Description

We now request that you prioritise using `upstream.tls.client_cert_id` over `client_cert` and `client_key` when configuring upstream mTLS certificates.

The reason is that we find it challenging to strike a balance between user experience and security. If we require the Admin API to return the raw private key when reading resources, this could be inadvertently exploited to compromise security. Conversely, if the Admin API returns a symmetric-encrypted ciphertext, we cannot utilise it for diff operations, which would result in the upstream always being perceived as having changed and triggering an update.

Using `upstream.tls.client_cert_id` avoids this issue. You can implement upstream mTLS by referencing an SSL resource with `type = client`, without compromising usability or security. We have properly handled encrypted diffs on SSL resources: the private key portion is excluded from the diff process.

You may configure it as follows:

```yaml
# yaml-language-server: $schema=./schema.json

services:
  - name: test
    routes: [xxx]
    upstream:
      type: roundrobin
      scheme: https
      nodes:
        - host: 1.1.1.1
          port: 443
          weight: 1
      tls:
        client_cert_id: my_upstream_cert

ssls:
  - snis: [placeholder.com]
    id: my_upstream_cert
    type: client
    certificates:
      - certificate: |
          -----BEGIN CERTIFICATE-----
          ...
          -----END CERTIFICATE-----
        key: |
          -----BEGIN PRIVATE KEY-----
          ...
          -----END PRIVATE KEY-----
```

A new lint rule has been introduced which will prevent synchronisation when you configure `client_cert` or `client_key`. You may now force synchronisation by disabling the linter with `--no-lint`. However, this rule may become mandatory in future.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
