### PR TITLE
fix(backend-api7): include plugins when dumping stream_route

### DIFF
--- a/libs/backend-api7/e2e/stream-route-plugins.e2e-spec.ts
+++ b/libs/backend-api7/e2e/stream-route-plugins.e2e-spec.ts
@@ -1,0 +1,101 @@
+import * as ADCSDK from '@api7/adc-sdk';
+import { globalAgent as httpAgent } from 'node:http';
+
+import { BackendAPI7 } from '../src';
+import {
+  createEvent,
+  deleteEvent,
+  dumpConfiguration,
+  generateHTTPSAgent,
+  syncEvents,
+  updateEvent,
+} from './support/utils';
+
+describe('Sync and Dump - stream route plugins', () => {
+  let backend: BackendAPI7;
+
+  beforeAll(() => {
+    backend = new BackendAPI7({
+      server: process.env.SERVER!,
+      token: process.env.TOKEN!,
+      tlsSkipVerify: true,
+      gatewayGroup: process.env.GATEWAY_GROUP,
+      cacheKey: 'default',
+      httpAgent,
+      httpsAgent: generateHTTPSAgent(),
+    });
+  });
+
+  // Regression: ToADC.transformStreamRoute used to drop the plugins field, so a
+  // dumped stream route always came back without plugins. The "Dump preserves the
+  // stream route plugins" assertion below fails on the buggy code and passes once
+  // plugins are mapped on the dump path.
+  describe('Stream route plugin round-trip and removal', () => {
+    const serviceName = 'stream-service';
+    const service = {
+      name: serviceName,
+      upstream: {
+        scheme: 'tcp',
+        nodes: [{ host: 'httpbin.org', port: 80, weight: 100 }],
+      },
+    } as ADCSDK.Service;
+
+    const streamRouteName = 'stream-route';
+    const plugins: ADCSDK.Plugins = {
+      'ip-restriction': { whitelist: ['127.0.0.0/24'] },
+    };
+    const streamRoute = {
+      name: streamRouteName,
+      plugins,
+    } as ADCSDK.StreamRoute;
+
+    it('Create stream service and stream route with plugins', async () =>
+      syncEvents(backend, [
+        createEvent(ADCSDK.ResourceType.SERVICE, serviceName, service),
+        createEvent(
+          ADCSDK.ResourceType.STREAM_ROUTE,
+          streamRouteName,
+          streamRoute,
+          serviceName,
+        ),
+      ]));
+
+    it('Dump preserves the stream route plugins', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      const svc = result.services?.find(
+        (item: ADCSDK.Service) => item.name === serviceName,
+      );
+      expect(svc?.stream_routes).toHaveLength(1);
+      expect(svc?.stream_routes?.[0].plugins).toMatchObject(plugins);
+    });
+
+    it('Remove all plugins from the stream route', async () =>
+      syncEvents(backend, [
+        updateEvent(
+          ADCSDK.ResourceType.STREAM_ROUTE,
+          streamRouteName,
+          { ...streamRoute, plugins: {} },
+          serviceName,
+        ),
+      ]));
+
+    it('Dump reflects the plugin removal', async () => {
+      const result = (await dumpConfiguration(backend)) as ADCSDK.Configuration;
+      const svc = result.services?.find(
+        (item: ADCSDK.Service) => item.name === serviceName,
+      );
+      expect(svc?.stream_routes).toHaveLength(1);
+      expect(svc?.stream_routes?.[0].plugins ?? {}).toEqual({});
+    });
+
+    it('Delete', async () =>
+      syncEvents(backend, [
+        deleteEvent(
+          ADCSDK.ResourceType.STREAM_ROUTE,
+          streamRouteName,
+          serviceName,
+        ),
+        deleteEvent(ADCSDK.ResourceType.SERVICE, serviceName),
+      ]));
+  });
+});

--- a/libs/backend-api7/src/transformer.ts
+++ b/libs/backend-api7/src/transformer.ts
@@ -37,6 +37,7 @@ export class ToADC {
       name: route.name,
       description: route.desc,
       labels: ToADC.transformLabels(route.labels),
+      plugins: route.plugins,
       server_addr: route.server_addr,
       server_port: route.server_port,
       remote_addr: route.remote_addr,

--- a/libs/backend-api7/test/transformer.spec.ts
+++ b/libs/backend-api7/test/transformer.spec.ts
@@ -1,0 +1,43 @@
+import * as ADCSDK from '@api7/adc-sdk';
+
+import { FromADC, ToADC } from '../src/transformer';
+import * as typing from '../src/typing';
+
+describe('Transformer', () => {
+  describe('stream route plugins round-trip', () => {
+    const plugins: ADCSDK.Plugins = {
+      'ip-restriction': { blacklist: ['0.0.0.0/0'] },
+    };
+
+    it('FromADC.transformStreamRoute writes plugins', () => {
+      const out = new FromADC().transformStreamRoute(
+        {
+          id: 'sr1',
+          name: 'sr1',
+          description: 'desc',
+          plugins,
+        } as ADCSDK.StreamRoute,
+        'svc1',
+      );
+      expect(out.plugins).toEqual(plugins);
+    });
+
+    // Regression: ToADC.transformStreamRoute used to drop the plugins field, so
+    // dumping a stream route always returned it without plugins. The differ then
+    // could not detect plugin removal (local empty === remote empty), leaving
+    // stale stream-route plugins on the gateway.
+    it('ToADC.transformStreamRoute preserves plugins on dump', () => {
+      const out = new ToADC().transformStreamRoute({
+        id: 'sr1',
+        name: 'sr1',
+        desc: 'desc',
+        service_id: 'svc1',
+        stream_route_id: 'sr1',
+        plugins,
+        server_addr: '1.1.1.1',
+        server_port: 80,
+      } as typing.StreamRoute);
+      expect(out.plugins).toEqual(plugins);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`ToADC.transformStreamRoute` (the dump / read direction) drops the `plugins`
field, while `FromADC.transformStreamRoute` (the write direction) keeps it.
So dumping a stream route from the API7 backend always returns it **without**
plugins.

The differ relies on the dumped remote state to know the current plugins. With
plugins missing from the dump:

- **Adding** plugins is detected (local has them, remote appears empty) ✓
- **Removing** the last plugins is **not** detected (local empty == remote
  empty), so stale stream-route plugins are left on the gateway ✗

## Fix

Map `plugins` in `ToADC.transformStreamRoute`, mirroring `transformRoute` and
the write-direction `FromADC.transformStreamRoute`.

## Verification

Added `libs/backend-api7/test/transformer.spec.ts`. Confirmed by running it both
ways:

- without the fix: `ToADC.transformStreamRoute preserves plugins` **fails**
  (`Received: undefined`)
- with the fix: **passes**

Full `backend-api7` (20) and `differ` (31) unit suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loss of stream route plugins during transformation so plugin configurations are preserved.

* **Tests**
  * Added unit tests to cover stream route plugin round-trips and prevent regressions.
  * Added end-to-end tests validating plugin lifecycle (sync, dump, removal, delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->