### PR TITLE
test(api7): deploy test components by docker compose

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -123,7 +123,7 @@ jobs:
         run: npx nx run backend-apisix-standalone:test
   api7:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,6 @@
 name: E2E Test
 permissions:
   contents: read
-  packages: read
 on:
   push:
     branches:
@@ -49,18 +48,10 @@ jobs:
           - 3.12.0
           - 3.13.0
           - 3.14.1
-          - dev
+    env:
+      BACKEND_APISIX_VERSION: ${{ matrix.version }}
+      BACKEND_APISIX_IMAGE: ${{ matrix.version }}-debian
     steps:
-      - name: Determine APISIX image tag
-        run: |
-          if [ "${{ matrix.version }}" = "dev" ]; then
-            echo "BACKEND_APISIX_VERSION=999.999.999" >> $GITHUB_ENV
-            echo "BACKEND_APISIX_IMAGE=dev" >> $GITHUB_ENV
-          else
-            echo "BACKEND_APISIX_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
-            echo "BACKEND_APISIX_IMAGE=${{ matrix.version }}-debian" >> $GITHUB_ENV
-          fi
-
       - uses: actions/checkout@v4
 
       # Setup backend environment
@@ -123,11 +114,14 @@ jobs:
         run: npx nx run backend-apisix-standalone:test
   api7:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
-        version: [3.5.5, 3.6.1, 3.7.8, 3.8.22, 3.9.2, dev]
+        version: [3.5.5, 3.6.1, 3.7.8, 3.8.23, 3.9.9, dev]
     steps:
       - name: Determine API7 image and license
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,7 @@
 name: E2E Test
 permissions:
   contents: read
+  packages: read
 on:
   push:
     branches:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -133,12 +133,20 @@ jobs:
             echo "BACKEND_API7_VERSION=999.999.999" >> $GITHUB_ENV
             echo "API7_DASHBOARD_IMAGE=ghcr.io/api7/api7-ee-3-integrated" >> $GITHUB_ENV
             echo "API7_IMAGE_TAG=dev" >> $GITHUB_ENV
-            echo "BACKEND_API7_LICENSE=${{ secrets.BACKEND_API7_DEV_LICENSE }}" >> $GITHUB_ENV
+            {
+              echo "BACKEND_API7_LICENSE<<EOLICENSE"
+              echo "${{ secrets.BACKEND_API7_DEV_LICENSE }}"
+              echo "EOLICENSE"
+            } >> $GITHUB_ENV
           else
             echo "BACKEND_API7_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
             echo "API7_DASHBOARD_IMAGE=api7/api7-ee-3-integrated" >> $GITHUB_ENV
             echo "API7_IMAGE_TAG=v${{ matrix.version }}" >> $GITHUB_ENV
-            echo "BACKEND_API7_LICENSE=${{ secrets.BACKEND_API7_LICENSE }}" >> $GITHUB_ENV
+            {
+              echo "BACKEND_API7_LICENSE<<EOLICENSE"
+              echo "${{ secrets.BACKEND_API7_LICENSE }}"
+              echo "EOLICENSE"
+            } >> $GITHUB_ENV
           fi
 
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,10 +48,18 @@ jobs:
           - 3.12.0
           - 3.13.0
           - 3.14.1
-    env:
-      BACKEND_APISIX_VERSION: ${{ matrix.version }}
-      BACKEND_APISIX_IMAGE: ${{ matrix.version }}-debian
+          - dev
     steps:
+      - name: Determine APISIX image tag
+        run: |
+          if [ "${{ matrix.version }}" = "dev" ]; then
+            echo "BACKEND_APISIX_VERSION=999.999.999" >> $GITHUB_ENV
+            echo "BACKEND_APISIX_IMAGE=dev" >> $GITHUB_ENV
+          else
+            echo "BACKEND_APISIX_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
+            echo "BACKEND_APISIX_IMAGE=${{ matrix.version }}-debian" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
 
       # Setup backend environment
@@ -117,13 +125,31 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
       matrix:
