### PR TITLE
feat(api7): add server-side configuration validator

### DIFF
--- a/apps/cli/src/command/index.ts
+++ b/apps/cli/src/command/index.ts
@@ -11,6 +11,7 @@ import { IngressSyncCommand } from './ingress-sync.command';
 import { LintCommand } from './lint.command';
 import { PingCommand } from './ping.command';
 import { SyncCommand } from './sync.command';
+import { ValidateCommand } from './validate.command';
 import { configurePluralize } from './utils';
 
 const versionCode = '0.24.3';
@@ -47,8 +48,8 @@ export const setupCommands = (): Command => {
     .addCommand(DiffCommand)
     .addCommand(SyncCommand)
     .addCommand(ConvertCommand)
-    .addCommand(LintCommand);
-  //.addCommand(ValidateCommand)
+    .addCommand(LintCommand)
+    .addCommand(ValidateCommand);
 
   if (process.env.NODE_ENV === 'development') program.addCommand(DevCommand);
 

--- a/apps/cli/src/command/validate.command.ts
+++ b/apps/cli/src/command/validate.command.ts
@@ -1,0 +1,71 @@
+import { Listr } from 'listr2';
+
+import { LintTask, LoadLocalConfigurationTask, ValidateTask } from '../tasks';
+import { InitializeBackendTask } from '../tasks/init_backend';
+import { SignaleRenderer } from '../utils/listr';
+import { TaskContext } from './diff.command';
+import { BackendCommand, NoLintOption } from './helper';
+import { BackendOptions } from './typing';
+
+export type ValidateOptions = BackendOptions & {
+  file: Array<string>;
+  lint: boolean;
+};
+
+export const ValidateCommand = new BackendCommand<ValidateOptions>(
+  'validate',
+  'validate the local configuration against the backend',
+  'Validate the configuration from the local file(s) against the backend without applying any changes.',
+)
+  .option(
+    '-f, --file <file-path>',
+    'file to validate',
+    (filePath, files: Array<string> = []) => files.concat(filePath),
+  )
+  .addOption(NoLintOption)
+  .addExamples([
+    {
+      title: 'Validate configuration from a single file',
+      command: 'adc validate -f adc.yaml',
+    },
+    {
+      title: 'Validate configuration from multiple files',
+      command: 'adc validate -f service-a.yaml -f service-b.yaml',
+    },
+    {
+      title: 'Validate configuration against API7 EE backend',
+      command:
+        'adc validate -f adc.yaml --backend api7ee --gateway-group default',
+    },
+    {
+      title: 'Validate configuration without lint check',
+      command: 'adc validate -f adc.yaml --no-lint',
+    },
+  ])
+  .handle(async (opts) => {
+    const tasks = new Listr<TaskContext, typeof SignaleRenderer>(
+      [
+        InitializeBackendTask(opts.backend, opts),
+        LoadLocalConfigurationTask(
+          opts.file,
+          opts.labelSelector,
+          opts.includeResourceType,
+          opts.excludeResourceType,
+        ),
+        opts.lint ? LintTask() : { task: () => undefined },
+        ValidateTask(),
+      ],
+      {
+        renderer: SignaleRenderer,
+        rendererOptions: { verbose: opts.verbose },
+        ctx: { remote: {}, local: {}, diff: [] },
+      },
+    );
+
+    try {
+      await tasks.run();
+    } catch (err) {
+      if (opts.verbose === 2) console.log(err);
+      process.exit(1);
+    }
+  });

--- a/apps/cli/src/command/validate.command.ts
+++ b/apps/cli/src/command/validate.command.ts
@@ -1,6 +1,11 @@
 import { Listr } from 'listr2';
 
-import { LintTask, LoadLocalConfigurationTask, ValidateTask } from '../tasks';
+import {
+  DiffResourceTask,
+  LintTask,
+  LoadLocalConfigurationTask,
+  ValidateTask,
+} from '../tasks';
 import { InitializeBackendTask } from '../tasks/init_backend';
 import { SignaleRenderer } from '../utils/listr';
 import { TaskContext } from './diff.command';
@@ -53,6 +58,7 @@ export const ValidateCommand = new BackendCommand<ValidateOptions>(
           opts.excludeResourceType,
         ),
         opts.lint ? LintTask() : { task: () => undefined },
+        DiffResourceTask(),
         ValidateTask(),
       ],
       {

--- a/apps/cli/src/tasks/index.ts
+++ b/apps/cli/src/tasks/index.ts
@@ -2,4 +2,5 @@ export * from './load_local';
 export * from './load_remote';
 export * from './diff';
 export * from './lint';
+export * from './validate';
 export * from './experimental';

--- a/apps/cli/src/tasks/validate.ts
+++ b/apps/cli/src/tasks/validate.ts
@@ -29,8 +29,12 @@ export const ValidateTask = (): ListrTask<{
       }
       for (const e of result.errors) {
         const parts: string[] = [e.resource_type];
-        if (e.resource_id) parts.push(`id="${e.resource_id}"`);
-        if (e.index !== undefined) parts.push(`index=${e.index}`);
+        if (e.resource_name) {
+          parts.push(`name="${e.resource_name}"`);
+        } else {
+          if (e.resource_id) parts.push(`id="${e.resource_id}"`);
+          if (e.index !== undefined) parts.push(`index=${e.index}`);
+        }
         lines.push(`  - [${parts.join(', ')}]: ${e.error}`);
       }
       const error = new Error(

--- a/apps/cli/src/tasks/validate.ts
+++ b/apps/cli/src/tasks/validate.ts
@@ -28,8 +28,10 @@ export const ValidateTask = (): ListrTask<{
         lines.push(result.errorMessage);
       }
       for (const e of result.errors) {
-        const id = e.resource_id ? ` "${e.resource_id}"` : '';
-        lines.push(`  - [${e.resource_type}${id}]: ${e.error}`);
+        const parts: string[] = [e.resource_type];
+        if (e.resource_id) parts.push(`id="${e.resource_id}"`);
+        if (e.index !== undefined) parts.push(`index=${e.index}`);
+        lines.push(`  - [${parts.join(', ')}]: ${e.error}`);
       }
       const error = new Error(
         `Configuration validation failed:\n${lines.join('\n')}`,

--- a/apps/cli/src/tasks/validate.ts
+++ b/apps/cli/src/tasks/validate.ts
@@ -1,0 +1,41 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import { ListrTask } from 'listr2';
+
+export const ValidateTask = (): ListrTask<{
+  backend: ADCSDK.Backend;
+  local: ADCSDK.Configuration;
+}> => ({
+  title: 'Validate configuration against backend',
+  task: async (ctx) => {
+    if (!ctx.backend.supportValidate) {
+      throw new Error(
+        'Validate is not supported by the current backend',
+      );
+    }
+
+    const supported = await ctx.backend.supportValidate();
+    if (!supported) {
+      const version = await ctx.backend.version();
+      throw new Error(
+        `Validate is not supported by the current backend version (${version}). Please upgrade to a newer version.`,
+      );
+    }
+
+    const result = await ctx.backend.validate!(ctx.local);
+    if (!result.success) {
+      const lines: string[] = [];
+      if (result.errorMessage) {
+        lines.push(result.errorMessage);
+      }
+      for (const e of result.errors) {
+        const id = e.resource_id ? ` "${e.resource_id}"` : '';
+        lines.push(`  - [${e.resource_type}${id}]: ${e.error}`);
+      }
+      const error = new Error(
+        `Configuration validation failed:\n${lines.join('\n')}`,
+      );
+      error.stack = '';
+      throw error;
+    }
+  },
+});

--- a/apps/cli/src/tasks/validate.ts
+++ b/apps/cli/src/tasks/validate.ts
@@ -1,9 +1,10 @@
 import * as ADCSDK from '@api7/adc-sdk';
 import { ListrTask } from 'listr2';
+import { lastValueFrom } from 'rxjs';
 
 export const ValidateTask = (): ListrTask<{
   backend: ADCSDK.Backend;
-  local: ADCSDK.Configuration;
+  diff: ADCSDK.Event[];
 }> => ({
   title: 'Validate configuration against backend',
   task: async (ctx) => {
@@ -21,7 +22,7 @@ export const ValidateTask = (): ListrTask<{
       );
     }
 
-    const result = await ctx.backend.validate!(ctx.local);
+    const result = await lastValueFrom(ctx.backend.validate!(ctx.diff));
     if (!result.success) {
       const lines: string[] = [];
       if (result.errorMessage) {

--- a/libs/backend-api7/e2e/validate.e2e-spec.ts
+++ b/libs/backend-api7/e2e/validate.e2e-spec.ts
@@ -51,7 +51,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
             routes: [
               {
                 name: 'validate-test-route',
-                paths: ['/validate-test'],
+                uris: ['/validate-test'],
                 methods: ['GET'],
               },
             ],
@@ -93,7 +93,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
             routes: [
               {
                 name: 'validate-bad-plugin-route',
-                paths: ['/bad-plugin'],
+                uris: ['/bad-plugin'],
                 plugins: {
                   'limit-count': {
                     // missing required fields: count, time_window
@@ -124,7 +124,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
               {
                 name: 'validate-bad-route',
                 // paths should be an array of strings, provide number instead
-                paths: [123 as unknown as string],
+                uris: [123 as unknown as string],
               },
             ],
           },
@@ -148,14 +148,14 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
             routes: [
               {
                 name: 'validate-multi-err-route1',
-                paths: ['/multi-err-1'],
+                uris: ['/multi-err-1'],
                 plugins: {
                   'limit-count': {},
                 },
               },
               {
                 name: 'validate-multi-err-route2',
-                paths: ['/multi-err-2'],
+                uris: ['/multi-err-2'],
                 plugins: {
                   'limit-count': {},
                 },
@@ -182,7 +182,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
             routes: [
               {
                 name: 'validate-mixed-route',
-                paths: ['/mixed-test'],
+                uris: ['/mixed-test'],
                 methods: ['GET', 'POST'],
               },
             ],
@@ -221,7 +221,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
             routes: [
               {
                 name: routeName,
-                paths: ['/dryrun-test'],
+                uris: ['/dryrun-test'],
               },
             ],
           },

--- a/libs/backend-api7/e2e/validate.e2e-spec.ts
+++ b/libs/backend-api7/e2e/validate.e2e-spec.ts
@@ -1,0 +1,242 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import { gte } from 'semver';
+import { globalAgent as httpAgent } from 'node:http';
+
+import { BackendAPI7 } from '../src';
+import {
+  conditionalDescribe,
+  generateHTTPSAgent,
+  semverCondition,
+  syncEvents,
+  createEvent,
+  deleteEvent,
+} from './support/utils';
+
+conditionalDescribe(semverCondition(gte, '3.9.10'))(
+  'Validate',
+  () => {
+    let backend: BackendAPI7;
+
+    beforeAll(() => {
+      backend = new BackendAPI7({
+        server: process.env.SERVER!,
+        token: process.env.TOKEN!,
+        tlsSkipVerify: true,
+        gatewayGroup: process.env.GATEWAY_GROUP,
+        cacheKey: 'default',
+        httpAgent,
+        httpsAgent: generateHTTPSAgent(),
+      });
+    });
+
+    it('should report supportValidate as true', async () => {
+      expect(await backend.supportValidate()).toBe(true);
+    });
+
+    it('should succeed with empty configuration', async () => {
+      const result = await backend.validate({});
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should succeed with valid service and route', async () => {
+      const config: ADCSDK.Configuration = {
+        services: [
+          {
+            name: 'validate-test-svc',
+            upstream: {
+              scheme: 'http',
+              nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+            },
+            routes: [
+              {
+                name: 'validate-test-route',
+                paths: ['/validate-test'],
+                methods: ['GET'],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = await backend.validate(config);
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should succeed with valid consumer', async () => {
+      const config: ADCSDK.Configuration = {
+        consumers: [
+          {
+            username: 'validate-test-consumer',
+            plugins: {
+              'key-auth': { key: 'test-key-123' },
+            },
+          },
+        ],
+      };
+
+      const result = await backend.validate(config);
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should fail with invalid plugin configuration', async () => {
+      const config: ADCSDK.Configuration = {
+        services: [
+          {
+            name: 'validate-bad-plugin-svc',
+            upstream: {
+              scheme: 'http',
+              nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+            },
+            routes: [
+              {
+                name: 'validate-bad-plugin-route',
+                paths: ['/bad-plugin'],
+                plugins: {
+                  'limit-count': {
+                    // missing required fields: count, time_window
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = await backend.validate(config);
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0].resource_type).toBe('route');
+    });
+
+    it('should fail with invalid route (bad uri type)', async () => {
+      const config: ADCSDK.Configuration = {
+        services: [
+          {
+            name: 'validate-bad-route-svc',
+            upstream: {
+              scheme: 'http',
+              nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+            },
+            routes: [
+              {
+                name: 'validate-bad-route',
+                // paths should be an array of strings, provide number instead
+                paths: [123 as unknown as string],
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = await backend.validate(config);
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should collect multiple errors', async () => {
+      const config: ADCSDK.Configuration = {
+        services: [
+          {
+            name: 'validate-multi-err-svc',
+            upstream: {
+              scheme: 'http',
+              nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+            },
+            routes: [
+              {
+                name: 'validate-multi-err-route1',
+                paths: ['/multi-err-1'],
+                plugins: {
+                  'limit-count': {},
+                },
+              },
+              {
+                name: 'validate-multi-err-route2',
+                paths: ['/multi-err-2'],
+                plugins: {
+                  'limit-count': {},
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = await backend.validate(config);
+      expect(result.success).toBe(false);
+      expect(result.errors.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should succeed with mixed resource types', async () => {
+      const config: ADCSDK.Configuration = {
+        services: [
+          {
+            name: 'validate-mixed-svc',
+            upstream: {
+              scheme: 'https',
+              nodes: [{ host: 'httpbin.org', port: 443, weight: 100 }],
+            },
+            routes: [
+              {
+                name: 'validate-mixed-route',
+                paths: ['/mixed-test'],
+                methods: ['GET', 'POST'],
+              },
+            ],
+          },
+        ],
+        consumers: [
+          {
+            username: 'validate-mixed-consumer',
+            plugins: {
+              'key-auth': { key: 'mixed-key-456' },
+            },
+          },
+        ],
+        global_rules: {
+          'prometheus': { prefer_name: false },
+        } as ADCSDK.Configuration['global_rules'],
+      };
+
+      const result = await backend.validate(config);
+      expect(result.success).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should be a dry-run (no side effects on server)', async () => {
+      const serviceName = 'validate-dryrun-svc';
+      const routeName = 'validate-dryrun-route';
+
+      const config: ADCSDK.Configuration = {
+        services: [
+          {
+            name: serviceName,
+            upstream: {
+              scheme: 'http',
+              nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+            },
+            routes: [
+              {
+                name: routeName,
+                paths: ['/dryrun-test'],
+              },
+            ],
+          },
+        ],
+      };
+
+      // Validate should succeed
+      const result = await backend.validate(config);
+      expect(result.success).toBe(true);
+
+      // Verify no resources were created by dumping
+      const { lastValueFrom, toArray } = await import('rxjs');
+      const dumped = await lastValueFrom(backend.dump());
+      const found = dumped.services?.find((s) => s.name === serviceName);
+      expect(found).toBeUndefined();
+    });
+  },
+);

--- a/libs/backend-api7/e2e/validate.e2e-spec.ts
+++ b/libs/backend-api7/e2e/validate.e2e-spec.ts
@@ -7,9 +7,6 @@ import {
   conditionalDescribe,
   generateHTTPSAgent,
   semverCondition,
-  syncEvents,
-  createEvent,
-  deleteEvent,
 } from './support/utils';
 
 conditionalDescribe(semverCondition(gte, '3.9.10'))(
@@ -233,7 +230,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
       expect(result.success).toBe(true);
 
       // Verify no resources were created by dumping
-      const { lastValueFrom, toArray } = await import('rxjs');
+      const { lastValueFrom } = await import('rxjs');
       const dumped = await lastValueFrom(backend.dump());
       const found = dumped.services?.find((s) => s.name === serviceName);
       expect(found).toBeUndefined();

--- a/libs/backend-api7/e2e/validate.e2e-spec.ts
+++ b/libs/backend-api7/e2e/validate.e2e-spec.ts
@@ -1,5 +1,7 @@
+import { DifferV3 } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
 import { gte } from 'semver';
+import { lastValueFrom } from 'rxjs';
 import { globalAgent as httpAgent } from 'node:http';
 
 import { BackendAPI7 } from '../src';
@@ -8,6 +10,15 @@ import {
   generateHTTPSAgent,
   semverCondition,
 } from './support/utils';
+
+const configToEvents = (
+  config: ADCSDK.Configuration,
+): Array<ADCSDK.Event> => {
+  return DifferV3.diff(
+    config as ADCSDK.InternalConfiguration,
+    {} as ADCSDK.InternalConfiguration,
+  );
+};
 
 conditionalDescribe(semverCondition(gte, '3.9.10'))(
   'Validate',
@@ -31,7 +42,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
     });
 
     it('should succeed with empty configuration', async () => {
-      const result = await backend.validate({});
+      const result = await lastValueFrom(backend.validate([]));
       expect(result.success).toBe(true);
       expect(result.errors).toEqual([]);
     });
@@ -56,7 +67,9 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
         ],
       };
 
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(true);
       expect(result.errors).toEqual([]);
     });
@@ -73,7 +86,9 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
         ],
       };
 
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(true);
       expect(result.errors).toEqual([]);
     });
@@ -102,7 +117,9 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
         ],
       };
 
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
       expect(result.errors[0].resource_type).toBe('routes');
@@ -128,7 +145,9 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
         ],
       };
 
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
@@ -162,7 +181,9 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
         ],
       };
 
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(false);
       expect(result.errors.length).toBeGreaterThanOrEqual(2);
     });
@@ -198,7 +219,9 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
         } as ADCSDK.Configuration['global_rules'],
       };
 
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(true);
       expect(result.errors).toEqual([]);
     });
@@ -226,11 +249,12 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
       };
 
       // Validate should succeed
-      const result = await backend.validate(config);
+      const result = await lastValueFrom(
+        backend.validate(configToEvents(config)),
+      );
       expect(result.success).toBe(true);
 
       // Verify no resources were created by dumping
-      const { lastValueFrom } = await import('rxjs');
       const dumped = await lastValueFrom(backend.dump());
       const found = dumped.services?.find((s) => s.name === serviceName);
       expect(found).toBeUndefined();

--- a/libs/backend-api7/e2e/validate.e2e-spec.ts
+++ b/libs/backend-api7/e2e/validate.e2e-spec.ts
@@ -105,7 +105,7 @@ conditionalDescribe(semverCondition(gte, '3.9.10'))(
       const result = await backend.validate(config);
       expect(result.success).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
-      expect(result.errors[0].resource_type).toBe('route');
+      expect(result.errors[0].resource_type).toBe('routes');
     });
 
     it('should fail with invalid route (bad uri type)', async () => {

--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -235,14 +235,17 @@ export class BackendAPI7 implements ADCSDK.Backend {
     return semver.gte(version, MINIMUM_VALIDATE_VERSION);
   }
 
-  public async validate(
-    config: ADCSDK.Configuration,
-  ): Promise<ADCSDK.BackendValidateResult> {
-    const gatewayGroupId = await this.getGatewayGroupId();
-    return new Validator({
-      client: this.client,
-      eventSubject: this.subject,
-      gatewayGroupId,
-    }).validate(config);
+  public validate(events: Array<ADCSDK.Event>) {
+    return from(this.getGatewayGroupId()).pipe(
+      switchMap((gatewayGroupId) =>
+        from(
+          new Validator({
+            client: this.client,
+            eventSubject: this.subject,
+            gatewayGroupId,
+          }).validate(events),
+        ),
+      ),
+    );
   }
 }

--- a/libs/backend-api7/src/index.ts
+++ b/libs/backend-api7/src/index.ts
@@ -9,6 +9,9 @@ import { Fetcher } from './fetcher';
 import { Operator } from './operator';
 import { ToADC } from './transformer';
 import * as typing from './typing';
+import { Validator } from './validator';
+
+const MINIMUM_VALIDATE_VERSION = '3.9.10';
 
 export class BackendAPI7 implements ADCSDK.Backend {
   private readonly client: AxiosInstance;
@@ -225,5 +228,21 @@ export class BackendAPI7 implements ADCSDK.Backend {
     return this.subject.subscribe(({ type, event }) => {
       if (eventType === type) cb(event);
     });
+  }
+
+  public async supportValidate(): Promise<boolean> {
+    const version = await this.version();
+    return semver.gte(version, MINIMUM_VALIDATE_VERSION);
+  }
+
+  public async validate(
+    config: ADCSDK.Configuration,
+  ): Promise<ADCSDK.BackendValidateResult> {
+    const gatewayGroupId = await this.getGatewayGroupId();
+    return new Validator({
+      client: this.client,
+      eventSubject: this.subject,
+      gatewayGroupId,
+    }).validate(config);
   }
 }

--- a/libs/backend-api7/src/validator.ts
+++ b/libs/backend-api7/src/validator.ts
@@ -1,0 +1,153 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import axios, { type AxiosInstance } from 'axios';
+import { Subject } from 'rxjs';
+
+import { FromADC } from './transformer';
+import * as typing from './typing';
+
+export interface ValidatorOptions {
+  client: AxiosInstance;
+  eventSubject: Subject<ADCSDK.BackendEvent>;
+  gatewayGroupId?: string;
+}
+
+interface ValidateRequestBody {
+  routes?: Array<typing.Route>;
+  services?: Array<typing.Service>;
+  consumers?: Array<typing.Consumer>;
+  ssls?: Array<typing.SSL>;
+  global_rules?: Array<typing.GlobalRule>;
+  stream_routes?: Array<typing.StreamRoute>;
+  plugin_metadata?: Array<Record<string, unknown>>;
+  consumer_groups?: Array<Record<string, unknown>>;
+}
+
+export class Validator extends ADCSDK.backend.BackendEventSource {
+  private readonly client: AxiosInstance;
+  private readonly fromADC = new FromADC();
+
+  constructor(private readonly opts: ValidatorOptions) {
+    super();
+    this.client = opts.client;
+    this.subject = opts.eventSubject;
+  }
+
+  public async validate(
+    config: ADCSDK.Configuration,
+  ): Promise<ADCSDK.BackendValidateResult> {
+    const body = this.buildRequestBody(config);
+
+    try {
+      const resp = await this.client.post(
+        '/apisix/admin/configs/validate',
+        body,
+        { params: { gateway_group_id: this.opts.gatewayGroupId } },
+      );
+      this.subject.next({
+        type: ADCSDK.BackendEventType.AXIOS_DEBUG,
+        event: { response: resp, description: 'Validate configuration' },
+      });
+      return { success: true, errors: [] };
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        this.subject.next({
+          type: ADCSDK.BackendEventType.AXIOS_DEBUG,
+          event: {
+            response: error.response,
+            description: 'Validate configuration (failed)',
+          },
+        });
+        const data = error.response.data;
+        return {
+          success: false,
+          errorMessage: data?.error_msg,
+          errors: data?.errors ?? [],
+        };
+      }
+      throw error;
+    }
+  }
+
+  private buildRequestBody(config: ADCSDK.Configuration): ValidateRequestBody {
+    const body: ValidateRequestBody = {};
+
+    if (config.services?.length) {
+      const services: Array<typing.Service> = [];
+      const routes: Array<typing.Route> = [];
+      const streamRoutes: Array<typing.StreamRoute> = [];
+
+      for (const service of config.services) {
+        const serviceId =
+          service.id ?? ADCSDK.utils.generateId(service.name);
+        const svc = { ...service, id: serviceId };
+        const transformed = this.fromADC.transformService(svc);
+        services.push(transformed);
+
+        for (const route of service.routes ?? []) {
+          const routeId = route.id ?? ADCSDK.utils.generateId(route.name);
+          const r = { ...route, id: routeId };
+          routes.push(this.fromADC.transformRoute(r, serviceId));
+        }
+
+        for (const streamRoute of service.stream_routes ?? []) {
+          const streamRouteId =
+            streamRoute.id ?? ADCSDK.utils.generateId(streamRoute.name);
+          const sr = { ...streamRoute, id: streamRouteId };
+          streamRoutes.push(
+            this.fromADC.transformStreamRoute(sr, serviceId),
+          );
+        }
+      }
+
+      body.services = services;
+      if (routes.length) body.routes = routes;
+      if (streamRoutes.length) body.stream_routes = streamRoutes;
+    }
+
+    if (config.consumers?.length) {
+      body.consumers = config.consumers.map((c) =>
+        this.fromADC.transformConsumer(c),
+      );
+    }
+
+    if (config.ssls?.length) {
+      body.ssls = config.ssls.map((ssl) => {
+        const sslId = ssl.id ?? ADCSDK.utils.generateId(ssl.snis?.[0] ?? '');
+        return this.fromADC.transformSSL({ ...ssl, id: sslId });
+      });
+    }
+
+    if (config.global_rules && Object.keys(config.global_rules).length) {
+      body.global_rules = this.fromADC.transformGlobalRule(
+        config.global_rules as Record<string, ADCSDK.GlobalRule>,
+      );
+    }
+
+    if (
+      config.plugin_metadata &&
+      Object.keys(config.plugin_metadata).length
+    ) {
+      body.plugin_metadata = Object.entries(config.plugin_metadata).map(
+        ([pluginName, config]) => ({
+          id: pluginName,
+          ...ADCSDK.utils.recursiveOmitUndefined(config),
+        }),
+      );
+    }
+
+    if (config.consumer_groups?.length) {
+      body.consumer_groups = config.consumer_groups.map((cg) => {
+        const id = ADCSDK.utils.generateId(cg.name);
+        return ADCSDK.utils.recursiveOmitUndefined({
+          id,
+          name: cg.name,
+          desc: cg.description,
+          labels: cg.labels,
+          plugins: cg.plugins,
+        }) as unknown as Record<string, unknown>;
+      });
+    }
+
+    return body;
+  }
+}

--- a/libs/backend-api7/src/validator.ts
+++ b/libs/backend-api7/src/validator.ts
@@ -35,7 +35,7 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
   public async validate(
     config: ADCSDK.Configuration,
   ): Promise<ADCSDK.BackendValidateResult> {
-    const body = this.buildRequestBody(config);
+    const { body, nameIndex } = this.buildRequestBody(config);
 
     try {
       const resp = await this.client.post(
@@ -58,23 +58,36 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
           },
         });
         const data = error.response.data;
+        const errors: ADCSDK.BackendValidationError[] = (data?.errors ?? []).map(
+          (e: ADCSDK.BackendValidationError) => {
+            const name = nameIndex[e.resource_type]?.[e.index];
+            return name ? { ...e, resource_name: name } : e;
+          },
+        );
         return {
           success: false,
           errorMessage: data?.error_msg,
-          errors: data?.errors ?? [],
+          errors,
         };
       }
       throw error;
     }
   }
 
-  private buildRequestBody(config: ADCSDK.Configuration): ValidateRequestBody {
+  private buildRequestBody(config: ADCSDK.Configuration): {
+    body: ValidateRequestBody;
+    nameIndex: Record<string, string[]>;
+  } {
     const body: ValidateRequestBody = {};
+    const nameIndex: Record<string, string[]> = {};
 
     if (config.services?.length) {
       const services: Array<typing.Service> = [];
       const routes: Array<typing.Route> = [];
       const streamRoutes: Array<typing.StreamRoute> = [];
+      const serviceNames: string[] = [];
+      const routeNames: string[] = [];
+      const streamRouteNames: string[] = [];
 
       for (const service of config.services) {
         const serviceId =
@@ -82,11 +95,13 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
         const svc = { ...service, id: serviceId };
         const transformed = this.fromADC.transformService(svc);
         services.push(transformed);
+        serviceNames.push(service.name);
 
         for (const route of service.routes ?? []) {
           const routeId = route.id ?? ADCSDK.utils.generateId(route.name);
           const r = { ...route, id: routeId };
           routes.push(this.fromADC.transformRoute(r, serviceId));
+          routeNames.push(route.name);
         }
 
         for (const streamRoute of service.stream_routes ?? []) {
@@ -96,18 +111,27 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
           streamRoutes.push(
             this.fromADC.transformStreamRoute(sr, serviceId),
           );
+          streamRouteNames.push(streamRoute.name);
         }
       }
 
       body.services = services;
-      if (routes.length) body.routes = routes;
-      if (streamRoutes.length) body.stream_routes = streamRoutes;
+      nameIndex.services = serviceNames;
+      if (routes.length) {
+        body.routes = routes;
+        nameIndex.routes = routeNames;
+      }
+      if (streamRoutes.length) {
+        body.stream_routes = streamRoutes;
+        nameIndex.stream_routes = streamRouteNames;
+      }
     }
 
     if (config.consumers?.length) {
       body.consumers = config.consumers.map((c) =>
         this.fromADC.transformConsumer(c),
       );
+      nameIndex.consumers = config.consumers.map((c) => c.username);
     }
 
     if (config.ssls?.length) {
@@ -115,12 +139,14 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
         const sslId = ssl.id ?? ADCSDK.utils.generateId(ssl.snis?.[0] ?? '');
         return this.fromADC.transformSSL({ ...ssl, id: sslId });
       });
+      nameIndex.ssls = config.ssls.map((ssl) => ssl.snis?.[0] ?? '');
     }
 
     if (config.global_rules && Object.keys(config.global_rules).length) {
       body.global_rules = this.fromADC.transformGlobalRule(
         config.global_rules as Record<string, ADCSDK.GlobalRule>,
       );
+      nameIndex.global_rules = Object.keys(config.global_rules);
     }
 
     if (
@@ -133,6 +159,7 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
           ...ADCSDK.utils.recursiveOmitUndefined(config),
         }),
       );
+      nameIndex.plugin_metadata = Object.keys(config.plugin_metadata);
     }
 
     if (config.consumer_groups?.length) {
@@ -146,8 +173,9 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
           plugins: cg.plugins,
         }) as unknown as Record<string, unknown>;
       });
+      nameIndex.consumer_groups = config.consumer_groups.map((cg) => cg.name);
     }
 
-    return body;
+    return { body, nameIndex };
   }
 }

