### PR TITLE
test(api7): fix password policy more then 12 chars

### DIFF
--- a/libs/backend-api7/e2e/support/global-setup.ts
+++ b/libs/backend-api7/e2e/support/global-setup.ts
@@ -92,6 +92,7 @@ const setupAPI7 = async () => {
   await waitForDashboard();
 };
 
+const newPassword = 'Admin12345!@#$%';
 const initUser = async (
   username = 'admin',
   password = 'admin',
@@ -116,7 +117,7 @@ const initUser = async (
   console.log('Modify password');
   await httpClient.put(`/api/password`, {
     old_password: password,
-    new_password: 'Admin12345!',
+    new_password: newPassword,
   });
 
   //@ts-expect-error forced
@@ -125,7 +126,7 @@ const initUser = async (
   console.log('Log in again');
   await httpClient.post(`/api/login`, {
     username: username,
-    password: 'Admin12345!',
+    password: newPassword,
   });
 
   // If the version is greater than or equal to 3.2.15, the license should


### PR DESCRIPTION
### Description

API7 enforces a new password policy requiring a minimum of 12 characters. The passwords used in the existing tests did not meet this requirement, so the tests failed. I have now updated them in this PR.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of password-change and re-login steps during setup flows by using a consistent new password value throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->