-        version: [3.5.5, 3.6.1, 3.7.8, 3.8.22, 3.9.2]
-    env:
-      BACKEND_API7_VERSION: ${{ matrix.version }}
-      BACKEND_API7_DOWNLOAD_URL: https://run.api7.ai/api7-ee/api7-ee-v${{ matrix.version }}.tar.gz
-      BACKEND_API7_LICENSE: ${{ secrets.BACKEND_API7_LICENSE }}
+        version: [3.5.5, 3.6.1, 3.7.8, 3.8.22, 3.9.2, dev]
     steps:
+      - name: Determine API7 image and license
+        run: |
+          if [ "${{ matrix.version }}" = "dev" ]; then
+            echo "BACKEND_API7_VERSION=999.999.999" >> $GITHUB_ENV
+            echo "API7_DASHBOARD_IMAGE=ghcr.io/api7/api7-ee-3-integrated" >> $GITHUB_ENV
+            echo "API7_IMAGE_TAG=dev" >> $GITHUB_ENV
+            echo "BACKEND_API7_LICENSE=${{ secrets.BACKEND_API7_DEV_LICENSE }}" >> $GITHUB_ENV
+          else
+            echo "BACKEND_API7_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
+            echo "API7_DASHBOARD_IMAGE=api7/api7-ee-3-integrated" >> $GITHUB_ENV
+            echo "API7_IMAGE_TAG=v${{ matrix.version }}" >> $GITHUB_ENV
+            echo "BACKEND_API7_LICENSE=${{ secrets.BACKEND_API7_LICENSE }}" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        if: matrix.version == 'dev'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Build and test ADC CLI
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -125,6 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'test/api7') || github.event_name == 'push'
     strategy:
+      fail-fast: false
       matrix:
         version: [3.5.5, 3.6.1, 3.7.8, 3.8.22, 3.9.2, dev]
     steps:

--- a/libs/backend-api7/e2e/assets/dashboard-conf.yaml
+++ b/libs/backend-api7/e2e/assets/dashboard-conf.yaml
@@ -1,25 +1,11 @@
 server:
   listen:
     disable: true
-    host: "0.0.0.0"
-    port: 7080
   tls:
-    disable: false
     host: "0.0.0.0"
     port: 7443
-  status:
-    disable: false
-    host: "0.0.0.0"
-    port: 7081
-  cron_spec: "@every 1s"
 log:
   level: warn
   output: stderr
-  access_log: stdout
 database:
   dsn: "postgres://api7ee:changeme@postgresql:5432/api7ee"
-  max_open_conns: 30
-session_options_config:
-  same_site: "lax"
-  secure: false
-  max_age: 86400

--- a/libs/backend-api7/e2e/assets/dashboard-conf.yaml
+++ b/libs/backend-api7/e2e/assets/dashboard-conf.yaml
@@ -1,0 +1,25 @@
+server:
+  listen:
+    disable: true
+    host: "0.0.0.0"
+    port: 7080
+  tls:
+    disable: false
+    host: "0.0.0.0"
+    port: 7443
+  status:
+    disable: false
+    host: "0.0.0.0"
+    port: 7081
+  cron_spec: "@every 1s"
+log:
+  level: warn
+  output: stderr
+  access_log: stdout
+database:
+  dsn: "postgres://api7ee:changeme@postgresql:5432/api7ee"
+  max_open_conns: 30
+session_options_config:
+  same_site: "lax"
+  secure: false
+  max_age: 86400

--- a/libs/backend-api7/e2e/assets/docker-compose.yaml
+++ b/libs/backend-api7/e2e/assets/docker-compose.yaml
@@ -1,10 +1,10 @@
 services:
   postgresql:
-    image: postgres:15-alpine
+    image: api7/postgresql:15.4.0-debian-11-r45
     environment:
-      POSTGRES_USER: api7ee
-      POSTGRES_PASSWORD: changeme
-      POSTGRES_DB: api7ee
+      POSTGRESQL_USERNAME: api7ee
+      POSTGRESQL_PASSWORD: changeme
+      POSTGRESQL_DATABASE: api7ee
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "api7ee", "-d", "api7ee"]
       interval: 5s

