### PR TITLE
feat(apisix): add server-side configuration validator

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,10 +48,20 @@ jobs:
           - 3.12.0
           - 3.13.0
           - 3.14.1
-    env:
-      BACKEND_APISIX_VERSION: ${{ matrix.version }}
-      BACKEND_APISIX_IMAGE: ${{ matrix.version }}-debian
+          - 3.15.0
+          - 3.16.0
+          - dev
     steps:
+      - name: Determine APISIX image tag
+        run: |
+          if [ "${{ matrix.version }}" = "dev" ]; then
+            echo "BACKEND_APISIX_VERSION=999.999.999" >> $GITHUB_ENV
+            echo "BACKEND_APISIX_IMAGE=dev" >> $GITHUB_ENV
+          else
+            echo "BACKEND_APISIX_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
+            echo "BACKEND_APISIX_IMAGE=${{ matrix.version }}-debian" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
 
       # Setup backend environment
@@ -80,6 +90,8 @@ jobs:
         version:
           - 3.13.0
           - 3.14.1
+          - 3.15.0
+          - 3.16.0
           - dev
     steps:
       - name: Determine APISIX image tag

--- a/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { DifferV3 } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
 import { lastValueFrom } from 'rxjs';
+import { gte } from 'semver';
 
 import { BackendAPISIXStandalone } from '../src';
 import {
@@ -8,6 +9,7 @@ import {
   server1,
   token1,
 } from './support/constants';
+import { conditionalDescribe, semverCondition } from './support/utils';
 
 const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   return DifferV3.diff(
@@ -16,7 +18,7 @@ const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   );
 };
 
