### PR TITLE
feat: use differ v4 as default implementation

### DIFF
--- a/libs/differ/src/index.ts
+++ b/libs/differ/src/index.ts
@@ -1,10 +1,10 @@
 import { DifferV3 } from './differv3.js';
 import { DifferV4 } from './differv4.js';
 
-// Feature gate: set env var ENABLE_DIFFER_V4=true to opt in to DifferV4.
-// Defaults to false in this patch release; will default to true in the next minor.
-export const ENABLE_DIFFER_V4 = ['true', '1'].includes(
-  process.env.ENABLE_DIFFER_V4 ?? '',
+// Feature gate: set env var ENABLE_DIFFER_V4=false to opt out of DifferV4.
+// Defaults to true; set ENABLE_DIFFER_V4=false to fall back to DifferV3.
+export const ENABLE_DIFFER_V4 = !['false', '0'].includes(
+  process.env.ENABLE_DIFFER_V4 ?? 'true',
 );
 
 export { DifferV3, DifferV4 };

--- a/libs/differ/src/index.ts
+++ b/libs/differ/src/index.ts
@@ -4,7 +4,7 @@ import { DifferV4 } from './differv4.js';
 // Feature gate: set env var ENABLE_DIFFER_V4=false to opt out of DifferV4.
 // Defaults to true; set ENABLE_DIFFER_V4=false to fall back to DifferV3.
 export const ENABLE_DIFFER_V4 = !['false', '0'].includes(
-  process.env.ENABLE_DIFFER_V4 ?? 'true',
+  (process.env.ENABLE_DIFFER_V4 ?? 'true').trim().toLowerCase(),
 );
 
 export { DifferV3, DifferV4 };


### PR DESCRIPTION
### Description

Use differ v4 as the default implementation.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The newer differ behavior is now enabled by default.
  * You can still opt out by setting the feature flag to `false` or `0` (case/whitespace-insensitive).
* **Bug Fixes**
  * Updated feature-flag default and evaluation so the runtime experience matches the intended default behavior more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->