### PR TITLE
fix: rename schema field https_verify_cert to https_verify_certificate

### DIFF
--- a/apps/cli/src/linter/specs/upstream.spec.ts
+++ b/apps/cli/src/linter/specs/upstream.spec.ts
@@ -94,6 +94,41 @@ describe('Upstream Linter', () => {
       expect: true,
     },
     {
+      name: 'should accept https_verify_certificate on active health check',
+      input: {
+        services: [
+          {
+            name: 'HealthCheck_HTTPS_VerifyCert',
+            upstream: {
+              nodes: [
+                {
+                  host: '1.1.1.1',
+                  port: 443,
+                  weight: 100,
+                },
+              ],
+              checks: {
+                active: {
+                  type: 'https',
+                  http_path: '/',
+                  https_verify_certificate: true,
+                  healthy: {
+                    interval: 2,
+                    successes: 1,
+                  },
+                  unhealthy: {
+                    interval: 1,
+                    timeouts: 3,
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as ADCSDK.Configuration,
+      expect: true,
+    },
+    {
       name: 'should only allow upstream mtls in client_cert and client_key',
       input: {
         services: [

--- a/libs/backend-apisix-standalone/src/typing.ts
+++ b/libs/backend-apisix-standalone/src/typing.ts
@@ -146,7 +146,7 @@ const UpstreamSchema = z.strictObject({
         host: z.string().min(1).optional(),
         port: z.coerce.number().int().min(1).max(65535).optional(),
         http_path: z.string().default('/').optional(),
-        https_verify_cert: z.boolean().default(true).optional(),
+        https_verify_certificate: z.boolean().default(true).optional(),
         http_request_headers: z.array(z.string()).min(1).optional(),
         healthy: z
           .strictObject({

--- a/libs/sdk/src/core/schema.ts
+++ b/libs/sdk/src/core/schema.ts
@@ -119,7 +119,7 @@ const upstreamSchema = (extend?: ZodRawShape) =>
             host: hostSchema.optional(),
             port: portSchema.optional(),
             http_path: z.string().default('/').optional(),
-            https_verify_cert: z.boolean().default(true).optional(),
+            https_verify_certificate: z.boolean().default(true).optional(),
             http_request_headers: z.array(z.string()).min(1).optional(),
             healthy: z
               .strictObject({

--- a/schema.json
+++ b/schema.json
@@ -124,7 +124,7 @@
                         "default": "/",
                         "type": "string"
                       },
-                      "https_verify_cert": {
+                      "https_verify_certificate": {
                         "default": true,
                         "type": "boolean"
                       },
@@ -556,7 +556,7 @@
                           "default": "/",
                           "type": "string"
                         },
-                        "https_verify_cert": {
+                        "https_verify_certificate": {
                           "default": true,
                           "type": "boolean"
                         },


### PR DESCRIPTION
The active health check schema in `libs/sdk/src/core/schema.ts` and `libs/backend-apisix-standalone/src/typing.ts` defines the field as `https_verify_cert`, but the canonical name everywhere else is `https_verify_certificate`:

- APISIX `apisix/schema_def.lua` and `lua-resty-healthcheck-api7`
- Dashboard API and APISIX Admin API responses

Because the parent schema uses `z.strictObject`, `adc dump` of a service with an HTTPS active health check produces YAML that contains `https_verify_certificate: true`, and the very next `adc sync` / `adc lint` rejects it:

```
Unrecognized key: "https_verify_certificate"
  → at services[0].upstream.checks.active
```

Round-trip dump→sync is broken for any service using HTTPS active health checks. Reported in https://github.com/api7/api7ee-3-control-plane/issues/2629.

The existing e2e fixtures (`libs/backend-api7/e2e/default-value.e2e-spec.ts`, `libs/differ/src/test/usecase.spec.ts`) already use the correct `https_verify_certificate`, but they don't go through the lint stage so the typo wasn't caught.

This PR:
- Renames the field in both schemas to `https_verify_certificate`
- Regenerates `schema.json`
- Adds a regression test in `apps/cli/src/linter/specs/upstream.spec.ts`

Verified locally with `nx test cli` (26 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the HTTPS certificate verification configuration field name in upstream health checks across validation schemas. Users with existing configurations should update their field references accordingly.

* **Tests**
  * Added test coverage for HTTPS active health checks with certificate verification enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->