### PR TITLE
fix: handle circular OpenAPI schemas during conversion

### DIFF
--- a/libs/converter-openapi/src/index.ts
+++ b/libs/converter-openapi/src/index.ts
@@ -22,6 +22,87 @@ const httpMethods: Array<OpenAPIV3_1.HttpMethods> = [
   'trace',
 ];
 
+type UnknownRecord = Record<string, unknown>;
+
+const copiedExtensionKeys = [
+  ExtKey.NAME,
+  ExtKey.LABELS,
+  ExtKey.PLUGINS,
+  ExtKey.SERVICE_DEFAULTS,
+  ExtKey.UPSTREAM_DEFAULTS,
+  ExtKey.UPSTREAM_NODE_DEFAULTS,
+  ExtKey.ROUTE_DEFAULTS,
+];
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const copyKey = (source: UnknownRecord, target: UnknownRecord, key: string) => {
+  if (source[key] !== undefined) target[key] = source[key];
+};
+
+const copyExtensionKeys = (source: UnknownRecord, target: UnknownRecord) => {
+  copiedExtensionKeys.forEach((key) => copyKey(source, target, key));
+  Object.entries(source)
+    .filter(([key]) => key.startsWith(ExtKey.PLUGIN_PREFIX))
+    .forEach(([key, value]) => {
+      target[key] = value;
+    });
+};
+
+const pruneOperation = (operation: unknown): unknown => {
+  if (!isRecord(operation)) return operation;
+
+  const result: UnknownRecord = {};
+  ['$ref', 'operationId', 'summary', 'description', 'servers'].forEach((key) =>
+    copyKey(operation, result, key),
+  );
+  copyExtensionKeys(operation, result);
+  return result;
+};
+
+const prunePathItem = (pathItem: unknown): unknown => {
+  if (!isRecord(pathItem)) return pathItem;
+
+  const result: UnknownRecord = {};
+  ['$ref', 'servers'].forEach((key) => copyKey(pathItem, result, key));
+  copyExtensionKeys(pathItem, result);
+  httpMethods.forEach((method) => {
+    if (pathItem[method] !== undefined)
+      result[method] = pruneOperation(pathItem[method]);
+  });
+  return result;
+};
+
+const prunePathItems = (pathItems: UnknownRecord): UnknownRecord =>
+  Object.fromEntries(
+    Object.entries(pathItems).map(([path, pathItem]) => [
+      path,
+      prunePathItem(pathItem),
+    ]),
+  );
+
+const createConversionDocument = (
+  specification: unknown,
+): OpenAPIV3_1.Document => {
+  const source = specification as unknown as UnknownRecord;
+  const result: UnknownRecord = {};
+
+  ['openapi', 'info', 'servers'].forEach((key) => copyKey(source, result, key));
+  copyExtensionKeys(source, result);
+
+  if (isRecord(source.paths)) result.paths = prunePathItems(source.paths);
+
+  const components = source.components;
+  if (isRecord(components) && isRecord(components.pathItems)) {
+    result.components = {
+      pathItems: prunePathItems(components.pathItems),
+    };
+  }
+
+  return result as unknown as OpenAPIV3_1.Document;
+};
+
 export class OpenAPIConverter implements ADCSDK.Converter {
   public toADC(content: string): Observable<ADCSDK.Configuration> {
     return from(this.parseOAS(content)).pipe(
@@ -135,9 +216,9 @@ export class OpenAPIConverter implements ADCSDK.Converter {
           tap((services) =>
             services.map((service) => {
               if (!service.path_prefix) return service;
-              service.routes = service.routes!.map((route) => {
+              service.routes = service.routes!.map((route: ADCSDK.Route) => {
                 route.uris = route.uris.map(
-                  (uri) => `${service.path_prefix}${uri}`,
+                  (uri: string) => `${service.path_prefix}${uri}`,
                 );
                 return route;
               });
@@ -157,7 +238,12 @@ export class OpenAPIConverter implements ADCSDK.Converter {
   }
 
   private parseOAS(content: string): Observable<OpenAPIV3_1.Document> {
-    return of(dereference(content)).pipe(
+    return of(upgrade(content).specification).pipe(
+      map((res) => {
+        if (!res) throw new Error('No schema found in OpenAPI document');
+        return createConversionDocument(res);
+      }),
+      map((specification) => dereference(specification)),
       map((res) => {
         if (res.errors?.length)
           throw new Error(
@@ -166,9 +252,8 @@ export class OpenAPIConverter implements ADCSDK.Converter {
               .join(', ')}`,
           );
         if (!res.schema) throw new Error('No schema found in OpenAPI document');
-        return res.schema;
+        return res.schema as OpenAPIV3_1.Document;
       }),
-      map((schema) => upgrade(schema).specification),
       tap((specification) => {
         const result = schema.safeParse(specification);
 

--- a/libs/converter-openapi/src/index.ts
+++ b/libs/converter-openapi/src/index.ts
@@ -49,27 +49,25 @@ const componentSchemaFields = [
   'callbacks',
 ];
 
-const pruneConversionDocument = (spec: UnknownRecord): void => {
-  ['tags', 'externalDocs', 'security', 'webhooks'].forEach((k) =>
-    unset(spec, k),
-  );
-  componentSchemaFields.forEach((k) => unset(spec, `components.${k}`));
+const rootSchemaFields = ['tags', 'externalDocs', 'security', 'webhooks'];
 
-  const prunePaths = (paths: unknown) => {
-    if (!isRecord(paths)) return;
-    Object.values(paths)
-      .filter(isRecord)
-      .forEach((pathItem) => {
-        unset(pathItem, 'parameters');
-        httpMethods.forEach((method) => {
-          if (isRecord(pathItem[method]))
-            operationSchemaFields.forEach((f) =>
-              unset(pathItem[method] as UnknownRecord, f),
-            );
-        });
+const prunePaths = (paths: unknown) => {
+  if (!isRecord(paths)) return;
+  Object.values(paths)
+    .filter(isRecord)
+    .forEach((pathItem) => {
+      unset(pathItem, 'parameters');
+      httpMethods.forEach((method) => {
+        const operation = pathItem[method];
+        if (isRecord(operation))
+          operationSchemaFields.forEach((f) => unset(operation, f));
       });
-  };
+    });
+};
 
+const pruneConversionDocument = (spec: UnknownRecord): void => {
+  rootSchemaFields.forEach((k) => unset(spec, k));
+  componentSchemaFields.forEach((k) => unset(spec, `components.${k}`));
   prunePaths(spec.paths);
   prunePaths(isRecord(spec.components) ? spec.components.pathItems : undefined);
 };

--- a/libs/converter-openapi/src/index.ts
+++ b/libs/converter-openapi/src/index.ts
@@ -2,7 +2,7 @@ import * as ADCSDK from '@api7/adc-sdk';
 import { dereference, upgrade } from '@scalar/openapi-parser';
 import { OpenAPIV3_1 } from '@scalar/openapi-types';
 import { isEmpty, unset } from 'lodash-es';
-import { Observable, from, map, of, switchMap, tap } from 'rxjs';
+import { Observable, defer, from, map, of, switchMap, tap } from 'rxjs';
 import slugify from 'slugify';
 import { z } from 'zod';
 
@@ -238,11 +238,12 @@ export class OpenAPIConverter implements ADCSDK.Converter {
   }
 
   private parseOAS(content: string): Observable<OpenAPIV3_1.Document> {
-    return of(upgrade(content).specification).pipe(
-      map((res) => {
-        if (!res) throw new Error('No schema found in OpenAPI document');
-        return createConversionDocument(res);
-      }),
+    return defer(() => {
+      const upgraded = upgrade(content);
+      if (!upgraded.specification)
+        throw new Error('No schema found in OpenAPI document');
+      return of(createConversionDocument(upgraded.specification));
+    }).pipe(
       map((specification) => dereference(specification)),
       map((res) => {
         if (res.errors?.length)

--- a/libs/converter-openapi/src/index.ts
+++ b/libs/converter-openapi/src/index.ts
@@ -24,83 +24,54 @@ const httpMethods: Array<OpenAPIV3_1.HttpMethods> = [
 
 type UnknownRecord = Record<string, unknown>;
 
-const copiedExtensionKeys = [
-  ExtKey.NAME,
-  ExtKey.LABELS,
-  ExtKey.PLUGINS,
-  ExtKey.SERVICE_DEFAULTS,
-  ExtKey.UPSTREAM_DEFAULTS,
-  ExtKey.UPSTREAM_NODE_DEFAULTS,
-  ExtKey.ROUTE_DEFAULTS,
-];
-
 const isRecord = (value: unknown): value is UnknownRecord =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const copyKey = (source: UnknownRecord, target: UnknownRecord, key: string) => {
-  if (source[key] !== undefined) target[key] = source[key];
-};
+const operationSchemaFields = [
+  'parameters',
+  'requestBody',
+  'responses',
+  'callbacks',
+  'security',
+  'tags',
+  'deprecated',
+  'externalDocs',
+];
 
-const copyExtensionKeys = (source: UnknownRecord, target: UnknownRecord) => {
-  copiedExtensionKeys.forEach((key) => copyKey(source, target, key));
-  Object.entries(source)
-    .filter(([key]) => key.startsWith(ExtKey.PLUGIN_PREFIX))
-    .forEach(([key, value]) => {
-      target[key] = value;
-    });
-};
+const componentSchemaFields = [
+  'schemas',
+  'responses',
+  'requestBodies',
+  'headers',
+  'parameters',
+  'examples',
+  'links',
+  'callbacks',
+];
 
-const pruneOperation = (operation: unknown): unknown => {
-  if (!isRecord(operation)) return operation;
-
-  const result: UnknownRecord = {};
-  ['$ref', 'operationId', 'summary', 'description', 'servers'].forEach((key) =>
-    copyKey(operation, result, key),
+const pruneConversionDocument = (spec: UnknownRecord): void => {
+  ['tags', 'externalDocs', 'security', 'webhooks'].forEach((k) =>
+    unset(spec, k),
   );
-  copyExtensionKeys(operation, result);
-  return result;
-};
+  componentSchemaFields.forEach((k) => unset(spec, `components.${k}`));
 
-const prunePathItem = (pathItem: unknown): unknown => {
-  if (!isRecord(pathItem)) return pathItem;
+  const prunePaths = (paths: unknown) => {
+    if (!isRecord(paths)) return;
+    Object.values(paths)
+      .filter(isRecord)
+      .forEach((pathItem) => {
+        unset(pathItem, 'parameters');
+        httpMethods.forEach((method) => {
+          if (isRecord(pathItem[method]))
+            operationSchemaFields.forEach((f) =>
+              unset(pathItem[method] as UnknownRecord, f),
+            );
+        });
+      });
+  };
 
-  const result: UnknownRecord = {};
-  ['$ref', 'servers'].forEach((key) => copyKey(pathItem, result, key));
-  copyExtensionKeys(pathItem, result);
-  httpMethods.forEach((method) => {
-    if (pathItem[method] !== undefined)
-      result[method] = pruneOperation(pathItem[method]);
-  });
-  return result;
-};
-
-const prunePathItems = (pathItems: UnknownRecord): UnknownRecord =>
-  Object.fromEntries(
-    Object.entries(pathItems).map(([path, pathItem]) => [
-      path,
-      prunePathItem(pathItem),
-    ]),
-  );
-
-const createConversionDocument = (
-  specification: unknown,
-): OpenAPIV3_1.Document => {
-  const source = specification as unknown as UnknownRecord;
-  const result: UnknownRecord = {};
-
-  ['openapi', 'info', 'servers'].forEach((key) => copyKey(source, result, key));
-  copyExtensionKeys(source, result);
-
-  if (isRecord(source.paths)) result.paths = prunePathItems(source.paths);
-
-  const components = source.components;
-  if (isRecord(components) && isRecord(components.pathItems)) {
-    result.components = {
-      pathItems: prunePathItems(components.pathItems),
-    };
-  }
-
-  return result as unknown as OpenAPIV3_1.Document;
+  prunePaths(spec.paths);
+  prunePaths(isRecord(spec.components) ? spec.components.pathItems : undefined);
 };
 
 export class OpenAPIConverter implements ADCSDK.Converter {
@@ -242,7 +213,8 @@ export class OpenAPIConverter implements ADCSDK.Converter {
       const upgraded = upgrade(content);
       if (!upgraded.specification)
         throw new Error('No schema found in OpenAPI document');
-      return of(createConversionDocument(upgraded.specification));
+      pruneConversionDocument(upgraded.specification as UnknownRecord);
+      return of(upgraded.specification as OpenAPIV3_1.Document);
     }).pipe(
       map((specification) => dereference(specification)),
       map((res) => {

--- a/libs/converter-openapi/test/assets/basic-8.yaml
+++ b/libs/converter-openapi/test/assets/basic-8.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.2
+info:
+  title: SectorAPI
+  version: 3.0.0
+servers:
+  - url: http://localhost:8080
+paths:
+  /v3/sectors:
+    get:
+      operationId: getSectors
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Section'
+components:
+  schemas:
+    Sector:
+      type: object
+      properties:
+        key:
+          type: string
+        description:
+          type: string
+    SectorNode:
+      type: object
+      properties:
+        sector:
+          $ref: '#/components/schemas/Sector'
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/SectorNode'
+    Section:
+      type: object
+      properties:
+        key:
+          type: string
+        description:
+          type: string
+        sectorNodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/SectorNode'

--- a/libs/converter-openapi/test/basic.spec.ts
+++ b/libs/converter-openapi/test/basic.spec.ts
@@ -408,4 +408,30 @@ describe('Basic', () => {
       ],
     });
   });
+
+  it('case 8 (self-referencing component schema)', async () => {
+    const oas = parse(loadAsset('basic-8.yaml'));
+    const config = await convert(oas);
+
+    expect(config).toEqual({
+      services: [
+        {
+          name: 'SectorAPI',
+          routes: [
+            {
+              methods: ['GET'],
+              name: 'getSectors',
+              uris: ['/v3/sectors'],
+            },
+          ],
+          upstream: {
+            nodes: [{ host: 'localhost', port: 8080, weight: 100 }],
+            pass_host: 'pass',
+            scheme: 'http',
+            timeout: { connect: 60, read: 60, send: 60 },
+          },
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
Fixes #453.

`adc convert openapi` only needs routing metadata, but the converter was dereferencing the whole OpenAPI document before conversion. For OpenAPI 3.0 documents with circular component schemas, that can make unrelated schema graphs fail before route conversion.

This changes the converter to upgrade the raw spec first, build a conversion-only document containing `info`, `servers`, `paths`, reusable path items, and `x-adc-*` fields, then dereference that smaller document. Request and response schema trees are left out because ADC config output does not consume them.

Route, service, upstream, label, and plugin metadata conversion behavior is preserved. A regression fixture covers the self-referencing schema from the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced OpenAPI conversion by pruning irrelevant or unsupported parts of the spec before dereferencing, improving reliability for complex documents.
  * Improved route generation by inlining each service’s path prefix directly into route URIs.
  * Strengthened schema parsing and dereferencing to produce more consistent output.

* **Tests**
  * Added a new OpenAPI fixture and Jest coverage for recursive/self-referencing component schemas (e.g., nested `children` structures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->