--- a/libs/backend-api7/e2e/assets/docker-compose.yaml
+++ b/libs/backend-api7/e2e/assets/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgresql:
-    image: bitnami/postgresql:14
+    image: bitnami/postgresql:15.4.0-debian-11-r45
     environment:
       POSTGRESQL_USERNAME: api7ee
       POSTGRESQL_PASSWORD: changeme

--- a/libs/backend-api7/e2e/assets/docker-compose.yaml
+++ b/libs/backend-api7/e2e/assets/docker-compose.yaml
@@ -1,0 +1,29 @@
+services:
+  postgresql:
+    image: bitnami/postgresql:14
+    environment:
+      POSTGRESQL_USERNAME: api7ee
+      POSTGRESQL_PASSWORD: changeme
+      POSTGRESQL_DATABASE: api7ee
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "api7ee", "-d", "api7ee"]
+      interval: 5s
+      retries: 10
+    networks:
+      api7:
+
+  dashboard:
+    image: ${API7_DASHBOARD_IMAGE:-api7/api7-ee-3-integrated}:${API7_IMAGE_TAG:-dev}
+    depends_on:
+      postgresql:
+        condition: service_healthy
+    volumes:
+      - ./dashboard-conf.yaml:/app/conf/config.yaml:ro
+    ports:
+      - "7443:7443"
+    networks:
+      api7:
+
+networks:
+  api7:
+    driver: bridge

--- a/libs/backend-api7/e2e/assets/docker-compose.yaml
+++ b/libs/backend-api7/e2e/assets/docker-compose.yaml
@@ -1,10 +1,10 @@
 services:
   postgresql:
-    image: bitnami/postgresql:15.4.0-debian-11-r45
+    image: postgres:15-alpine
     environment:
-      POSTGRESQL_USERNAME: api7ee
-      POSTGRESQL_PASSWORD: changeme
-      POSTGRESQL_DATABASE: api7ee
+      POSTGRES_USER: api7ee
+      POSTGRES_PASSWORD: changeme
+      POSTGRES_DB: api7ee
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "api7ee", "-d", "api7ee"]
       interval: 5s

--- a/libs/backend-api7/e2e/support/global-setup.ts
+++ b/libs/backend-api7/e2e/support/global-setup.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
-import { spawn, spawnSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve as pathResolve } from 'node:path';
 import { Agent } from 'node:https';
 import * as semver from 'semver';
 
@@ -31,49 +31,58 @@ httpClient.interceptors.request.use(
   (error) => Promise.reject(error),
 );
 
