### PR TITLE
fix: make upstream optional in backend-api7 typing

### DIFF
--- a/libs/backend-api7/src/typing.ts
+++ b/libs/backend-api7/src/typing.ts
@@ -66,7 +66,7 @@ export interface Service {
   hosts?: Array<string>;
   path_prefix?: string;
   strip_path_prefix?: boolean;
-  upstream: Upstream;
+  upstream?: Upstream;
   plugins?: Plugins;
   version?: string;
   service_version_id?: string;


### PR DESCRIPTION
## Summary

Make the `upstream` field optional in the `Service` interface of `backend-api7` typing.

A service may not always have an upstream — for example when using service discovery or plugin-only services. The transformers (`ToADC.transformService` and `FromADC.transformService`) already guard against `undefined` upstream with conditional checks, so the type definition was out of sync with the runtime behavior.

## Changes

- `libs/backend-api7/src/typing.ts`: Changed `upstream: Upstream` to `upstream?: Upstream`

## Testing

All existing `backend-api7` tests pass (`npx nx test backend-api7` — 8/8 tests passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Service configuration is now more flexible with upstream settings made optional. This reduces required configuration steps and allows services to be created with fewer mandatory fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->