### PR TITLE
feat(apisix-standalone): lrucache ttl and active invalidation

### DIFF
--- a/apps/cli/src/server/schema.ts
+++ b/apps/cli/src/server/schema.ts
@@ -11,6 +11,7 @@ const SyncTask = z.strictObject({
     excludeResourceType: z.array(z.enum(ADCSDK.ResourceType)).optional(),
     labelSelector: z.record(z.string(), z.string()).optional(),
     cacheKey: z.string(),
+    bypassCache: z.boolean().optional().default(false),
   }),
   config: z.looseObject({}),
 });

--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -77,6 +77,9 @@ export const syncHandler: RequestHandler<
       httpsAgent: (task.opts as any).tlsSkipVerify ? httpsInsecureAgent : httpsAgent,
     });
 
+    backend.on('TASK_START', ({ name }) =>
+      logger.log({ level: 'info', message: name ?? '', requestId: req.requestId }),
+    );
     backend.on('AXIOS_DEBUG', ({ description, response }) =>
       logger.log({
         level: 'debug',

--- a/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
+++ b/libs/backend-apisix-standalone/e2e/cache.e2e-spec.ts
@@ -6,6 +6,7 @@ import { gt, lte } from 'semver';
 import { BackendAPISIXStandalone } from '../src';
 import {
   config as configCache,
+  invalidate as invalidateCache,
   latestVersion as latestVersionCache,
   rawConfig as rawConfigCache,
 } from '../src/cache';
@@ -440,4 +441,102 @@ describe('Cache - Multiple APISIX (Partial new instances)', () => {
       expect(rawConfig?.ssls_conf_version).toBeLessThan(200);
     },
   );
+});
+
+describe('Cache - bypassCache invalidation', () => {
+  let backend: BackendAPISIXStandalone;
+  const cacheKey = 'default';
+
+  const syncedConfig = {
+    services: [
+      {
+        name: 'service1',
+        upstream: { nodes: [{ host: '127.0.0.1', port: 9180, weight: 100 }] },
+        routes: [{ name: 'route1', uris: ['/'] }],
+      },
+    ],
+  } as ADCSDK.Configuration;
+
+  // Data that does not exist in APISIX, injected directly into the cache to simulate staleness
+  const staleConfig = {
+    services: [
+      {
+        name: 'stale-service',
+        upstream: { nodes: [{ host: '1.2.3.4', port: 80, weight: 100 }] },
+        routes: [{ name: 'stale-route', uris: ['/stale'] }],
+      },
+    ],
+  } as ADCSDK.Configuration;
+
+  beforeAll(async () => {
+    await restartAPISIX();
+    // Previous describe blocks may leave stale entries (e.g. rawConfigCache) that
+    // would cause duplicate-ID errors when the operator builds the PUT payload.
+    invalidateCache(cacheKey);
+    backend = new BackendAPISIXStandalone({
+      server: server1,
+      token: token1,
+      tlsSkipVerify: true,
+      cacheKey,
+      ...defaultBackendOptions,
+    });
+  });
+
+  afterAll(() => (configCache.clear(), rawConfigCache.clear()));
+
+  it('initialize cache and sync config to APISIX', async () => {
+    await dumpConfiguration(backend);
+    mockStableTimestamp.mockReturnValueOnce(Date.now());
+    const events = DifferV3.diff(syncedConfig, {});
+    await syncEvents(backend, events);
+    expect(configCache.get(cacheKey)).toMatchObject(syncedConfig);
+  });
+
+  it('inject stale data into cache', () => {
+    configCache.set(cacheKey, staleConfig);
+    expect(configCache.get(cacheKey)).toMatchObject(staleConfig);
+  });
+
+  it('dump without bypassCache returns stale data (no API call)', async () => {
+    let apiCall = 0;
+    const sub = backend.on('AXIOS_DEBUG', () => apiCall++);
+    const result = await dumpConfiguration(backend);
+    sub.unsubscribe();
+
+    expect(apiCall).toEqual(0);
+    expect(result.services?.[0].name).toEqual('stale-service');
+  });
+
+  it('dump with bypassCache fetches fresh data from APISIX', async () => {
+    const freshBackend = new BackendAPISIXStandalone({
+      server: server1,
+      token: token1,
+      tlsSkipVerify: true,
+      cacheKey,
+      bypassCache: true,
+      ...defaultBackendOptions,
+    });
+
+    let apiCall = 0;
+    const sub = freshBackend.on('AXIOS_DEBUG', () => apiCall++);
+    const result = await dumpConfiguration(freshBackend);
+    sub.unsubscribe();
+
+    expect(apiCall).toBeGreaterThan(0);
+    expect(result).toMatchObject(syncedConfig);
+  });
+
+  it('cache is repopulated with fresh data after bypassCache dump', () => {
+    expect(configCache.get(cacheKey)).toMatchObject(syncedConfig);
+  });
+
+  it('subsequent dump without bypassCache serves repopulated cache (no API call)', async () => {
+    let apiCall = 0;
+    const sub = backend.on('AXIOS_DEBUG', () => apiCall++);
+    const result = await dumpConfiguration(backend);
+    sub.unsubscribe();
+
+    expect(apiCall).toEqual(0);
+    expect(result).toMatchObject(syncedConfig);
+  });
 });

--- a/libs/backend-apisix-standalone/eslint.config.ts
+++ b/libs/backend-apisix-standalone/eslint.config.ts
@@ -16,7 +16,14 @@ export default config([
             '{projectRoot}/test/**/*',
             '{projectRoot}/e2e/**/*',
           ],
-          ignoredDependencies: ['tslib'],
+          ignoredDependencies: [
+            'tslib',
+            // lru-cache v11 does not expose ./package.json via its exports map, and its
+            // dist/commonjs/package.json lacks name/version fields. Nx's package resolver
+            // hits that incomplete package.json and returns null instead of walking up to
+            // the real one, so the import in cache.ts is never recorded as an npm dep.
+            'lru-cache',
+          ],
         },
       ],
     },

