### PR TITLE
fix(server): free socket timeout invalid operator

### DIFF
--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -22,7 +22,7 @@ const keepAlive: HttpOptions = {
   maxSockets: 256, // per host
   maxFreeSockets: 16, // per host free
   freeSocketTimeout:
-    parseInt(process.env.ADC_INGRESS_FREE_SOCKET_TIMEOUT) ?? 50000, // free socket keepalive for 50 seconds, and if the ADC_INGRESS_FREE_SOCKET_TIMEOUT environment variable is provided, it takes precedence.
+    parseInt(process.env.ADC_INGRESS_FREE_SOCKET_TIMEOUT) || 50000, // free socket keepalive for 50 seconds, and if the ADC_INGRESS_FREE_SOCKET_TIMEOUT environment variable is provided, it takes precedence.
 };
 const httpAgent = new HttpAgent(keepAlive);
 


### PR DESCRIPTION
### Description

#407 introduced an error: when the environment variable does not exist, it becomes `undefined`. In this case, parseInt returns `NaN`, which is still considered a "number" type. Therefore, the `??` operator does not apply to this scenario, as NaN is neither `undefined` nor `null`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