-describe('Validate', () => {
+conditionalDescribe(semverCondition(gte, '3.15.0'))('Validate', () => {
   let backend: BackendAPISIXStandalone;
 
   beforeAll(() => {

--- a/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
@@ -18,7 +18,7 @@ const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   );
 };
 
-conditionalDescribe(semverCondition(gte, '3.17.0'))('Validate', () => {
+conditionalDescribe(semverCondition(gte, '3.16.0'))('Validate', () => {
   let backend: BackendAPISIXStandalone;
 
   beforeAll(() => {

--- a/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
@@ -18,7 +18,7 @@ const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   );
 };
 
-conditionalDescribe(semverCondition(gte, '3.15.0'))('Validate', () => {
+conditionalDescribe(semverCondition(gte, '3.17.0'))('Validate', () => {
   let backend: BackendAPISIXStandalone;
 
   beforeAll(() => {

--- a/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/validate.e2e-spec.ts
@@ -1,0 +1,214 @@
+import { DifferV3 } from '@api7/adc-differ';
+import * as ADCSDK from '@api7/adc-sdk';
+import { lastValueFrom } from 'rxjs';
+
+import { BackendAPISIXStandalone } from '../src';
+import {
+  defaultBackendOptions,
+  server1,
+  token1,
+} from './support/constants';
+
+const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
+  return DifferV3.diff(
+    config as ADCSDK.InternalConfiguration,
+    {} as ADCSDK.InternalConfiguration,
+  );
+};
+
+describe('Validate', () => {
+  let backend: BackendAPISIXStandalone;
+
+  beforeAll(() => {
+    backend = new BackendAPISIXStandalone({
+      server: server1,
+      token: token1,
+      cacheKey: 'validate-test',
+      ...defaultBackendOptions,
+    });
+  });
+
+  it('should succeed with empty configuration', async () => {
+    const result = await lastValueFrom(backend.validate([]));
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should succeed with valid service and route', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-test-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-test-route',
+              uris: ['/validate-test'],
+              methods: ['GET'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should succeed with valid consumer', async () => {
+    const config: ADCSDK.Configuration = {
+      consumers: [
+        {
+          username: 'validate-test-consumer',
+          plugins: {
+            'key-auth': { key: 'test-key-123' },
+          },
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should fail with invalid plugin configuration', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-bad-plugin-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-bad-plugin-route',
+              uris: ['/bad-plugin'],
+              plugins: {
+                'limit-count': {
+                  // missing required fields: count, time_window
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].resource_type).toBe('routes');
+  });
+
+  it('should fail with invalid route (bad uri type)', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-bad-route-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-bad-route',
+              uris: [123 as unknown as string],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should collect multiple errors', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-multi-err-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-multi-err-route1',
+              uris: ['/multi-err-1'],
+              plugins: {
+                'limit-count': {},
+              },
+            },
+            {
+              name: 'validate-multi-err-route2',
+              uris: ['/multi-err-2'],
+              plugins: {
+                'limit-count': {},
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should succeed with mixed resource types', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-mixed-svc',
+          upstream: {
+            scheme: 'https',
+            nodes: [{ host: 'httpbin.org', port: 443, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-mixed-route',
+              uris: ['/mixed-test'],
+              methods: ['GET', 'POST'],
+            },
+          ],
+        },
+      ],
+      consumers: [
+        {
+          username: 'validate-mixed-consumer',
+          plugins: {
+            'key-auth': { key: 'mixed-key-456' },
+          },
+        },
+      ],
+      global_rules: {
+        prometheus: { prefer_name: false },
+      } as ADCSDK.Configuration['global_rules'],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/libs/backend-apisix-standalone/package.json
+++ b/libs/backend-apisix-standalone/package.json
@@ -21,6 +21,7 @@
     "vitest": "catalog:"
   },
   "dependencies": {
+    "@api7/adc-backend-apisix": "workspace:*",
     "@api7/adc-sdk": "workspace:*",
     "axios": "catalog:",
     "rxjs": "catalog:",

--- a/libs/backend-apisix-standalone/src/index.ts
+++ b/libs/backend-apisix-standalone/src/index.ts
@@ -1,4 +1,5 @@
 import * as ADCSDK from '@api7/adc-sdk';
+import { Validator } from '@api7/adc-backend-apisix';
 import axios, { type AxiosInstance } from 'axios';
 import { type Observable, Subject, from, map, of, switchMap } from 'rxjs';
 import semver, { SemVer, eq as semverEQ } from 'semver';
@@ -164,6 +165,21 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
     return this.subject.subscribe(({ type, event }) => {
       if (eventType === type) cb(event);
     });
+  }
+
+  public validate(events: Array<ADCSDK.Event>) {
+    const server = this.serverTokenMap.keys().next().value as string;
+    const token = this.serverTokenMap.get(server)!;
+    return from(
+      new Validator({
+        client: this.client,
+        eventSubject: this.subject,
+        requestConfig: {
+          baseURL: server,
+          headers: { 'X-API-KEY': token },
+        },
+      }).validate(events),
+    );
   }
 
   supportStreamRoute?: () => Promise<boolean>;

--- a/libs/backend-apisix/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/validate.e2e-spec.ts
@@ -14,7 +14,7 @@ const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   );
 };
 
-conditionalDescribe(semverCondition(gte, '3.15.0'))('Validate', () => {
+conditionalDescribe(semverCondition(gte, '3.17.0'))('Validate', () => {
   let backend: BackendAPISIX;
 
   beforeAll(() => {

--- a/libs/backend-apisix/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/validate.e2e-spec.ts
@@ -1,9 +1,11 @@
 import { DifferV3 } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
 import { lastValueFrom } from 'rxjs';
+import { gte } from 'semver';
 
 import { BackendAPISIX } from '../src';
 import { defaultBackendOptions } from './support/constants';
+import { conditionalDescribe, semverCondition } from './support/utils';
 
 const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   return DifferV3.diff(
@@ -12,7 +14,7 @@ const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
   );
 };
 
-describe('Validate', () => {
+conditionalDescribe(semverCondition(gte, '3.15.0'))('Validate', () => {
   let backend: BackendAPISIX;
 
   beforeAll(() => {

--- a/libs/backend-apisix/e2e/validate.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/validate.e2e-spec.ts
@@ -1,0 +1,236 @@
+import { DifferV3 } from '@api7/adc-differ';
+import * as ADCSDK from '@api7/adc-sdk';
+import { lastValueFrom } from 'rxjs';
+
+import { BackendAPISIX } from '../src';
+import { defaultBackendOptions } from './support/constants';
+
+const configToEvents = (config: ADCSDK.Configuration): Array<ADCSDK.Event> => {
+  return DifferV3.diff(
+    config as ADCSDK.InternalConfiguration,
+    {} as ADCSDK.InternalConfiguration,
+  );
+};
+
+describe('Validate', () => {
+  let backend: BackendAPISIX;
+
+  beforeAll(() => {
+    backend = new BackendAPISIX(defaultBackendOptions);
+  });
+
+  it('should succeed with empty configuration', async () => {
+    const result = await lastValueFrom(backend.validate([]));
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should succeed with valid service and route', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-test-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-test-route',
+              uris: ['/validate-test'],
+              methods: ['GET'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should succeed with valid consumer', async () => {
+    const config: ADCSDK.Configuration = {
+      consumers: [
+        {
+          username: 'validate-test-consumer',
+          plugins: {
+            'key-auth': { key: 'test-key-123' },
+          },
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should fail with invalid plugin configuration', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-bad-plugin-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-bad-plugin-route',
+              uris: ['/bad-plugin'],
+              plugins: {
+                'limit-count': {
+                  // missing required fields: count, time_window
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0].resource_type).toBe('routes');
+  });
+
+  it('should fail with invalid route (bad uri type)', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-bad-route-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-bad-route',
+              uris: [123 as unknown as string],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('should collect multiple errors', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-multi-err-svc',
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-multi-err-route1',
+              uris: ['/multi-err-1'],
+              plugins: {
+                'limit-count': {},
+              },
+            },
+            {
+              name: 'validate-multi-err-route2',
+              uris: ['/multi-err-2'],
+              plugins: {
+                'limit-count': {},
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should succeed with mixed resource types', async () => {
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: 'validate-mixed-svc',
+          upstream: {
+            scheme: 'https',
+            nodes: [{ host: 'httpbin.org', port: 443, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-mixed-route',
+              uris: ['/mixed-test'],
+              methods: ['GET', 'POST'],
+            },
+          ],
+        },
+      ],
+      consumers: [
+        {
+          username: 'validate-mixed-consumer',
+          plugins: {
+            'key-auth': { key: 'mixed-key-456' },
+          },
+        },
+      ],
+      global_rules: {
+        prometheus: { prefer_name: false },
+      } as ADCSDK.Configuration['global_rules'],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should be a dry-run (no side effects on server)', async () => {
+    const serviceName = 'validate-dryrun-svc';
+
+    const config: ADCSDK.Configuration = {
+      services: [
+        {
+          name: serviceName,
+          upstream: {
+            scheme: 'http',
+            nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+          },
+          routes: [
+            {
+              name: 'validate-dryrun-route',
+              uris: ['/dryrun-test'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = await lastValueFrom(
+      backend.validate(configToEvents(config)),
+    );
+    expect(result.success).toBe(true);
+
+    const dumped = await lastValueFrom(backend.dump());
+    const found = dumped.services?.find((s) => s.name === serviceName);
+    expect(found).toBeUndefined();
+  });
+});

--- a/libs/backend-apisix/src/index.ts
+++ b/libs/backend-apisix/src/index.ts
@@ -5,6 +5,9 @@ import semver, { SemVer } from 'semver';
 
 import { Fetcher } from './fetcher';
 import { Operator } from './operator';
+import { Validator } from './validator';
+
+export { Validator } from './validator';
 
 export class BackendAPISIX implements ADCSDK.Backend {
   private static logScope = ['APISIX'];
@@ -100,6 +103,15 @@ export class BackendAPISIX implements ADCSDK.Backend {
     return this.subject.subscribe(({ type, event }) => {
       if (eventType === type) cb(event);
     });
+  }
+
+  public validate(events: Array<ADCSDK.Event>) {
+    return from(
+      new Validator({
+        client: this.client,
+        eventSubject: this.subject,
+      }).validate(events),
+    );
   }
 
   supportStreamRoute?: () => Promise<boolean>;

--- a/libs/backend-apisix/src/validator.ts
+++ b/libs/backend-apisix/src/validator.ts
@@ -49,6 +49,11 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
       });
       return { success: true, errors: [] };
     } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        throw new Error(
+          'Validate is not supported by the current APISIX version. Please upgrade to a newer version.',
+        );
+      }
       if (axios.isAxiosError(error) && error.response?.status === 400) {
         this.subject.next({
           type: ADCSDK.BackendEventType.AXIOS_DEBUG,

--- a/libs/backend-apisix/src/validator.ts
+++ b/libs/backend-apisix/src/validator.ts
@@ -164,6 +164,7 @@ export class Validator extends ADCSDK.backend.BackendEventSource {
         }
         case ADCSDK.ResourceType.GLOBAL_RULE: {
           body.global_rules.push({
+            id: event.resourceId,
             plugins: { [event.resourceId]: event.newValue },
           } as unknown as typing.GlobalRule);
           nameIndex.global_rules.push(event.resourceName);

--- a/libs/backend-apisix/src/validator.ts
+++ b/libs/backend-apisix/src/validator.ts
@@ -1,0 +1,181 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import axios, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
+import { Subject } from 'rxjs';
+
+import { FromADC } from './transformer';
+import * as typing from './typing';
+
+export interface ValidatorOptions {
+  client: AxiosInstance;
+  eventSubject: Subject<ADCSDK.BackendEvent>;
+  requestConfig?: AxiosRequestConfig;
+}
+
+interface ValidateRequestBody {
+  routes: Array<typing.Route>;
+  services: Array<typing.Service>;
+  consumers: Array<typing.Consumer>;
+  ssls: Array<typing.SSL>;
+  global_rules: Array<typing.GlobalRule>;
+  stream_routes: Array<typing.StreamRoute>;
+  plugin_metadata: Array<Record<string, unknown>>;
+  upstreams: Array<typing.Upstream>;
+}
+
+export class Validator extends ADCSDK.backend.BackendEventSource {
+  private readonly client: AxiosInstance;
+  private readonly fromADC = new FromADC();
+
+  constructor(private readonly opts: ValidatorOptions) {
+    super();
+    this.client = opts.client;
+    this.subject = opts.eventSubject;
+  }
+
+  public async validate(
+    events: Array<ADCSDK.Event>,
+  ): Promise<ADCSDK.BackendValidateResult> {
+    const { body, nameIndex } = this.buildRequestBody(events);
+
+    try {
+      const resp = await this.client.post(
+        '/apisix/admin/configs/validate',
+        body,
+        this.opts.requestConfig,
+      );
+      this.subject.next({
+        type: ADCSDK.BackendEventType.AXIOS_DEBUG,
+        event: { response: resp, description: 'Validate configuration' },
+      });
+      return { success: true, errors: [] };
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 400) {
+        this.subject.next({
+          type: ADCSDK.BackendEventType.AXIOS_DEBUG,
+          event: {
+            response: error.response,
+            description: 'Validate configuration (failed)',
+          },
+        });
+        const data = error.response.data;
+        const errors: ADCSDK.BackendValidationError[] = (
+          data?.errors ?? []
+        ).map((e: ADCSDK.BackendValidationError) => {
+          const name = nameIndex[e.resource_type]?.[e.index];
+          return name ? { ...e, resource_name: name } : e;
+        });
+        return {
+          success: false,
+          errorMessage: data?.error_msg,
+          errors,
+        };
+      }
+      throw error;
+    }
+  }
+
+  private buildRequestBody(events: Array<ADCSDK.Event>): {
+    body: ValidateRequestBody;
+    nameIndex: Record<string, string[]>;
+  } {
+    const body: ValidateRequestBody = {
+      routes: [],
+      services: [],
+      consumers: [],
+      ssls: [],
+      global_rules: [],
+      stream_routes: [],
+      plugin_metadata: [],
+      upstreams: [],
+    };
+    const nameIndex: Record<string, string[]> = {
+      routes: [],
+      services: [],
+      consumers: [],
+      ssls: [],
+      global_rules: [],
+      stream_routes: [],
+      plugin_metadata: [],
+      upstreams: [],
+    };
+
+    const flat = events.filter(
+      (e) =>
+        e.type === ADCSDK.EventType.CREATE ||
+        e.type === ADCSDK.EventType.UPDATE,
+    );
+
+    for (const event of flat) {
+      switch (event.resourceType) {
+        case ADCSDK.ResourceType.SERVICE: {
+          (event.newValue as ADCSDK.Service).id = event.resourceId;
+          const [service, upstream] = this.fromADC.transformService(
+            event.newValue as ADCSDK.Service,
+          );
+          body.services.push(service);
+          nameIndex.services.push(event.resourceName);
+          if (upstream) {
+            body.upstreams.push(upstream);
+            nameIndex.upstreams.push(event.resourceName);
+          }
+          break;
+        }
+        case ADCSDK.ResourceType.ROUTE: {
+          (event.newValue as ADCSDK.Route).id = event.resourceId;
+          body.routes.push(
+            this.fromADC.transformRoute(
+              event.newValue as ADCSDK.Route,
+              event.parentId!,
+            ),
+          );
+          nameIndex.routes.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.STREAM_ROUTE: {
+          (event.newValue as ADCSDK.StreamRoute).id = event.resourceId;
+          body.stream_routes.push(
+            this.fromADC.transformStreamRoute(
+              event.newValue as ADCSDK.StreamRoute,
+              event.parentId!,
+            ),
+          );
+          nameIndex.stream_routes.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.CONSUMER: {
+          body.consumers.push(
+            this.fromADC.transformConsumer(event.newValue as ADCSDK.Consumer),
+          );
+          nameIndex.consumers.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.SSL: {
+          (event.newValue as ADCSDK.SSL).id = event.resourceId;
+          body.ssls.push(
+            this.fromADC.transformSSL(event.newValue as ADCSDK.SSL),
+          );
+          nameIndex.ssls.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.GLOBAL_RULE: {
+          body.global_rules.push({
+            plugins: { [event.resourceId]: event.newValue },
+          } as unknown as typing.GlobalRule);
+          nameIndex.global_rules.push(event.resourceName);
+          break;
+        }
+        case ADCSDK.ResourceType.PLUGIN_METADATA: {
+          body.plugin_metadata.push({
+            id: event.resourceId,
+            ...ADCSDK.utils.recursiveOmitUndefined(
+              event.newValue as Record<string, unknown>,
+            ),
+          });
+          nameIndex.plugin_metadata.push(event.resourceName);
+          break;
+        }
+      }
+    }
+    return { body, nameIndex };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
 
   libs/backend-apisix-standalone:
     dependencies:
+      '@api7/adc-backend-apisix':
+        specifier: workspace:*
+        version: link:../backend-apisix
       '@api7/adc-sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
Add `validate()` support to both APISIX and APISIX Standalone backends, sharing a common `Validator` class in `backend-apisix`.

## Changes

- Create shared `Validator` class in `libs/backend-apisix/src/validator.ts`
  - Transforms ADC events to APISIX validate request body
  - Handles upstreams as separate resources (APISIX extracts them from services)
  - Posts to `/apisix/admin/configs/validate` and processes 200/400 responses
  - Returns user-friendly error when endpoint doesn't exist (404)
- Add `validate()` method to `BackendAPISIX`
- Add `validate()` method to `BackendAPISIXStandalone` (imports `Validator` from backend-apisix)
- Add e2e test suites for both backends (gated behind `semverCondition(gte, '3.17.0')`)
- Update CI matrix: add APISIX 3.15.0, 3.16.0, and dev to both apisix and standalone jobs

## Notes

- The `/apisix/admin/configs/validate` endpoint exists on APISIX master but not in any released version (3.2.2–3.16.0). Tests are version-gated and will auto-enable when 3.17.0 releases.
- The standalone backend reuses the same `Validator` via `@api7/adc-backend-apisix` workspace dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validate API to run configuration validation for APISIX resources; returns detailed per‑resource error reports and preserves dry‑run semantics.

* **Tests**
  * Added comprehensive end‑to‑end tests covering successful validations, multiple failure modes (single/multiple errors, invalid types), mixed resource sets, and dry‑run behavior.

* **Chores**
  * CI matrix expanded to test additional APISIX versions; workspace dependency added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->