--- a/libs/backend-apisix-standalone/package.json
+++ b/libs/backend-apisix-standalone/package.json
@@ -26,6 +26,7 @@
     "axios": "catalog:",
     "rxjs": "catalog:",
     "lodash-es": "catalog:",
+    "lru-cache": "catalog:",
     "zod": "catalog:",
     "tslib": "catalog:",
     "semver": "catalog:"

--- a/libs/backend-apisix-standalone/src/cache.ts
+++ b/libs/backend-apisix-standalone/src/cache.ts
@@ -1,9 +1,20 @@
 import * as ADCSDK from '@api7/adc-sdk';
+import { LRUCache } from 'lru-cache';
 import { type SemVer } from 'semver';
 
 import * as typing from './typing';
 
-export const version = new Map<string, SemVer>();
-export const latestVersion = new Map<string, number>();
-export const config = new Map<string, ADCSDK.Configuration>();
-export const rawConfig = new Map<string, typing.APISIXStandalone>();
+const max = Number(process.env.ADC_STANDALONE_CACHE_MAX ?? 16);
+const ttl = Number(process.env.ADC_STANDALONE_CACHE_TTL_MS ?? 3_600_000);
+
+export const version = new LRUCache<string, SemVer>({ max, ttl });
+export const latestVersion = new LRUCache<string, number>({ max, ttl });
+export const config = new LRUCache<string, ADCSDK.Configuration>({ max, ttl });
+export const rawConfig = new LRUCache<string, typing.APISIXStandalone>({ max, ttl });
+
+export const invalidate = (key: string): void => {
+  version.delete(key);
+  latestVersion.delete(key);
+  config.delete(key);
+  rawConfig.delete(key);
+};

--- a/libs/backend-apisix-standalone/src/cache.ts
+++ b/libs/backend-apisix-standalone/src/cache.ts
@@ -9,8 +9,8 @@ const parseEnvInt = (value: string | undefined, defaultVal: number): number => {
   return Number.isFinite(n) && n >= 1 ? Math.floor(n) : defaultVal;
 };
 
-const max = parseEnvInt(process.env.ADC_STANDALONE_CACHE_MAX, 16);
-const ttl = parseEnvInt(process.env.ADC_STANDALONE_CACHE_TTL_MS, 3_600_000);
+const max = parseEnvInt(process.env.ADC_APISIX_STANDALONE_CACHE_MAX, 16);
+const ttl = parseEnvInt(process.env.ADC_APISIX_STANDALONE_CACHE_TTL_MS, 3_600_000);
 
 export const version = new LRUCache<string, SemVer>({ max, ttl });
 export const latestVersion = new LRUCache<string, number>({ max, ttl });

--- a/libs/backend-apisix-standalone/src/cache.ts
+++ b/libs/backend-apisix-standalone/src/cache.ts
@@ -4,8 +4,13 @@ import { type SemVer } from 'semver';
 
 import * as typing from './typing';
 
-const max = Number(process.env.ADC_STANDALONE_CACHE_MAX ?? 16);
-const ttl = Number(process.env.ADC_STANDALONE_CACHE_TTL_MS ?? 3_600_000);
+const parseEnvInt = (value: string | undefined, defaultVal: number): number => {
+  const n = Number(value ?? defaultVal);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : defaultVal;
+};
+
+const max = parseEnvInt(process.env.ADC_STANDALONE_CACHE_MAX, 16);
+const ttl = parseEnvInt(process.env.ADC_STANDALONE_CACHE_TTL_MS, 3_600_000);
 
 export const version = new LRUCache<string, SemVer>({ max, ttl });
 export const latestVersion = new LRUCache<string, number>({ max, ttl });

