### PR TITLE
fix(apisix): transform client TLS certificate pairs when dump upstream

### DIFF
--- a/libs/backend-apisix/src/transformer.ts
+++ b/libs/backend-apisix/src/transformer.ts
@@ -222,8 +222,8 @@ export class ToADC {
       tls: upstream.tls
         ? {
             client_cert_id: upstream.tls.client_cert_id,
-            cert: upstream.tls.client_cert,
-            key: upstream.tls.client_key,
+            client_cert: upstream.tls.client_cert,
+            client_key: upstream.tls.client_key,
             verify: upstream.tls.verify,
           }
         : undefined,

--- a/libs/sdk/src/core/schema.ts
+++ b/libs/sdk/src/core/schema.ts
@@ -163,10 +163,6 @@ const upstreamSchema = (extend?: ZodRawShape) =>
           client_cert_id: z.string().optional(),
           verify: z.boolean().optional(),
         })
-        .refine(
-          (data) => data.client_cert || data.client_key,
-          'Please replace `client_cert` and `client_key` with SSL resources and `client_cert_id`.',
-        )
         .optional(),
       keepalive_pool: z
         .strictObject({


### PR DESCRIPTION
### Description

Correctly convert inline client TLS certificate pairs when dumping upstream from the APISIX backend.

According to the ADC schema, these should be `client_cert` and `client_key`, consistent with the original Admin API. Do not use `cert` and `key`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
