### PR TITLE
feat(server): report apisix-standalone endpoint status

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -255,7 +255,7 @@ const generateOutputForAPISIXStandalone = (
       return {
         server: result.server,
         success: result.success,
-        reason: result.error.message,
+        reason: result?.error?.message,
         requested_at: new Date(
           result.axiosResponse?.headers?.date ?? date,
         ).toISOString(),


### PR DESCRIPTION
### Description

When syncing to the `apisix-standalone` backend on the ADC server mode, report endpoint status information additionally.

BREAK CHANGE:

**_Only for apisix-standalone backend, neither related to apisix nor api7ee_**

- All apisix-standalone endpoint statuses are now reported via the `endpoint_status` field instead of the previously used `success` and `failed` fields.

- `failed` will always be an empty array.

- `success` contains records generated by the diff returns events. However, you should not assume all synchronizations succeeded based on this; the synchronization status is confirmed by the `success_count`, `failed_count`, `status`, and `endpoint_status` values.

- `total_resources` will always be 0.

- `status`, `success_count`, and `failed_count` reflect the synchronization status on the endpoint.

```json
{
  "status": "partial_failure",
  "total_resources": 0,
  "success_count": 3,
  "failed_count": 1,
  "success": [
    {
      "event": {
        "resourceType": "consumer",
        "type": "delete",
        "resourceId": "test-consumer1",
        "resourceName": "test-consumer1"
      },
      "synced_at": "2025-12-29T04:42:59.940Z"
    },
    {
      "event": {
        "resourceType": "consumer",
        "type": "create",
        "resourceId": "test-consumer2",
        "resourceName": "test-consumer2"
      },
      "synced_at": "2025-12-29T04:42:59.940Z"
    }
  ],
  "failed": [],
  "endpoint_status": [
    {
      "server": "http://127.0.0.1:49180",
      "success": false,
      "reason": "connect ECONNREFUSED 127.0.0.1:49180",
      "requested_at": "2025-12-29T04:42:59.940Z"
    },
    {
      "server": "http://127.0.0.1:19180",
      "success": true,
      "requested_at": "2025-12-29T04:42:59.000Z",
      "response": {
        "status": 202,
        "headers": {
          "date": "Mon, 29 Dec 2025 04:42:59 GMT",
          "content-type": "application/json",
          "transfer-encoding": "chunked",
          "connection": "keep-alive",
          "server": "APISIX/3.14.1",
          "access-control-allow-origin": "*",
          "access-control-allow-credentials": "true",
          "access-control-expose-headers": "*",
          "access-control-max-age": "3600",
          "x-last-modified": "1766983379",
          "x-digest": "45b9104ccfc3a51fc7444df450e32f8958db1a64"
        },
        "data": ""
      },
      "request": {
        "url": "http://127.0.0.1:19180/apisix/admin/configs",
        "method": "put",
        "headers": {
          "Accept": "application/json, text/plain, */*",
          "Content-Type": "application/json",
          "X-API-KEY": "*****",
          "x-digest": "45b9104ccfc3a51fc7444df450e32f8958db1a64",
          "User-Agent": "axios/1.13.2",
          "Content-Length": "503",
          "Accept-Encoding": "gzip, compress, deflate, br"
        },
        "data": "{\"protos_conf_version\":0,\"consumer_groups_conf_version\":0,\"plugin_configs_conf_version\":0,\"services_conf_version\":0,\"ssls_conf_version\":0,\"routes_conf_version\":0,\"plugins_conf_version\":0,\"consumers\":[{\"modifiedIndex\":1766983379959,\"username\":\"test-consumer2\",\"plugins\":{\"limit-count\":{\"count\":100,\"time_window\":60}}}],\"stream_routes_conf_version\":0,\"secrets_conf_version\":0,\"upstreams_conf_version\":0,\"plugin_metadata_conf_version\":0,\"consumers_conf_version\":1766983379959,\"global_rules_conf_version\":0}"
      }
    },
    {
      "server": "http://127.0.0.1:29180",
      "success": true,
      "requested_at": "2025-12-29T04:42:59.000Z",
      "response": {
        "status": 202,
        "headers": {
          "date": "Mon, 29 Dec 2025 04:42:59 GMT",
          "content-type": "application/json",
          "transfer-encoding": "chunked",
          "connection": "keep-alive",
          "server": "APISIX/3.14.1",
          "access-control-allow-origin": "*",
          "access-control-allow-credentials": "true",
          "access-control-expose-headers": "*",
          "access-control-max-age": "3600",
          "x-last-modified": "1766983379",
          "x-digest": "45b9104ccfc3a51fc7444df450e32f8958db1a64"
        },
        "data": ""
      },
      "request": {
        "url": "http://127.0.0.1:29180/apisix/admin/configs",
        "method": "put",
        "headers": {
          "Accept": "application/json, text/plain, */*",
          "Content-Type": "application/json",
          "X-API-KEY": "*****",
          "x-digest": "45b9104ccfc3a51fc7444df450e32f8958db1a64",
          "User-Agent": "axios/1.13.2",
          "Content-Length": "503",
          "Accept-Encoding": "gzip, compress, deflate, br"
        },
        "data": "{\"protos_conf_version\":0,\"consumer_groups_conf_version\":0,\"plugin_configs_conf_version\":0,\"services_conf_version\":0,\"ssls_conf_version\":0,\"routes_conf_version\":0,\"plugins_conf_version\":0,\"consumers\":[{\"modifiedIndex\":1766983379959,\"username\":\"test-consumer2\",\"plugins\":{\"limit-count\":{\"count\":100,\"time_window\":60}}}],\"stream_routes_conf_version\":0,\"secrets_conf_version\":0,\"upstreams_conf_version\":0,\"plugin_metadata_conf_version\":0,\"consumers_conf_version\":1766983379959,\"global_rules_conf_version\":0}"
      }
    },
    {
      "server": "http://127.0.0.1:39180",
      "success": true,
      "requested_at": "2025-12-29T04:42:59.000Z",
      "response": {
        "status": 202,
        "headers": {
          "date": "Mon, 29 Dec 2025 04:42:59 GMT",
          "content-type": "application/json",
          "transfer-encoding": "chunked",
          "connection": "keep-alive",
          "server": "APISIX/3.14.1",
          "access-control-allow-origin": "*",
          "access-control-allow-credentials": "true",
          "access-control-expose-headers": "*",
          "access-control-max-age": "3600",
          "x-last-modified": "1766983379",
          "x-digest": "45b9104ccfc3a51fc7444df450e32f8958db1a64"
        },
        "data": ""
      },
      "request": {
        "url": "http://127.0.0.1:39180/apisix/admin/configs",
        "method": "put",
        "headers": {
          "Accept": "application/json, text/plain, */*",
          "Content-Type": "application/json",
          "X-API-KEY": "*****",
          "x-digest": "45b9104ccfc3a51fc7444df450e32f8958db1a64",
          "User-Agent": "axios/1.13.2",
          "Content-Length": "503",
          "Accept-Encoding": "gzip, compress, deflate, br"
        },
        "data": "{\"protos_conf_version\":0,\"consumer_groups_conf_version\":0,\"plugin_configs_conf_version\":0,\"services_conf_version\":0,\"ssls_conf_version\":0,\"routes_conf_version\":0,\"plugins_conf_version\":0,\"consumers\":[{\"modifiedIndex\":1766983379959,\"username\":\"test-consumer2\",\"plugins\":{\"limit-count\":{\"count\":100,\"time_window\":60}}}],\"stream_routes_conf_version\":0,\"secrets_conf_version\":0,\"upstreams_conf_version\":0,\"plugin_metadata_conf_version\":0,\"consumers_conf_version\":1766983379959,\"global_rules_conf_version\":0}"
      }
    }
  ]
}
```

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