--- a/libs/backend-apisix-standalone/src/index.ts
+++ b/libs/backend-apisix-standalone/src/index.ts
@@ -6,6 +6,7 @@ import semver, { SemVer, eq as semverEQ } from 'semver';
 
 import {
   config as configCache,
+  invalidate as invalidateCache,
   latestVersion as latestVersionCache,
   rawConfig as rawConfigCache,
   version as versionCache,
@@ -13,6 +14,8 @@ import {
 import { Fetcher } from './fetcher';
 import { Operator } from './operator';
 import * as typing from './typing';
+
+type BackendOpts = ADCSDK.BackendOptions & { bypassCache?: boolean };
 
 export class BackendAPISIXStandalone implements ADCSDK.Backend {
   private static logScope = ['APISIX'];
@@ -24,7 +27,7 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
     string
   >();
 
-  constructor(private readonly opts: ADCSDK.BackendOptions) {
+  constructor(private readonly opts: BackendOpts) {
     const servers = opts.server.split(',');
     const tokens = opts.token.split(',');
     servers.forEach((server, idx) => {
@@ -94,6 +97,7 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
   // 2.2. Find the latest updated server among them and it will be used as the initial cache
   // 3. Transform and return that configuration
   public dump(): Observable<ADCSDK.Configuration> {
+    if (this.opts.bypassCache) invalidateCache(this.opts.cacheKey!);
     return from(this.version()).pipe<ADCSDK.Configuration>(
       switchMap((version) => {
         const cachedConfig = configCache.get(this.opts.cacheKey!);

--- a/libs/backend-apisix-standalone/src/index.ts
+++ b/libs/backend-apisix-standalone/src/index.ts
@@ -97,7 +97,13 @@ export class BackendAPISIXStandalone implements ADCSDK.Backend {
   // 2.2. Find the latest updated server among them and it will be used as the initial cache
   // 3. Transform and return that configuration
   public dump(): Observable<ADCSDK.Configuration> {
-    if (this.opts.bypassCache) invalidateCache(this.opts.cacheKey!);
+    if (this.opts.bypassCache) {
+      invalidateCache(this.opts.cacheKey!);
+      this.subject.next({
+        type: ADCSDK.BackendEventType.TASK_START,
+        event: { name: `Cache invalidated for key: "${this.opts.cacheKey!}"` },
+      });
+    }
     return from(this.version()).pipe<ADCSDK.Configuration>(
       switchMap((version) => {
         const cachedConfig = configCache.get(this.opts.cacheKey!);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     listr2:
       specifier: ^10.0.0
       version: 10.2.1
+    lru-cache:
+      specifier: ^11.0.0
+      version: 11.2.2
     rxjs:
       specifier: ^7.8.2
       version: 7.8.2
@@ -336,6 +339,9 @@ importers:
       lodash-es:
         specifier: '>=4.17.24'
         version: 4.18.1
+      lru-cache:
+        specifier: 'catalog:'
+        version: 11.2.2
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ catalog:
   js-yaml: ^4.1.2
   listr2: ^10.0.0
   lodash-es: ^4.18.1
+  lru-cache: ^11.0.0
   rxjs: ^7.8.2
   semver: ^7.7.4
   source-map-support: ^0.5.21


### PR DESCRIPTION
### Description

Replace the cache in the apisix-standalone backend with an LRU cache that supports TTL.

By default, the cache holds 16 cache keys with a TTL of 60 minutes.

The LRU cache supports overriding its size and TTL using the `ADC_APISIX_STANDALONE_CACHE_MAX` and `ADC_APISIX_STANDALONE_CACHE_TTL_MS` environment variables.

Additionally, this backend supports active cache invalidation. To enable this, set `bypassCache` in the `task.opts` of the sync API. This behavior first deletes the local cache, which triggers the cache initialization process and repopulates the cache. As a result, the sync API will perform a diff against the latest cache.

Fix: https://github.com/apache/apisix-ingress-controller/issues/2774#issuecomment-4666087725

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional `bypassCache` flag for sync/dump requests to force fresh configuration retrieval by invalidating the relevant cached entry first.
  * Added `TASK_START`-level logging for backend task events (event name and request id).

* **Tests**
  * Added end-to-end coverage for bypassing cache invalidation, ensuring fresh data is fetched and the cache is repopulated.

* **Chores**
  * Improved standalone caching by switching to an LRU cache with configurable max size and TTL via environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->