### PR TITLE
docs(converter-openapi): align README extension table with code

### DIFF
--- a/libs/converter-openapi/README.md
+++ b/libs/converter-openapi/README.md
@@ -112,7 +112,7 @@ servers:
     <tr>
       <td rowspan="3">x-adc-route-defaults</td>
       <td>Root Level</td>
-      <td rowspan="3">It supports setting/overriding parameters in the route at various levels. This field on sub-levels will cause the service to be split.</td>
+      <td rowspan="3">It supports setting/overriding parameters in the route at various levels. Sub-level values override root-level values (operation > path > root); the merged result is applied to each route. This field does not by itself cause the service to be split.</td>
     </tr>
     <tr>
       <td>Path Level</td>

--- a/libs/converter-openapi/README.md
+++ b/libs/converter-openapi/README.md
@@ -35,12 +35,9 @@ A library for implementing the OpenAPI specification and ADC profile conversion.
       <td>Override the name of the generated route</td>
     </tr>
     <tr>
-      <td rowspan="3">x-adc-labels</td>
+      <td rowspan="2">x-adc-labels</td>
       <td>Root Level</td>
-      <td rowspan="3">Add labels field to the specified level. It supports string and string array formats.</td>
-    </tr>
-    <tr>
-      <td>Path Level</td>
+      <td rowspan="2">Add labels field to the specified level. It supports string and string array formats.</td>
     </tr>
     <tr>
       <td>Operation Level</td>
@@ -48,11 +45,10 @@ A library for implementing the OpenAPI specification and ADC profile conversion.
     <tr>
       <td rowspan="3">x-adc-plugins</td>
       <td>Root Level</td>
-      <td>Add plugins field to the specified level. It is an object that contains one or more plugins.</td>
+      <td rowspan="3">Add plugins field to the specified level. It is an object that contains one or more plugins. Plugins set at the path or operation level are attached directly to the routes generated from that path or operation; they do not by themselves cause the service to be split.</td>
     </tr>
     <tr>
       <td>Path Level</td>
-      <td rowspan="2">Plugin objects at the Path level and Operation level will cause the service to be split, i.e. the sub-level containing the plugin will be included in a new service.</td>
     </tr>
     <tr>
       <td>Operation Level</td>


### PR DESCRIPTION
Fixes #446.

Three long-standing inaccuracies in `libs/converter-openapi/README.md`'s supported-extensions table, identified by cross-checking each row against `src/schema.ts`, `src/parser.ts`, `src/index.ts`, `src/extension.ts`, and the fixtures under `test/assets/`.

## 1. `x-adc-labels` was documented at Path level but is not honored there

The Zod schema only defines `x-adc-labels` on the root document and on each operation object — there is no entry for it in the path-item schema:

https://github.com/api7/adc/blob/main/libs/converter-openapi/src/schema.ts#L58-L75

The path-item is a `z.looseObject`, so a path-level `x-adc-labels: {...}` passes validation, but `src/index.ts` never reads `operations[ExtKey.LABELS]` — only `oas[ExtKey.LABELS]` (root) and `operation[ExtKey.LABELS]` (operation) are mapped through:

https://github.com/api7/adc/blob/main/libs/converter-openapi/src/index.ts#L44
https://github.com/api7/adc/blob/main/libs/converter-openapi/src/index.ts#L95

Result: path-level labels are silently dropped at conversion. Dropping the Path row from the table.

## 2. `x-adc-plugins` at Path/Operation was documented as causing a service split, but does not

The actual splitting condition in `parseSeprateService` only fires on `x-adc-service-defaults`, `x-adc-upstream-defaults`, or a sub-level `servers:` entry:

https://github.com/api7/adc/blob/main/libs/converter-openapi/src/parser.ts#L60-L65

Plugins are merged into `route.plugins` directly in `src/index.ts` (lines 82-85, 102) without invoking `parseSeprateService`. The test fixtures `extension-5.yaml` and `extension-6.yaml` both produce a single service in the output despite carrying plugins at root, path, and operation levels. Rewriting the description to match.

## 3. `x-adc-route-defaults` was documented as causing a service split, but does not

Same root cause as #2 — the field is not on the splitting checklist in `parseSeprateService`. It is merged into each route via `structuredClone` spreads in `src/index.ts`:

https://github.com/api7/adc/blob/main/libs/converter-openapi/src/index.ts#L103-L105

The order is root → path → operation, with operation winning. Verified against `test/assets/extension-7.yaml`: the GET-only service split in that fixture is caused by an operation-level `servers:` block, not by `x-adc-route-defaults`; the PUT operation keeps its merged route-defaults on the main service without splitting. Updating the description.

## Note for reviewers

I chose to fix the README rather than the code because the current behavior (no splitting on plugins or route-defaults; no path-level labels) looks intentional and the test suite encodes it. If any of these is actually a wanted feature, this PR can become a starting point for that conversation — happy to take the other route.

## Context

Surfaced while writing downstream documentation in api7/docs#1638. Posting the README fix here so the upstream source of truth stops misleading users.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `x-adc-labels` is supported only at Root and Operation levels (Path level removed).
  * Updated `x-adc-plugins` wording to remove the previous claim that Path/Operation-level plugins trigger service splitting.
  * Revised `x-adc-route-defaults` to clarify it does not by itself cause service splitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->