+const assetsDir = pathResolve(__dirname, '../../e2e/assets');
+
+const waitForDashboard = async (
+  maxRetries = 60,
+  intervalMs = 2000,
+): Promise<void> => {
+  console.log('Waiting for Dashboard to be ready...');
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      await httpClient.get('/api/status', { timeout: 2000 });
+      console.log('Dashboard is ready');
+      return;
+    } catch {
+      // Also try login endpoint as a fallback health check
+      try {
+        await httpClient.post(
+          '/api/login',
+          { username: '', password: '' },
+          { timeout: 2000, validateStatus: () => true },
+        );
+        console.log('Dashboard is ready');
+        return;
+      } catch {
+        // not ready yet
+      }
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(
+    `Dashboard not ready after ${maxRetries * intervalMs / 1000}s`,
+  );
+};
+
 const setupAPI7 = async () => {
-  return new Promise<void>((resolve, reject) => {
-    const download = spawnSync(
-      'sh',
-      [
-        '-c',
-        `curl -O ${process.env.BACKEND_API7_DOWNLOAD_URL} && tar xf api7-ee-*.tar.gz`,
-      ],
-      { cwd: `/tmp` },
-    );
+  const pullPolicy =
+    process.env.API7_IMAGE_TAG === 'dev' ? '--pull always' : '';
 
-    console.log('stdout: ' + download.stdout.toString('utf-8'));
-    console.log('stderr: ' + download.stderr.toString('utf-8'));
+  console.log('\nSetup API7 Instance via Docker Compose\n');
+  const result = spawnSync(
+    'sh',
+    ['-c', `docker compose ${pullPolicy} up -d`],
+    {
+      cwd: assetsDir,
+      stdio: 'inherit',
+    },
+  );
 
-    const dockerComposePath = `/tmp/api7-ee/docker-compose.yaml`;
-    const dockerCompose = readFileSync(dockerComposePath, 'utf-8').replaceAll(
-      ': bitnami/',
-      ': bitnamilegacy/',
-    );
-    writeFileSync(dockerComposePath, dockerCompose, 'utf-8');
+  if (result.status !== 0)
+    throw new Error(`docker compose up failed with code ${result.status}`);
 
-    const setup = spawn('sh', ['-c', `cd api7-ee && bash run.sh start`], {
-      cwd: `/tmp`,
-    });
-
-    console.log('\nSetup API7 Instance\n');
-
-    setup.stdout.on('data', function (data) {
-      console.log('stdout: ' + data.toString());
-    });
-
-    setup.stderr.on('data', function (data) {
-      console.log('stderr: ' + data.toString());
-    });
-
-    setup.on('exit', function (code) {
-      if (code)
-        reject(`child process exited with non-zero code: ${code?.toString()}`);
-
-      console.log('Successful deployment');
-      resolve();
-    });
-  });
+  console.log('Docker Compose started');
+  await waitForDashboard();
 };
 
 const initUser = async (
@@ -181,4 +190,14 @@ export default async () => {
   process.env.GATEWAY_GROUP = 'adc';
   process.env.BACKEND_API7_VERSION = '0.0.0'; */
   // ONLY FOR LOCAL TEST //
+
+  // Return teardown function to clean up Docker Compose
+  return async () => {
+    if (process.env['SKIP_API7_SETUP'] === 'true') return;
+    console.log('Tearing down API7 via Docker Compose');
+    spawnSync('sh', ['-c', 'docker compose down -v'], {
+      cwd: assetsDir,
+      stdio: 'inherit',
+    });
+  };
 };

--- a/libs/backend-api7/e2e/support/global-setup.ts
+++ b/libs/backend-api7/e2e/support/global-setup.ts
@@ -64,22 +64,29 @@ const waitForDashboard = async (
   );
 };
 