--- a/libs/backend-api7/src/validator.ts
+++ b/libs/backend-api7/src/validator.ts
@@ -33,9 +33,9 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
   }
 
   public async validate(
-    config: ADCSDK.Configuration,
+    events: Array<ADCSDK.Event>,
   ): Promise<ADCSDK.BackendValidateResult> {
-    const { body, nameIndex } = this.buildRequestBody(config);
+    const { body, nameIndex } = this.buildRequestBody(events);
 
     try {
       const resp = await this.client.post(
@@ -74,106 +74,161 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
     }
   }
 
-  private buildRequestBody(config: ADCSDK.Configuration): {
+  private flattenEvents(events: Array<ADCSDK.Event>): Array<ADCSDK.Event> {
+    const flat: Array<ADCSDK.Event> = [];
+    for (const event of events) {
+      if (event.type !== ADCSDK.EventType.ONLY_SUB_EVENTS) {
+        flat.push(event);
+      }
+      if (event.subEvents?.length) {
+        flat.push(...this.flattenEvents(event.subEvents));
+      }
+    }
+    return flat;
+  }
+
+  private buildRequestBody(events: Array<ADCSDK.Event>): {
     body: ValidateRequestBody;
     nameIndex: Record<string, string[]>;
   } {
     const body: ValidateRequestBody = {};
     const nameIndex: Record<string, string[]> = {};
 
-    if (config.services?.length) {
-      const services: Array<typing.Service> = [];
-      const routes: Array<typing.Route> = [];
-      const streamRoutes: Array<typing.StreamRoute> = [];
-      const serviceNames: string[] = [];
-      const routeNames: string[] = [];
-      const streamRouteNames: string[] = [];
+    const flat = this.flattenEvents(events).filter(
+      (e) =>
+        e.type === ADCSDK.EventType.CREATE ||
+        e.type === ADCSDK.EventType.UPDATE,
+    );
 
-      for (const service of config.services) {
-        const serviceId =
-          service.id ?? ADCSDK.utils.generateId(service.name);
-        const svc = { ...service, id: serviceId };
-        const transformed = this.fromADC.transformService(svc);
-        services.push(transformed);
-        serviceNames.push(service.name);
+    const services: Array<typing.Service> = [];
+    const serviceNames: string[] = [];
+    const routes: Array<typing.Route> = [];
+    const routeNames: string[] = [];
+    const streamRoutes: Array<typing.StreamRoute> = [];
+    const streamRouteNames: string[] = [];
+    const consumers: Array<typing.Consumer> = [];
+    const consumerNames: string[] = [];
+    const ssls: Array<typing.SSL> = [];
+    const sslNames: string[] = [];
+    const globalRules: Array<typing.GlobalRule> = [];
+    const globalRuleNames: string[] = [];
+    const pluginMetadata: Array<Record<string, unknown>> = [];
+    const pluginMetadataNames: string[] = [];
+    const consumerGroups: Array<Record<string, unknown>> = [];
+    const consumerGroupNames: string[] = [];
 
-        for (const route of service.routes ?? []) {
-          const routeId = route.id ?? ADCSDK.utils.generateId(route.name);
-          const r = { ...route, id: routeId };
-          routes.push(this.fromADC.transformRoute(r, serviceId));
-          routeNames.push(route.name);
-        }
-
-        for (const streamRoute of service.stream_routes ?? []) {
-          const streamRouteId =
-            streamRoute.id ?? ADCSDK.utils.generateId(streamRoute.name);
-          const sr = { ...streamRoute, id: streamRouteId };
-          streamRoutes.push(
-            this.fromADC.transformStreamRoute(sr, serviceId),
+    for (const event of flat) {
+      switch (event.resourceType) {
+        case ADCSDK.ResourceType.SERVICE: {
+          (event.newValue as ADCSDK.Service).id = event.resourceId;
+          services.push(
+            this.fromADC.transformService(event.newValue as ADCSDK.Service),
           );
-          streamRouteNames.push(streamRoute.name);
+          serviceNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.ROUTE: {
+          (event.newValue as ADCSDK.Route).id = event.resourceId;
+          routes.push(
+            this.fromADC.transformRoute(
+              event.newValue as ADCSDK.Route,
+              event.parentId!,
+            ),
+          );
+          routeNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.STREAM_ROUTE: {
+          (event.newValue as ADCSDK.StreamRoute).id = event.resourceId;
+          streamRoutes.push(
+            this.fromADC.transformStreamRoute(
+              event.newValue as ADCSDK.StreamRoute,
+              event.parentId!,
+            ),
+          );
+          streamRouteNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.CONSUMER: {
+          consumers.push(
+            this.fromADC.transformConsumer(event.newValue as ADCSDK.Consumer),
+          );
+          consumerNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.SSL: {
+          (event.newValue as ADCSDK.SSL).id = event.resourceId;
+          ssls.push(
+            this.fromADC.transformSSL(event.newValue as ADCSDK.SSL),
+          );
+          sslNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.GLOBAL_RULE: {
+          globalRules.push({
+            plugins: { [event.resourceId]: event.newValue },
+          } as unknown as typing.GlobalRule);
+          globalRuleNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.PLUGIN_METADATA: {
+          pluginMetadata.push({
+            id: event.resourceId,
+            ...ADCSDK.utils.recursiveOmitUndefined(
+              event.newValue as Record<string, unknown>,
+            ),
+          });
+          pluginMetadataNames.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.CONSUMER_GROUP: {
+          const cg = event.newValue as ADCSDK.ConsumerGroup;
+          consumerGroups.push(
+            ADCSDK.utils.recursiveOmitUndefined({
+              id: event.resourceId,
+              name: cg.name,
+              desc: cg.description,
+              labels: cg.labels,
+              plugins: cg.plugins,
+            }) as unknown as Record<string, unknown>,
+          );
+          consumerGroupNames.push(event.resourceName);
+          break;
         }
       }
+    }
 
+    if (services.length) {
       body.services = services;
       nameIndex.services = serviceNames;
-      if (routes.length) {
-        body.routes = routes;
-        nameIndex.routes = routeNames;
-      }
-      if (streamRoutes.length) {
-        body.stream_routes = streamRoutes;
-        nameIndex.stream_routes = streamRouteNames;
-      }
     }
-
-    if (config.consumers?.length) {
-      body.consumers = config.consumers.map((c) =>
-        this.fromADC.transformConsumer(c),
-      );
-      nameIndex.consumers = config.consumers.map((c) => c.username);
+    if (routes.length) {
+      body.routes = routes;
+      nameIndex.routes = routeNames;
     }
-
-    if (config.ssls?.length) {
-      body.ssls = config.ssls.map((ssl) => {
-        const sslId = ssl.id ?? ADCSDK.utils.generateId(ssl.snis?.[0] ?? '');
-        return this.fromADC.transformSSL({ ...ssl, id: sslId });
-      });
-      nameIndex.ssls = config.ssls.map((ssl) => ssl.snis?.[0] ?? '');
+    if (streamRoutes.length) {
+      body.stream_routes = streamRoutes;
+      nameIndex.stream_routes = streamRouteNames;
     }
-
-    if (config.global_rules && Object.keys(config.global_rules).length) {
-      body.global_rules = this.fromADC.transformGlobalRule(
-        config.global_rules as Record<string, ADCSDK.GlobalRule>,
-      );
-      nameIndex.global_rules = Object.keys(config.global_rules);
+    if (consumers.length) {
+      body.consumers = consumers;
+      nameIndex.consumers = consumerNames;
     }
-
-    if (
-      config.plugin_metadata &&
-      Object.keys(config.plugin_metadata).length
-    ) {
-      body.plugin_metadata = Object.entries(config.plugin_metadata).map(
-        ([pluginName, config]) => ({
-          id: pluginName,
-          ...ADCSDK.utils.recursiveOmitUndefined(config),
-        }),
-      );
-      nameIndex.plugin_metadata = Object.keys(config.plugin_metadata);
+    if (ssls.length) {
+      body.ssls = ssls;
+      nameIndex.ssls = sslNames;
     }
-
-    if (config.consumer_groups?.length) {
-      body.consumer_groups = config.consumer_groups.map((cg) => {
-        const id = ADCSDK.utils.generateId(cg.name);
-        return ADCSDK.utils.recursiveOmitUndefined({
-          id,
-          name: cg.name,
-          desc: cg.description,
-          labels: cg.labels,
-          plugins: cg.plugins,
-        }) as unknown as Record<string, unknown>;
-      });
-      nameIndex.consumer_groups = config.consumer_groups.map((cg) => cg.name);
+    if (globalRules.length) {
+      body.global_rules = globalRules;
+      nameIndex.global_rules = globalRuleNames;
+    }
+    if (pluginMetadata.length) {
+      body.plugin_metadata = pluginMetadata;
+      nameIndex.plugin_metadata = pluginMetadataNames;
+    }
+    if (consumerGroups.length) {
+      body.consumer_groups = consumerGroups;
+      nameIndex.consumer_groups = consumerGroupNames;
     }
 
     return { body, nameIndex };

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -70,6 +70,7 @@ export interface BackendSyncResult {
 export interface BackendValidationError {
   resource_type: string;
   resource_id?: string;
+  resource_name?: string;
   index: number;
   error: string;
 }

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -67,6 +67,19 @@ export interface BackendSyncResult {
   server?: string;
 }
 
+export interface BackendValidationError {
+  resource_type: string;
+  resource_id?: string;
+  index: number;
+  error: string;
+}
+
+export interface BackendValidateResult {
+  success: boolean;
+  errorMessage?: string;
+  errors: BackendValidationError[];
+}
+
 export interface BackendMetadata {
   logScope: string[];
 }
@@ -84,6 +97,9 @@ export interface Backend {
     opts?: BackendSyncOptions,
   ) => Observable<BackendSyncResult>;
 
+  validate?: (
+    config: ADCSDK.Configuration,
+  ) => Promise<BackendValidateResult>;
   supportValidate?: () => Promise<boolean>;
   supportStreamRoute?: () => Promise<boolean>;
 

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -99,8 +99,8 @@ export interface Backend {
   ) => Observable<BackendSyncResult>;
 
   validate?: (
-    config: ADCSDK.Configuration,
-  ) => Promise<BackendValidateResult>;
+    events: Array<ADCSDK.Event>,
+  ) => Observable<BackendValidateResult>;
   supportValidate?: () => Promise<boolean>;
   supportStreamRoute?: () => Promise<boolean>;
 


### PR DESCRIPTION
## Summary

Add a `validate` subcommand that validates local ADC configuration against the server-side `/apisix/admin/configs/validate` API (dry-run, no side effects).

## Changes

### SDK (`libs/sdk/`)
- Add `BackendValidationError`, `BackendValidateResult` interfaces
- Add optional `validate?(events: Array<ADCSDK.Event>) => Observable<BackendValidateResult>` and `supportValidate?()` to `Backend` interface

### Backend API7 (`libs/backend-api7/`)
- Add `Validator` class that:
  - Flattens events (including subEvents) and groups by resource type
  - Transforms ADC resources to backend format using `FromADC` transformers (same as `Operator`)
  - Builds name index for mapping server error indices back to human-readable resource names
  - POSTs to `/apisix/admin/configs/validate` with `gateway_group_id`
- Add `supportValidate()` with version gating (`>= 3.9.10`)
- Add `validate()` returning `Observable<BackendValidateResult>`

### CLI (`apps/cli/`)
- Add `ValidateTask` that checks backend support, subscribes to validate observable, and formats errors with resource name/id/index
- Add `ValidateCommand` with pipeline: InitBackend → LoadLocal → Lint → DiffResource (empty remote) → Validate
- Register in command index

### E2E Tests (`libs/backend-api7/e2e/`)
- 9 test cases: supportValidate check, empty config, valid service+route, valid consumer, invalid plugin, invalid route, multiple errors, mixed resources, dry-run verification
- Version-gated with `conditionalDescribe(semverCondition(gte, '3.9.10'))`
- Tests use `DifferV3.diff(config, {})` to generate events from config, matching the CLI pipeline

## Usage

```bash
# Validate a single file
adc validate -f adc.yaml --backend api7ee --gateway-group default

# Validate multiple files
adc validate -f service-a.yaml -f service-b.yaml --backend api7ee

# Skip lint check
adc validate -f adc.yaml --backend api7ee --no-lint
```