### PR TITLE
fix(apisix-standalone): vitest use isolate environment

### DIFF
--- a/libs/backend-apisix-standalone/vitest.config.ts
+++ b/libs/backend-apisix-standalone/vitest.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
       provider: 'v8',
     },
     maxWorkers: 1,
-    isolate: false,
+    isolate: true,
   },
 });


### PR DESCRIPTION
### Description

Tests of apisix-standalone rely on isolation between tests to ensure caches are correctly purged. This fix enables the isolation environment for these E2E tests.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