-const setupAPI7 = async () => {
-  const pullPolicy =
-    process.env.API7_IMAGE_TAG === 'dev' ? '--pull always' : '';
+const runCompose = (...args: string[]) => {
+  const result = spawnSync('docker', ['compose', ...args], {
+    cwd: assetsDir,
+    stdio: 'inherit',
+  });
 
-  console.log('\nSetup API7 Instance via Docker Compose\n');
-  const result = spawnSync(
-    'sh',
-    ['-c', `docker compose ${pullPolicy} up -d`],
-    {
-      cwd: assetsDir,
-      stdio: 'inherit',
-    },
-  );
-
+  if (result.error) throw result.error;
+  if (result.signal)
+    throw new Error(
+      `docker compose ${args.join(' ')} terminated by signal ${result.signal}`,
+    );
   if (result.status !== 0)
-    throw new Error(`docker compose up failed with code ${result.status}`);
+    throw new Error(
+      `docker compose ${args.join(' ')} failed with code ${result.status}`,
+    );
+};
+
+const setupAPI7 = async () => {
+  console.log('\nSetup API7 Instance via Docker Compose\n');
+  if (process.env.API7_IMAGE_TAG === 'dev') {
+    runCompose('pull');
+  }
+  runCompose('up', '-d');
 
   console.log('Docker Compose started');
   await waitForDashboard();
@@ -195,9 +202,10 @@ export default async () => {
   return async () => {
     if (process.env['SKIP_API7_SETUP'] === 'true') return;
     console.log('Tearing down API7 via Docker Compose');
-    spawnSync('sh', ['-c', 'docker compose down -v'], {
-      cwd: assetsDir,
-      stdio: 'inherit',
-    });
+    try {
+      runCompose('down', '-v');
+    } catch (err) {
+      console.error('Teardown failed:', err);
+    }
   };
 };

--- a/libs/backend-api7/e2e/support/global-setup.ts
+++ b/libs/backend-api7/e2e/support/global-setup.ts
@@ -178,7 +178,7 @@ const generateToken = async () => {
   process.env.TOKEN = resp.data.value.token;
 };
 
-export default async () => {
+export async function setup() {
   if (process.env['SKIP_API7_SETUP'] !== 'true') await setupAPI7();
   try {
     await initUser();
@@ -197,15 +197,14 @@ export default async () => {
   process.env.GATEWAY_GROUP = 'adc';
   process.env.BACKEND_API7_VERSION = '0.0.0'; */
   // ONLY FOR LOCAL TEST //
+}
 
-  // Return teardown function to clean up Docker Compose
-  return async () => {
-    if (process.env['SKIP_API7_SETUP'] === 'true') return;
-    console.log('Tearing down API7 via Docker Compose');
-    try {
-      runCompose('down', '-v');
-    } catch (err) {
-      console.error('Teardown failed:', err);
-    }
-  };
-};
+export async function teardown() {
+  if (process.env['SKIP_API7_SETUP'] === 'true') return;
+  console.log('Tearing down API7 via Docker Compose');
+  try {
+    runCompose('down', '-v');
+  } catch (err) {
+    console.error('Teardown failed:', err);
+  }
+}

--- a/libs/backend-api7/e2e/support/global-teardown.ts
+++ b/libs/backend-api7/e2e/support/global-teardown.ts
@@ -1,3 +1,4 @@
+// Teardown is handled by the globalSetup return function in global-setup.ts
 export default async () => {
-  //TODO
+  // no-op
 };

--- a/libs/backend-api7/e2e/support/global-teardown.ts
+++ b/libs/backend-api7/e2e/support/global-teardown.ts
@@ -1,4 +1,0 @@
-// Teardown is handled by the globalSetup return function in global-setup.ts
-export default async () => {
-  // no-op
-};

--- a/libs/backend-api7/e2e/sync-and-dump-2.e2e-spec.ts
+++ b/libs/backend-api7/e2e/sync-and-dump-2.e2e-spec.ts
@@ -86,7 +86,6 @@ describe('Sync and Dump - 2', () => {
               timeout: 1,
               concurrency: 10,
               http_path: '/',
-              https_verify_certificate: true,
               healthy: {
                 interval: 1,
                 http_statuses: [200, 302],


### PR DESCRIPTION
## Summary

Replace the tarball-based API7 E2E test infrastructure with Docker Compose, deploying only Dashboard + PostgreSQL (the components ADC actually tests against). Also adds `dev` version testing for the api7 backend.

## Changes

### Docker Compose for API7 E2E
- **New**: `libs/backend-api7/e2e/assets/docker-compose.yaml` — Dashboard + PostgreSQL services
- **New**: `libs/backend-api7/e2e/assets/dashboard-conf.yaml` — Minimal dashboard config (TLS, log, DSN only)
- **Rewritten**: `global-setup.ts` — Uses `docker compose up/down`, named `setup`/`teardown` exports
- **Deleted**: `global-teardown.ts` — Teardown handled by named export in global-setup.ts

### Dev version testing (api7 only)
- Added `dev` to api7 CI matrix
- API7 dev: uses GHCR images (`ghcr.io/api7/api7-ee-3-integrated:dev`) with `BACKEND_API7_DEV_LICENSE`
- `fail-fast: false` on api7 matrix to prevent healthy jobs from being canceled
- `packages: read` permission at api7 job level for GHCR access

### Version updates
- Updated 3.8.22 → 3.8.23, 3.9.2 → 3.9.9

### Test fix
- Removed `https_verify_certificate` from `sync-and-dump-2` test expectation (dev CP no longer returns this default field)

### Why only Dashboard + PostgreSQL?
ADC E2E tests only interact with the Dashboard Admin API (`/apisix/admin/*` proxied through Dashboard on port 7443). No data plane traffic is ever sent to the gateway. The previous tarball approach deployed DPM, Gateway, and etcd unnecessarily.