### PR TITLE
fix(server): free socket timeout caused socket hang up

### DIFF
--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -21,7 +21,8 @@ const keepAlive: HttpOptions = {
   keepAlive: true,
   maxSockets: 256, // per host
   maxFreeSockets: 16, // per host free
-  freeSocketTimeout: 60000,
+  freeSocketTimeout:
+    parseInt(process.env.ADC_INGRESS_FREE_SOCKET_TIMEOUT) ?? 50000, // free socket keepalive for 50 seconds, and if the ADC_INGRESS_FREE_SOCKET_TIMEOUT environment variable is provided, it takes precedence.
 };
 const httpAgent = new HttpAgent(keepAlive);
 


### PR DESCRIPTION
### Description

Fixes https://github.com/apache/apisix-ingress-controller/issues/2704

APISIX and its Helm chart both set the nginx client-side keepalive_timeout to 60s, instead of nginx's default value of 75s.
Therefore, if ADC uses the same 60s, we may frequently encounter a socket hang-up error. This is because by the time the downstream (ADC) attempts to reuse the connection, the upstream (APISIX Admin API) has already closed it. This causes the sync to fail.

Regarding nginx keepalive_timeout, this mechanism is at the application level. Node.js, which ADC is based on, silently sends TCP Keep-Alive packets to maintain the TCP connection. These packets are handled by the remote Linux Kernel without triggering any events on the application socket. Therefore, if no actual HTTP requests are sent within a 60s period, nginx will close the connection, which results in the socket hang up error.

This PR sets the maximum idle time for the socket to 50s; if it is not used again within 50s, it will be marked for release. This prevents client errors caused by the server side actively terminating the connection.

Note that while this PR supports overriding this value via an environment variable, you should not rely on it. We may modify or remove these variables at any time without notice. This is an internal matter, and we are under no obligation to guarantee the internal implementation will remain consistent. Please use the officially distributed APISIX Ingress Controller Helm chart. Build it yourself only if you understand what you are doing and the risks involved.

I will initiate another proposal on APISIX to explore setting the default keepalive_timeout to the nginx default value of 75 seconds.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
