### PR TITLE
docs: restructure ADC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,97 @@
 # API Declarative CLI (ADC)
 
-ADC is a command line utility that interfaces with API7 Enterprise and Apache APISIX Admin APIs.
+API Declarative CLI (ADC) is a command-line tool for managing Apache APISIX and API7 Enterprise configuration declaratively. ADC reads local YAML or JSON files, compares them with the gateway configuration exposed by the Admin API, and applies the changes needed to make the gateway match the desired state.
+
+Use ADC when you want gateway configuration to be reviewed, versioned, promoted, and restored like application code.
+
+## Features
+
+- Export gateway configuration to an ADC file with `adc dump`.
+- Preview configuration drift with `adc diff`.
+- Apply local configuration with `adc sync`.
+- Validate local files before applying changes with `adc lint` and `adc validate`.
+- Convert OpenAPI specifications to ADC configuration with `adc convert openapi`.
+- Scope ownership by resource type or label so different teams can manage separate parts of a shared backend.
 
 ## Supported Backends
 
-The following backend types are supported in ADC:
+ADC supports the following backend types:
 
-1. [API7 Enterprise](libs/backend-api7/README.md)
-2. [Apache APISIX](libs/backend-apisix/README.md)
-
-## Supported Converters
-
-The following converters are supported to convert API specifications to ADC configuration:
-
-1. [OpenAPI Spec 3](libs/converter-openapi/README.md)
+- [API7 Enterprise](libs/backend-api7/README.md)
+- [Apache APISIX](libs/backend-apisix/README.md)
+- Apache APISIX standalone mode
 
 ## Installation
 
-The easiest way to install ADC is through the install script:
+Install ADC with the install script:
 
 ```bash
 curl -sL "https://run.api7.ai/adc/install" | sh
 ```
 
-Or, you can download the appropriate binary from the [releases page](https://github.com/api7/adc/releases):
+You can also download a pre-built binary for Linux, macOS, or Windows from the [releases page](https://github.com/api7/adc/releases).
 
-Pre-built binaries for `amd64` and `arm64` on Linux, Windows, and macOS are available now.
-
-## Configure ADC
-
-You can configure ADC through environment variables or command line flags. Run `adc help [command]` to see the available configuration options for a command.
-
-ADC supports dotenv, so you can store and use your environment variables in a `.env` file. The examples below show how to configure ADC for both API7 Enterprise and Apache APISIX backends.
-
-### Example API7 Enterprise Configuration
+Verify the installation:
 
 ```bash
-ADC_BACKEND=api7ee
-ADC_SERVER=https://localhost:7443
-ADC_TOKEN=<token generated from the dashboard>
+adc --help
 ```
 
-### Example Apache APISIX Configuration
+## Quick Start
+
+Configure the backend with environment variables or a `.env` file.
+
+For API7 Enterprise:
 
 ```bash
-ADC_SERVER=http://localhost:9180
-ADC_TOKEN=<APISIX Admin API key>
+export ADC_BACKEND=api7ee
+export ADC_SERVER=https://localhost:7443
+export ADC_TOKEN=<dashboard-token>
+export ADC_GATEWAY_GROUP=default
 ```
 
-## Usage
+For Apache APISIX:
 
-This section highlights some of the common ADC commands.
+```bash
+export ADC_BACKEND=apisix
+export ADC_SERVER=http://localhost:9180
+export ADC_TOKEN=<admin-api-key>
+```
 
-### Check Connectivity
-
-The `ping` command verifies the configuration by trying to connect to the configured backend:
+Check connectivity:
 
 ```bash
 adc ping
 ```
 
-### Dump Configuration in ADC Format
-
-The `dump` command fetches the current configuration of the backend and saves it in the ADC configuration file format:
+Export the current configuration:
 
 ```bash
 adc dump -o adc.yaml
 ```
 
-### Show the Difference between Local and Remote Configuration
-
-The `diff` command compares the configuration in the specified ADC configuration file with the current configuration of the backend:
+Preview local changes before applying them:
 
 ```bash
 adc diff -f adc.yaml
 ```
 
-### Synchronize Local Configuration
-
-The `sync` command synchronizes the configuration in the specified ADC configuration file with the backend:
+Apply the local configuration:
 
 ```bash
 adc sync -f adc.yaml
 ```
 
-### Convert API Specifications
-
-The `convert` command converts API specifications to ADC configuration. Currently, it supports converting an OpenAPI 3 specification to ADC configuration.
-
-```bash
-adc convert openapi -f openapi.yaml
-```
-
-### Verify ADC Configuration
-
-The `lint` command verifies the provided ADC configuration file locally.
-
-```bash
-adc lint -f adc.yaml
-```
-
 ## Documentation
 
-See the [`docs/`](docs/README.md) folder for the CLI command reference, configuration file reference, and a full ADC workflow guide.
+See [docs/](docs/README.md) for the workflow guide and reference documentation:
+
+- [Use ADC for Declarative Configuration](docs/guides/workflow.md)
+- [CLI Command Reference](docs/reference/cli.md)
+- [Configuration Reference](docs/reference/configuration.md)
+- [OpenAPI Converter Reference](docs/reference/openapi-converter.md)
+- [Resource IDs](docs/guides/resource-ids.md)
+- [Label Selector](docs/guides/label-selector.md)
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,25 @@
 # ADC Documentation
 
-- [CLI Command Reference](./reference/cli.md) — every `adc` command, its flags, and sample usage.
-- [Configuration Reference](./reference/configuration.md) — the `adc.yaml`/`adc.json` schema and variable syntax.
-- [OpenAPI Converter Reference](./reference/openapi-converter.md) — the `x-adc-*` extension fields supported by `adc convert openapi`.
-- [ADC Workflow Guide](./guides/workflow.md) — a walkthrough of the lint/diff/sync/dump loop, from configuring ADC to converting an OpenAPI spec.
-- [Resource IDs](./guides/resource-ids.md) — how ADC assigns resource ids, and how to safely adopt resources that were previously managed through the Admin API or a UI.
-- [Label Selector](./guides/label-selector.md) — how to let multiple teams or pipelines safely share a single backend with `--label-selector`.
+API Declarative CLI (ADC) manages Apache APISIX and API7 Enterprise configuration from local YAML or JSON files. Use it to export existing gateway configuration, review drift, validate proposed changes, and apply the desired state through the gateway Admin API.
 
-For backend-specific details, see the backend READMEs:
+Start with the workflow guide if you are setting up ADC for the first time. Use the reference pages when you need exact command flags, configuration fields, or OpenAPI conversion behavior.
 
-- [Apache APISIX Backend](../libs/backend-apisix/README.md)
-- [API7 Enterprise Backend](../libs/backend-api7/README.md)
-- [OpenAPI Converter](../libs/converter-openapi/README.md)
+## Get Started
+
+- [Use ADC for Declarative Configuration](./guides/workflow.md): configure a backend, write an `adc.yaml` file, lint it, preview changes, sync it, and export backups.
+- [Resource IDs](./guides/resource-ids.md): understand how ADC matches local resources to remote resources, especially before adopting resources that were created outside ADC.
+- [Label Selector](./guides/label-selector.md): split ownership by labels so multiple teams or pipelines can manage one backend safely.
+
+## Reference
+
+- [CLI Command Reference](./reference/cli.md): commands, flags, backend options, and examples.
+- [Configuration Reference](./reference/configuration.md): ADC configuration file structure, variables, resource fields, and links to the generated schema.
+- [OpenAPI Converter Reference](./reference/openapi-converter.md): `adc convert openapi`, supported `x-adc-*` extensions, merge rules, and examples.
+
+## Component Notes
+
+These files describe implementation-specific behavior for ADC backends and converters:
+
+- [Apache APISIX backend](../libs/backend-apisix/README.md)
+- [API7 Enterprise backend](../libs/backend-api7/README.md)
+- [OpenAPI converter](../libs/converter-openapi/README.md)

--- a/docs/guides/label-selector.md
+++ b/docs/guides/label-selector.md
@@ -1,81 +1,111 @@
 # Label Selector
 
-`--label-selector` lets multiple ADC configuration sources — different teams, different CI pipelines, different config files — safely manage disjoint subsets of resources on the **same** backend, without one sync accidentally deleting another's resources.
+`--label-selector` scopes ADC operations to resources with matching labels. Use it when multiple teams, applications, or CI pipelines manage separate parts of the same backend.
 
-## The Problem It Solves
+Without a selector, `adc sync` reconciles all resources in the command scope. If team A and team B sync separate files to the same backend without partitioning, one team can accidentally delete the other team's resources. A selector prevents that by making each run see only its own labeled resources.
 
-`adc sync` and `adc diff` are full reconciliation operations: whatever exists on the backend but is absent from your local file(s) is treated as "should be deleted." That's fine as long as one ADC pipeline owns the entire backend. It breaks down the moment two teams share a backend — team A's `sync` would see team B's resources as unmanaged leftovers and delete them.
-
-`--label-selector` fixes this by scoping both sides of the reconciliation to only the resources that carry a given label:
+## Basic Usage
 
 ```bash
 adc sync -f team-a.yaml --label-selector team=a
 ```
 
-This complements (it doesn't replace) API7 Enterprise's `--gateway-group`, which is a hard, backend-level partition available only for the `api7ee` backend. Label selectors are a soft, convention-based partition that works the same way on every backend, including plain `apisix`.
-
-## Syntax and Matching Rules
+You can provide multiple labels in one flag or repeat the flag:
 
 ```bash
---label-selector team=a
---label-selector team=a,env=prod        # comma-separated pairs in one flag
---label-selector team=a --label-selector env=prod   # or repeat the flag
+adc sync -f catalog.yaml --label-selector team=catalog,env=prod
+adc sync -f catalog.yaml --label-selector team=catalog --label-selector env=prod
 ```
 
-- Matching is **exact string equality**, and multiple pairs are combined with **AND** — a resource must match every key=value pair to be included. There's no "key exists regardless of value," no wildcard, no OR.
-- There is no `ADC_*` environment variable for this option — it's flag-only.
+Matching uses exact string equality. Multiple labels are combined with AND, so a resource must match every key-value pair to be included.
 
-## What Actually Happens on Each Side
+ADC does not support wildcards, OR expressions, or key-exists selectors. There is no `ADC_*` environment variable for label selectors; pass them as command-line flags.
 
-`--label-selector` does two different things depending on whether it's applied to the local file or the remote backend state, and understanding both is necessary to use it correctly.
+## How Remote Filtering Works
 
-### Remote: Filtering
+For `dump`, and for the remote side of `diff` and `sync`, ADC filters remote resources by label.
 
-When ADC fetches the backend configuration (`dump`, and the remote side of `diff`/`sync`), it drops any resource whose `labels` don't match every pair in the selector. This only happens at the **top-level resource** granularity — `services`, `consumers`, `ssls`. `global_rules` and `plugin_metadata` are never filtered (they're global singletons keyed by plugin name, not label-bearing per-resource collections).
+Remote filtering applies to top-level resource collections that carry labels, such as:
 
-Critically, filtering does **not** recurse into nested resources. A service's `routes`/`stream_routes` and a consumer's `credentials` travel with their parent as soon as the parent matches — they are never independently checked against the selector. This is deliberate; `libs/backend-api7/src/fetcher.ts` has an explicit comment about it:
+- `services`
+- `consumers`
+- `consumer_groups`
+- `ssls`
+- other label-bearing top-level resource collections supported by the backend
 
-```
-// In the current design, the consumer's credentials are not filtered
-// using labels because nested labels filters can be misleading. Even
-// if labels set for the consumer, the labels filter is not attached.
-```
+Remote filtering does not apply to `global_rules` or `plugin_metadata`. These resources are keyed by plugin name and are treated as global configuration.
 
-The `api7ee` backend applies this filter server-side (as `labels[key]=value` Admin API query parameters), so a filtered `dump` doesn't transfer the whole backend configuration over the wire. The `apisix` backend has no such API-level filter, so ADC always fetches the entire remote configuration and applies the same filtering client-side afterward. Either way, the CLI performs the same client-side filtering pass again regardless of backend, so behavior is consistent even though the `apisix` path is less efficient.
+Filtering does not independently select nested resources. If a service matches the selector, its routes and stream routes are included with the service. If a consumer group matches the selector, its nested consumers are included with the group.
 
-### Local: Injection
+For API7 Enterprise, ADC passes label filters to the Admin API so the backend can filter matching top-level resources. For Apache APISIX, ADC fetches the remote configuration and applies the same label filtering client-side.
 
-When ADC loads your local file(s) for `sync`/`diff`, it does the opposite of filtering: it **merges** every key=value pair from the selector into the `labels` of every top-level resource, and recurses into a service's `routes`/`stream_routes` to stamp them too (existing label keys with the same name are overwritten by the selector's value). Nothing local is ever dropped or excluded — `--label-selector` only removes resources from the *remote* side of the comparison.
+## How Local Label Injection Works
 
-This injection isn't cosmetic — it's necessary for two different reasons depending on the level:
+ADC also applies the selector to the local file. It merges the selector labels into each local top-level resource and selected nested resources. For `diff` and `sync`, this happens before ADC compares the local file with the backend. For `validate`, this happens before ADC sends the local resources for backend validation.
 
-**On top-level resources, it's required for correctness.** The exact same selector is used to filter the remote side on every future run. If a resource were created without the label, the very next invocation with the same `--label-selector` would no longer see it as "already there" (since remote filtering would exclude it) — the diff would try to create it again against an identical, deterministic id (see [Resource IDs](./resource-ids.md)), producing a conflict or a resource that's permanently invisible to its own partition. Injection guarantees anything synced under a given selector stays discoverable under that same selector.
-
-**On nested routes/stream_routes, it's only about diff stability, not filtering correctness.** Since nested resources are never independently filtered (see above), an unlabeled route wouldn't fall out of scope. But the remote route already carries the label — stamped there when it was first created, as a child of an already-labeled service — so if the local copy doesn't carry the same label, the differ sees a real (if meaningless) field difference every time and reports a spurious `update route` event on every single `sync`/`diff`, forever.
-
-A side effect of both: you don't have to hand-write `labels: { team: a }` on every resource in your file. Declare it once via the flag (or wire it into your CI pipeline per team/environment), and ADC applies it uniformly — removing the chance that a forgotten label on one resource silently drops it out of its partition.
-
-## Example: Two Teams, One Backend
-
-Team A and team B each maintain their own configuration file and CI pipeline against the same `apisix`/`api7ee` instance:
+For example, this command:
 
 ```bash
-# Team A's pipeline
+adc sync -f catalog.yaml --label-selector team=catalog
+```
+
+turns a local service like this:
+
+```yaml
+services:
+  - name: catalog
+    routes:
+      - name: list-products
+        uris:
+          - /products
+```
+
+into an in-memory configuration equivalent to:
+
+```yaml
+services:
+  - name: catalog
+    labels:
+      team: catalog
+    routes:
+      - name: list-products
+        labels:
+          team: catalog
+        uris:
+          - /products
+```
+
+If the file already has the same label key, the selector value wins.
+
+This behavior keeps future runs stable. Resources created under a selector remain visible to that selector, and nested resources do not produce repeated diffs just because the backend copy has labels added by an earlier sync.
+
+## Share One Backend Across Teams
+
+Team A and team B can manage separate files against the same backend:
+
+```bash
+# Team A
 adc sync -f team-a.yaml --label-selector team=a
 
-# Team B's pipeline
+# Team B
 adc sync -f team-b.yaml --label-selector team=b
 ```
 
-Team A's `sync` only ever sees (and can therefore only ever delete or update) resources labeled `team=a`; team B's resources are invisible to it, and vice versa. Neither file needs to mention the `team` label explicitly — ADC stamps it on every resource each pipeline creates.
+Team A sees and reconciles only resources labeled `team=a`. Team B sees and reconciles only resources labeled `team=b`.
 
-To inspect what a given partition currently looks like on the backend:
+To inspect one partition:
 
 ```bash
-adc dump -o team-a-backup.yaml --label-selector team=a
+adc dump -o team-a.yaml --label-selector team=a
 ```
+
+## Important Limits
+
+- Do not use label selectors to split ownership of routes inside one shared service. A service is the top-level unit for filtering, so its nested routes move with it.
+- Use `--gateway-group` for API7 Enterprise gateway group isolation. Use `--label-selector` when teams share a gateway group or when the backend is Apache APISIX.
+- Be careful with `global_rules` and `plugin_metadata`. They are global and are not filtered by label selector.
 
 ## Related
 
-- [CLI Command Reference](../reference/cli.md#common-backend-options)
 - [Resource IDs](./resource-ids.md)
+- [CLI Command Reference](../reference/cli.md#common-backend-options)

--- a/docs/guides/resource-ids.md
+++ b/docs/guides/resource-ids.md
@@ -1,56 +1,69 @@
 # Resource IDs
 
-Every resource ADC manages (services, routes, upstreams, consumers, SSLs, and so on) is identified on the backend by an `id`, not by its `name`. When ADC computes a diff, it matches local resources against remote resources **by `id`**. This choice has a direct consequence:
+ADC matches local resources to remote resources by resource ID. Names are used to generate IDs only when an explicit `id` is not present in the local configuration.
 
-> If a local resource's `id` does not match the `id` of the resource already on the backend, ADC does not treat it as "the same resource, updated" — it treats it as two different resources, and the diff will **delete** the remote one and **create** a new one from the local definition.
+This matters most when adopting resources that already exist on the backend. A resource created through a UI or Admin API may have a server-generated ID that does not match the ID ADC would derive from its name. If ADC cannot match the IDs, it treats the local resource and remote resource as different resources.
 
-This is why ADC needs a stable, predictable `id` for every resource before it commits a configuration to the control plane: it's the only way `sync` can tell "this is an update to an existing resource" apart from "this is a brand new resource that happens to look similar."
+## Why IDs Matter
 
-There are two distinct situations, depending on who is managing the resource's lifecycle.
+`adc sync` is a reconciliation operation. For each resource in scope, ADC compares the local desired state with the remote state and computes create, update, and delete events.
 
-## Resources Fully Managed by ADC
+If an existing remote resource has ID `abc123`, but the local file describes a similar resource with generated ID `def456`, ADC does not treat that as an in-place update. It sees:
 
-If a resource was created by ADC and is only ever touched through `adc sync`, you never need to write an `id` field yourself. ADC derives it deterministically from the resource's identity, so the same input always produces the same `id`:
+- one remote resource to delete
+- one local resource to create
 
-| Resource type                              | ID is derived from                                              |
-| -------------------------------------------- | ------------------------------------------------------------------ |
-| Consumer                                    | The `username` itself (used directly, not hashed).                |
-| Global rule / plugin metadata               | The map key (e.g. the plugin name) itself.                        |
-| Service, SSL                                | `sha1(name)` — or `sha1(snis.join(','))` for SSL.                  |
-| Route, Stream Route, Upstream, Consumer Credential | `sha1("<parent-name>.<name>")`, namespaced by the parent's `name` (e.g. the owning service) so that identically named routes in two different services get different ids. |
+Depending on the resource, that replacement can cause traffic disruption, break references that use the old ID, or create unnecessary audit history.
 
-This is exactly what `adc dump` (without `--with-id`) reproduces implicitly: because the id is a pure function of the name (and parent name), you don't need to persist it — ADC recomputes the same id every time it reads the file, and it will always match what it previously created on the backend.
+## Generated IDs
 
-The practical implication: **renaming** a resource that ADC generated the id for changes its id too (since the id is derived from the name), which means `sync` will delete the old resource and create a new one under the new name, rather than renaming it in place. If you need to rename a resource without a delete/create cycle, give it an explicit `id` first (see below) so the id stays stable across the rename.
+When no explicit `id` is set, ADC derives IDs deterministically.
 
-## Adopting Resources Previously Managed by the UI or Admin API
+| Resource type       | Generated ID                                    |
+| ------------------- | ----------------------------------------------- |
+| Consumer            | `username`                                      |
+| Global rule         | Plugin name                                     |
+| Plugin metadata     | Plugin name                                     |
+| Service             | `sha1(name)`                                    |
+| SSL                 | `sha1(snis.join(','))`                          |
+| Upstream            | `sha1("<service-name>.<upstream-name>")`        |
+| Route               | `sha1("<service-name>.<route-name>")`           |
+| Stream route        | `sha1("<service-name>.<stream-route-name>")`    |
+| Consumer credential | `sha1("<consumer-username>.<credential-name>")` |
 
-Resources created through the Admin API or a dashboard (API7 Enterprise's UI, for instance) are assigned a random, server-generated `id` — it has no relationship to the resource's `name`. If you write a fresh `adc.yaml` for such a resource and sync it without specifying `id`, ADC computes `sha1(name)`, which will not equal the resource's actual random id already on the backend. The diff sees two different ids and does exactly what's described above: deletes the existing resource and creates a new one in its place. Depending on the resource, this can mean brief traffic disruption, loss of anything keyed to the old id (e.g. external references, audit history), and needless churn.
+For resources that ADC created and continues to manage, you normally do not need to write IDs by hand. ADC will generate the same ID from the same names on every run.
 
-To bring such a resource under ADC management safely:
+## Rename Behavior
 
-1. **Dump the current backend state with real ids inlined:**
+If a resource uses a generated ID, renaming it changes the generated ID. ADC will treat that as deleting the old resource and creating a new one.
 
-   ```bash
-   adc dump --with-id -o adc.yaml
-   ```
+To rename a resource without changing its backend ID:
 
-   Every resource in `adc.yaml` now has its actual backend `id` set explicitly. Because every resource type's id resolution is `id ?? generateId(...)` — the explicit `id` always wins over the derived one — ADC will use these ids going forward instead of recomputing them from the name.
+1. Export the resource with explicit IDs.
+2. Keep the `id` field in the file.
+3. Change the display name or resource name while preserving the `id`.
+4. Run `adc diff` and confirm the change is an update, not a delete and create.
 
-2. **Confirm there is no drift before you start managing it declaratively:**
+## Adopt Existing Resources
 
-   ```bash
-   adc diff -f adc.yaml
-   ```
+Before pointing ADC at resources that were created outside ADC, export the current backend state with IDs:
 
-   This should report no changes. If it does report changes, they reflect real differences between what's in `adc.yaml` and the live backend state (for example, fields the dump can't fully round-trip) — resolve those before proceeding.
+```bash
+adc dump --with-id -o adc.yaml
+```
 
-3. **Commit `adc.yaml` to version control and manage it with `adc sync` from now on.** As long as the `id` field stays in the file, future syncs will match against the correct backend resource and update it in place instead of replacing it.
+Then confirm that ADC sees no changes:
 
-4. **Keep the `id` field.** Don't strip it out later "for cleanliness" — doing so turns the resource back into a name-derived id on the next sync, which (unless the hash happens to coincide with the real id) triggers the delete/create behavior described above. There's no supported way to migrate a resource from an explicit id back to a derived one without a delete/create cycle.
+```bash
+adc diff -f adc.yaml
+```
+
+If the diff is empty, commit the file and use it as the starting point for ADC-managed configuration.
+
+Keep the exported `id` fields. Removing them later can cause ADC to fall back to generated IDs and replace the resources on the next sync.
 
 ## Related
 
-- [`adc dump --with-id`](../reference/cli.md#adc-dump)
+- [Use ADC for Declarative Configuration](./workflow.md)
+- [CLI Command Reference](../reference/cli.md#adc-dump)
 - [Configuration Reference](../reference/configuration.md)
-- [Label Selector](./label-selector.md)

--- a/docs/guides/workflow.md
+++ b/docs/guides/workflow.md
@@ -1,74 +1,90 @@
 # Use ADC for Declarative Configuration
 
-ADC (API Declarative CLI) lets you manage your gateway configuration declaratively using YAML files. This enables GitOps workflows, version-controlled configuration, and reproducible deployments across different environments.
+ADC lets you manage Apache APISIX and API7 Enterprise configuration from local files. A typical workflow is:
 
-Instead of making imperative API calls, you define the desired state in a YAML file and ADC reconciles it with the gateway.
+1. Connect ADC to a backend.
+2. Export or write an `adc.yaml` file.
+3. Lint and validate the file.
+4. Preview the diff.
+5. Sync the expected changes.
+6. Keep the file in version control.
+
+This gives teams a reviewable source of truth for gateway configuration and makes drift visible before changes reach production.
 
 ## Prerequisites
 
-- An Apache APISIX or API7 Enterprise instance is running and its Admin API is reachable.
-- ADC is installed. See the [installation instructions](../../README.md#installation).
-- For API7 Enterprise: a Gateway Group is created, a Gateway instance is running, and you have a token to access the Admin API.
+- ADC is installed. See [Installation](../../README.md#installation).
+- An Apache APISIX or API7 Enterprise Admin API endpoint is reachable from the machine or CI runner that runs ADC.
+- You have an Admin API key or API7 Enterprise dashboard token.
+- For API7 Enterprise, you know the target gateway group.
 
-## Configure ADC
+## Configure the Backend
 
-ADC can be configured through environment variables, a `.env` file, or command-line flags. All three sources expose the same options; flags take precedence over environment variables, which take precedence over `.env` values.
+ADC reads configuration from command-line flags, environment variables, and `.env` files. Command-line flags take precedence over environment variables, and environment variables take precedence over `.env` values.
 
-### Using Environment Variables
-
-For an API7 Enterprise backend:
+For API7 Enterprise:
 
 ```bash
 export ADC_BACKEND=api7ee
 export ADC_SERVER=https://localhost:7443
-export ADC_TOKEN=${API_KEY}
+export ADC_TOKEN=<dashboard-token>
 export ADC_GATEWAY_GROUP=default
 ```
 
-For an Apache APISIX backend:
+For Apache APISIX:
 
 ```bash
 export ADC_BACKEND=apisix
 export ADC_SERVER=http://localhost:9180
-export ADC_TOKEN=${ADMIN_API_KEY}
+export ADC_TOKEN=<admin-api-key>
 ```
 
-### Using a `.env` File
-
-ADC loads a `.env` file in the working directory automatically (via `dotenv`), so you can persist the same variables instead of exporting them in your shell:
+You can store the same values in a `.env` file in the working directory:
 
 ```text title=".env"
 ADC_BACKEND=api7ee
 ADC_SERVER=https://localhost:7443
-ADC_TOKEN=${API_KEY}
+ADC_TOKEN=<dashboard-token>
 ADC_GATEWAY_GROUP=default
 ```
 
-### Using Command-Line Flags
-
-Every option is also available as a flag, which overrides whatever is set via environment variables or `.env` for that single invocation — useful for one-off commands or targeting a different backend without changing your shell state:
+For a one-off command, pass the options as flags:
 
 ```bash
-adc ping --backend apisix --server http://localhost:9180 --token ${ADMIN_API_KEY}
+adc ping --backend apisix --server http://localhost:9180 --token <admin-api-key>
 ```
 
-If you are connecting to a local instance with a self-signed certificate, add `--tls-skip-verify` to the ADC command (or set `ADC_TLS_SKIP_VERIFY=true`).
+If the backend uses a self-signed certificate, use `--ca-cert-file` with a trusted CA certificate. For local testing, you can use `--tls-skip-verify`.
 
-See the [CLI Command Reference](../reference/cli.md#common-backend-options) for the full list of configuration options and their corresponding environment variables.
-
-Verify connectivity:
+Verify the connection:
 
 ```bash
 adc ping
 ```
 
-## Write a Declarative Configuration
+## Create a Configuration File
 
-Define your gateway resources such as services, routes, and consumers in an `adc.yaml` file.
+You can write a configuration file by hand, convert one from OpenAPI, or start from the current backend state.
+
+To export the current backend configuration:
+
+```bash
+adc dump -o adc.yaml
+```
+
+If the backend already has resources that were created outside ADC, export the real backend IDs before adopting them:
+
+```bash
+adc dump --with-id -o adc.yaml
+```
+
+Keeping those IDs prevents ADC from replacing existing resources with newly generated IDs. See [Resource IDs](./resource-ids.md) before adopting UI-created or Admin API-created resources.
+
+An ADC file can define services, routes, consumers, global rules, plugin metadata, and SSL certificates:
 
 ```yaml title="adc.yaml"
 services:
-  - name: adc-workflow-httpbin-service
+  - name: httpbin-service
     upstream:
       name: default
       scheme: http
@@ -78,83 +94,99 @@ services:
           port: 80
           weight: 100
     routes:
-      - name: adc-workflow-route
+      - name: get-ip
         uris:
-          - /anything/adc-workflow
+          - /ip
         methods:
           - GET
         plugins:
-          key-auth:
-            header: apikey
+          key-auth: {}
 
 consumers:
-  - username: adc-workflow-consumer
+  - username: demo-user
     credentials:
-      - name: adc-workflow-key
+      - name: primary-key
         type: key-auth
         config:
-          key: adc-workflow-api-key
+          key: <api-key>
 ```
 
-The configuration file uses top-level keys to organize resources such as `services`, `consumers`, `global_rules`, and `plugin_metadata`. See the [Configuration Reference](../reference/configuration.md) for the full schema.
+See [Configuration Reference](../reference/configuration.md) for the supported fields.
 
-## Validate the Configuration Locally
+## Check the File Locally
 
-Before applying changes, use the `lint` command to check your configuration for syntax errors and schema violations.
+Run `adc lint` before comparing or syncing:
 
 ```bash
 adc lint -f adc.yaml
 ```
 
+`lint` checks local syntax and ADC schema rules. It does not connect to the backend.
+
+## Validate Against the Backend
+
+Run `adc validate` when you want backend-side validation without applying changes:
+
+```bash
+adc validate -f adc.yaml
+```
+
+`validate` asks the backend to validate the resources described by the local file. This is useful in CI because it catches issues that only the target backend can know, such as unsupported plugin configuration.
+
 ## Preview Changes
 
-The `diff` command shows you exactly what changes ADC will make to the gateway configuration to match your local file.
+Run `adc diff` before applying a file:
 
 ```bash
 adc diff -f adc.yaml
 ```
 
-This output helps you avoid accidental deletions or modifications before applying the configuration. A detailed, machine-readable diff is also written to `diff.yaml`.
+Review the output carefully. `adc diff` also writes a machine-readable `diff.yaml` file in the current directory.
 
-## Apply the Configuration
+## Apply Changes
 
-Once you have verified the changes, use the `sync` command to apply the configuration to the gateway.
+After reviewing the diff, sync the file:
 
 ```bash
 adc sync -f adc.yaml
 ```
 
-> **Caution**: `adc sync` is a reconciliation operation. It will create, update, and delete resources to match the desired state in your YAML file. Resources that exist on the gateway but are not in the YAML file will be removed.
+`adc sync` reconciles the backend to match the local file. It can create, update, and delete resources that are in the command scope. A remote resource that is in scope but absent from the local file can be deleted.
 
-If you only want to check whether a sync would succeed — for example in a CI pipeline — without applying it, use `adc validate` instead, which computes the diff and runs backend-side validation without writing any changes.
+The command scope is controlled by:
 
-## Back Up the Current Configuration
+- `--gateway-group` for API7 Enterprise gateway groups.
+- `--label-selector` for label-based ownership.
+- `--include-resource-type` and `--exclude-resource-type` for resource type filters.
 
-You can export the current gateway configuration to a YAML file using the `dump` command. This is useful for creating backups or migrating configurations between environments.
+Use [Label Selector](./label-selector.md) if more than one team or pipeline manages the same backend.
 
-```bash
-adc dump -o backup.yaml
-```
+## Convert OpenAPI to ADC
 
-## Convert from OpenAPI
-
-ADC can generate a declarative configuration from an existing OpenAPI specification file. Both OpenAPI 2.0 (Swagger) and OpenAPI 3.x are accepted, in either JSON or YAML format.
+ADC can generate configuration from OpenAPI 2.0 and OpenAPI 3.x specifications:
 
 ```bash
 adc convert openapi -f openapi.yaml -o adc.yaml
 ```
 
-A plain OpenAPI document only describes endpoints. To configure gateway-specific behavior on the converted output — plugins, labels, upstream defaults, route defaults, and so on — annotate the specification with `x-adc-*` extension fields. See the [OpenAPI Converter Reference](../reference/openapi-converter.md) for the full extension reference, processing rules, and examples.
+Plain OpenAPI documents describe APIs, not gateway-specific behavior. Add `x-adc-*` extensions when you need to control generated service names, route names, plugins, labels, upstream defaults, or route defaults. See [OpenAPI Converter Reference](../reference/openapi-converter.md).
 
-## A Typical ADC Workflow
+## Suggested CI Flow
 
-1. **Lint**: `adc lint -f adc.yaml`
-2. **Diff**: `adc diff -f adc.yaml`
-3. **Sync**: `adc sync -f adc.yaml`
-4. **Dump**: `adc dump -o backup.yaml`
+For a pull request or deployment pipeline, use this order:
 
-## Next Steps
+```bash
+adc lint -f adc.yaml
+adc validate -f adc.yaml
+adc diff -f adc.yaml
+adc sync -f adc.yaml
+```
 
-- [CLI Command Reference](../reference/cli.md) — see all available commands and options.
-- [Configuration Reference](../reference/configuration.md) — full configuration file schema and variable syntax.
-- [Resource IDs](./resource-ids.md) — required reading before pointing ADC at a backend that already has resources created through the Admin API or a UI.
+Run `sync` only after the diff has been reviewed or approved by your release process.
+
+## Related
+
+- [CLI Command Reference](../reference/cli.md)
+- [Configuration Reference](../reference/configuration.md)
+- [Resource IDs](./resource-ids.md)
+- [Label Selector](./label-selector.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Command Reference
 
-API Declarative CLI (ADC) is a command-line tool for managing Apache APISIX and API7 Enterprise declaratively. It offers simplicity and clarity in defining the desired state of the gateway, allowing developers and administrators to focus on the result rather than the steps.
+API Declarative CLI (ADC) is a command-line tool for managing Apache APISIX and API7 Enterprise declaratively. ADC compares local configuration files with the backend state exposed by the Admin API and applies the changes needed to match the desired state.
 
 The declarative configuration serves as the single source of truth that developers can manage through their existing version control systems.
 
@@ -17,7 +17,7 @@ with global options:
 
 ## Configuring ADC
 
-ADC needs to be configured before it can be used to manage the gateway. You can configure ADC using environment variables or command-line flags.
+Configure ADC with environment variables, a `.env` file, or command-line flags. Flags override environment variables for that command.
 
 ### Using Environment Variables
 
@@ -28,7 +28,7 @@ export ADC_BACKEND=api7ee
 export ADC_SERVER=https://localhost:7443
 ```
 
-A better way is to configure these options in a `.env` file, which ADC loads automatically:
+You can also configure these options in a `.env` file, which ADC loads automatically:
 
 ```text title=".env"
 ADC_BACKEND=api7ee
@@ -37,33 +37,33 @@ ADC_SERVER=https://localhost:7443
 
 ### Using Command-Line Flags
 
-You can also configure ADC or overwrite the configuration in the environment variables using the command-line flags. For example, to configure/overwrite the backend type and address for the `ping` command:
+You can pass the same values as command-line flags. For example:
 
 ```shell
 adc ping --backend api7ee --server "https://localhost:7443"
 ```
 
-Run `adc help [command]` to see the available configuration options for a command.
+Run `adc help [command]` to see all options for a command.
 
 ## Common Backend Options
 
 The options below are shared by every command that talks to a backend (`ping`, `sync`, `dump`, `diff`, `validate`):
 
-| Option                        | Default Value           | Description                                                                        | Valid Values                             | Env Variable               |
-| ------------------------------ | ------------------------ | ----------------------------------------------------------------------------------- | ------------------------------------------ | ---------------------------- |
-| `--verbose <integer>`         | `1`                      | Verbosity level for logs. `0` no logs, `1` basic logs, `2` debug logs.               | `0`, `1` or `2`                            |                             |
-| `--backend <backend>`         | `apisix`                 | Type of backend to connect to.                                                      | `apisix`, `api7ee` or `apisix-standalone` | `ADC_BACKEND`               |
-| `--server <string>`           | `http://localhost:9180` | HTTP address of the backend.                                                        |                                            | `ADC_SERVER`                |
-| `--token <string>`            |                          | Token for ADC to connect to the backend.                                            |                                            | `ADC_TOKEN`                 |
-| `--gateway-group <string>`    | `default`                | Gateway group to operate on (only supported for the `api7ee` backend).              |                                            | `ADC_GATEWAY_GROUP`         |
-| `--label-selector <labelKey=labelValue>` |               | Scope this command to resources matching the given label(s). See [Label Selector](../guides/label-selector.md). |                                            |                             |
-| `--include-resource-type <string>` |                     | Only include the specified resource type(s). Mutually exclusive with `--exclude-resource-type`. |                                | |
-| `--exclude-resource-type <string>` |                     | Exclude the specified resource type(s). Mutually exclusive with `--include-resource-type`. |                                | |
-| `--timeout <duration>`        | `10s`                    | Timeout for ADC to connect with the backend (examples: `30s`, `10m`, `1h10m`).       |                                            |                             |
-| `--ca-cert-file <string>`     |                          | Path to the CA certificate to verify the backend.                                   |                                            | `ADC_CA_CERT_FILE`          |
-| `--tls-client-cert-file <string>` |                     | Path to the mutual TLS client certificate to verify the backend.                    |                                            | `ADC_TLS_CLIENT_CERT_FILE`  |
-| `--tls-client-key-file <string>`  |                      | Path to the mutual TLS client key to verify the backend.                            |                                            | `ADC_TLS_CLIENT_KEY_FILE`   |
-| `--tls-skip-verify`           | `false`                  | Disable verification of the backend TLS certificate.                                |                                            | `ADC_TLS_SKIP_VERIFY`       |
+| Option                                   | Default Value           | Description                                                                                                     | Valid Values                              | Env Variable               |
+| ---------------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------- |
+| `--verbose <integer>`                    | `1`                     | Verbosity level for logs. `0` no logs, `1` basic logs, `2` debug logs.                                          | `0`, `1` or `2`                           |                            |
+| `--backend <backend>`                    | `apisix`                | Type of backend to connect to.                                                                                  | `apisix`, `api7ee` or `apisix-standalone` | `ADC_BACKEND`              |
+| `--server <string>`                      | `http://localhost:9180` | HTTP address of the backend.                                                                                    |                                           | `ADC_SERVER`               |
+| `--token <string>`                       |                         | Token for ADC to connect to the backend.                                                                        |                                           | `ADC_TOKEN`                |
+| `--gateway-group <string>`               | `default`               | Gateway group to operate on (only supported for the `api7ee` backend).                                          |                                           | `ADC_GATEWAY_GROUP`        |
+| `--label-selector <labelKey=labelValue>` |                         | Scope this command to resources matching the given label(s). See [Label Selector](../guides/label-selector.md). |                                           |                            |
+| `--include-resource-type <string>`       |                         | Only include the specified resource type(s). Mutually exclusive with `--exclude-resource-type`.                 |                                           |                            |
+| `--exclude-resource-type <string>`       |                         | Exclude the specified resource type(s). Mutually exclusive with `--include-resource-type`.                      |                                           |                            |
+| `--timeout <duration>`                   | `10s`                   | Timeout for ADC to connect with the backend (examples: `30s`, `10m`, `1h10m`).                                  |                                           |                            |
+| `--ca-cert-file <string>`                |                         | Path to the CA certificate to verify the backend.                                                               |                                           | `ADC_CA_CERT_FILE`         |
+| `--tls-client-cert-file <string>`        |                         | Path to the mutual TLS client certificate to verify the backend.                                                |                                           | `ADC_TLS_CLIENT_CERT_FILE` |
+| `--tls-client-key-file <string>`         |                         | Path to the mutual TLS client key to verify the backend.                                                        |                                           | `ADC_TLS_CLIENT_KEY_FILE`  |
+| `--tls-skip-verify`                      | `false`                 | Disable verification of the backend TLS certificate.                                                            |                                           | `ADC_TLS_SKIP_VERIFY`      |
 
 `--tls-client-cert-file` and `--tls-client-key-file` must be provided together.
 
@@ -87,9 +87,9 @@ adc ping --backend apisix --server http://192.168.1.21:9180
 
 Lint the local configuration file(s) to ensure it meets ADC requirements. Runs entirely locally; it does not connect to a backend.
 
-| Option                   | Description       |
-| ------------------------- | ------------------ |
-| `-f, --file <file-path>` | File(s) to lint.   |
+| Option                   | Description      |
+| ------------------------ | ---------------- |
+| `-f, --file <file-path>` | File(s) to lint. |
 
 #### Sample Usage
 
@@ -107,11 +107,11 @@ Synchronize the local configuration to the backend. This is a reconciliation ope
 
 In addition to the [common backend options](#common-backend-options):
 
-| Option                            | Default Value | Description                                                  |
-| ---------------------------------- | --------------- | --------------------------------------------------------------- |
-| `-f, --file <file-path>`          |                | Configuration file(s) to synchronize. Repeatable; supports glob expressions. |
-| `--no-lint`                       |                | Disable the lint check that runs before syncing.              |
-| `--request-concurrent <integer>` | `10`           | Number of concurrent requests sent to the backend.            |
+| Option                           | Default Value | Description                                                                  |
+| -------------------------------- | ------------- | ---------------------------------------------------------------------------- |
+| `-f, --file <file-path>`         |               | Configuration file(s) to synchronize. Repeatable; supports glob expressions. |
+| `--no-lint`                      |               | Disable the lint check that runs before syncing.                             |
+| `--request-concurrent <integer>` | `10`          | Number of concurrent requests sent to the backend.                           |
 
 #### Sample Usage
 
@@ -150,12 +150,12 @@ Save the configuration of the backend to a local file.
 
 In addition to the [common backend options](#common-backend-options):
 
-| Option                     | Default Value | Description                                        |
-| --------------------------- | --------------- | ----------------------------------------------------- |
-| `-o, --output <file-path>` | `adc.yaml`     | Path of the file to save the configuration to.     |
-| `--with-id`                |                | Inline each resource's backend-assigned `id` into the dumped file. |
+| Option                     | Default Value | Description                                                        |
+| -------------------------- | ------------- | ------------------------------------------------------------------ |
+| `-o, --output <file-path>` | `adc.yaml`    | Path of the file to save the configuration to.                     |
+| `--with-id`                |               | Inline each resource's backend-assigned `id` into the dumped file. |
 
-`--with-id` matters for resources that were originally created outside of ADC (through the Admin API or a management UI), where the backend generates a random ID rather than one ADC can derive from the resource's name. Without the real `id` present in the file, a later `adc sync` would compute its own name-derived ID, see that it doesn't match the resource's actual ID on the backend, and replace the resource (delete the old one, create a new one) instead of updating it in place. Passing `--with-id` when you first dump such a backend inlines the real `id` on every resource, so subsequent syncs recognize it and update rather than replace it. See [Resource IDs](../guides/resource-ids.md) for the full explanation and migration steps.
+Use `--with-id` when adopting resources that were originally created outside ADC, such as resources created through a UI or the Admin API. It preserves the backend-assigned IDs in the dumped file so later syncs can update those resources in place instead of replacing them. See [Resource IDs](../guides/resource-ids.md).
 
 #### Sample Usage
 
@@ -172,7 +172,7 @@ adc dump --include-resource-type global_rule --include-resource-type plugin_meta
 # Save only the resources with the specified labels
 adc dump --label-selector app=catalog
 
-# Save the remote resources' ids
+# Save remote resource IDs
 adc dump --with-id
 
 # Save configuration from a specified backend
@@ -185,10 +185,10 @@ Show the differences between the local configuration file(s) and the backend con
 
 In addition to the [common backend options](#common-backend-options):
 
-| Option                    | Description                                                     |
-| --------------------------- | ------------------------------------------------------------------ |
-| `-f, --file <file-path>`  | Configuration file(s) to compare. Repeatable; supports glob expressions. |
-| `--no-lint`               | Disable the lint check that runs before diffing.                |
+| Option                   | Description                                                              |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `-f, --file <file-path>` | Configuration file(s) to compare. Repeatable; supports glob expressions. |
+| `--no-lint`              | Disable the lint check that runs before diffing.                         |
 
 #### Sample Usage
 
@@ -208,13 +208,13 @@ adc diff -f service-a.yaml -f service-b.yaml --backend api7ee --server https://l
 
 ### `adc validate`
 
-Validate the local configuration file(s) against the backend without applying any changes. Unlike `lint`, which only checks the file locally, `validate` also computes the diff against the backend and runs backend-specific validation (see each backend's validator).
+Validate the local configuration file(s) against backend-specific validation rules without applying any changes. Unlike `lint`, which only checks local ADC schema rules, `validate` asks the configured backend to validate the resources described by the local file.
 
 In addition to the [common backend options](#common-backend-options):
 
-| Option                   | Description         |
-| ------------------------- | --------------------- |
-| `-f, --file <file-path>` | File(s) to validate. |
+| Option                   | Description                                         |
+| ------------------------ | --------------------------------------------------- |
+| `-f, --file <file-path>` | File(s) to validate.                                |
 | `--no-lint`              | Disable the lint check that runs before validating. |
 
 #### Sample Usage
@@ -237,10 +237,10 @@ adc validate -f adc.yaml --no-lint
 
 Convert an OpenAPI specification to ADC configuration. The converter accepts OpenAPI 2.0 (Swagger) and OpenAPI 3.x specifications in either JSON or YAML format.
 
-| Option                             | Default Value | Description                          |
-| ------------------------------------ | --------------- | --------------------------------------- |
-| `-f, --file <openapi-file-path>`  |                | OpenAPI specification file(s) to convert. Repeatable. |
-| `-o, --output <output-path>`      | `adc.yaml`     | Output file path.                    |
+| Option                           | Default Value | Description                                           |
+| -------------------------------- | ------------- | ----------------------------------------------------- |
+| `-f, --file <openapi-file-path>` |               | OpenAPI specification file(s) to convert. Repeatable. |
+| `-o, --output <output-path>`     | `adc.yaml`    | Output file path.                                     |
 
 #### Sample Usage
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,24 +1,24 @@
 # Configuration Reference
 
-ADC uses configuration files to define services, consumers, global rules, plugin metadata, and SSL certificates. The configuration file can be in YAML or JSON format and serves as the single source of truth for declarative management.
+ADC uses configuration files to define services, consumers, global rules, plugin metadata, and SSL certificates. The configuration file can be YAML or JSON and is the desired state that ADC commands read locally, compare, validate, and sync.
 
 This document describes the configuration file structure and variable syntax. See the [CLI Command Reference](./cli.md) for CLI usage.
 
-> For the exhaustive, always up-to-date schema (including every field and validation rule), see `schema.json`, generated from the Zod schemas in `libs/sdk/src/core/schema.ts` via `nx run cli:export-schema`.
+For the exhaustive schema, including every field and validation rule, use the generated `schema.json`. It is exported from the Zod schemas in `libs/sdk/src/core/schema.ts` with `nx run cli:export-schema`.
 
 ## Configuration File Structure
 
 An ADC configuration file has the following top-level keys:
 
 ```yaml
-services:        # Service definitions with routes and upstreams
-consumers:        # Consumer definitions with credentials
-global_rules:     # Global plugin configurations
-plugin_metadata:  # Plugin metadata configurations
-ssls:             # SSL certificate configurations
+services: # Service definitions with routes and upstreams
+consumers: # Consumer definitions with credentials
+global_rules: # Global plugin configurations
+plugin_metadata: # Plugin metadata configurations
+ssls: # SSL certificate configurations
 ```
 
-All keys are optional. You can define a partial configuration that only includes the resources you want to manage; resources of a type that is omitted entirely are left untouched on the backend. To manage only specific resource types during `sync`/`dump`/`diff`, use `--include-resource-type`/`--exclude-resource-type` (see the [CLI Command Reference](./cli.md)).
+All keys are optional, but `adc sync` is a reconciliation operation. A remote resource that is in the command scope but absent from the local file can be deleted. To manage only part of a backend, scope the command with `--include-resource-type`, `--exclude-resource-type`, or `--label-selector`.
 
 ## Example Configuration
 
@@ -68,7 +68,7 @@ services:
             uri: /get
 
 consumers:
-  - username: jane
+  - username: internal-user
     labels:
       organisation: ACME
     credentials:
@@ -77,16 +77,16 @@ consumers:
           type: internal
         type: key-auth
         config:
-          key: c1_yN0nCWousUfiR4EzfH
+          key: <internal-api-key>
 
-  - username: john
+  - username: partner-user
     labels:
       organisation: API7.ai
     credentials:
       - name: primary-key
         type: key-auth
         config:
-          key: EIul6mAuYkLJ27on1aJD4
+          key: <partner-api-key>
 
 global_rules:
   prometheus:
@@ -97,19 +97,19 @@ global_rules:
 
 ## Variables
 
-ADC supports three variable syntaxes, each resolving values from different sources.
+ADC supports three variable syntaxes. Each one is resolved by a different component and at a different time.
 
 The supported ADC versions vary by syntax:
 
-| Syntax     | Resolved by | Minimum ADC version |
-| ---------- | ----------- | -------------------- |
-| `$env://`  | Data plane  | v0.12.1               |
-| `${ENV}`   | ADC         | v0.12.0               |
-| `\${}`     | Data plane  | v0.19.1               |
+| Syntax    | Resolved by | Minimum ADC version |
+| --------- | ----------- | ------------------- |
+| `$env://` | Data plane  | v0.12.1             |
+| `${ENV}`  | ADC         | v0.12.0             |
+| `\${}`    | Data plane  | v0.19.1             |
 
 ### Data Plane Environment Variables (`$env://`)
 
-Use the `$env://` syntax to reference environment variables on the data plane (gateway) instance at runtime. This is useful for values that differ across gateway instances or environments:
+Use `$env://` to reference environment variables on the data plane instance at runtime. This is useful for values that differ across gateway instances or environments:
 
 ```yaml
 services:
@@ -124,7 +124,7 @@ The variable is resolved by the gateway when the configuration is loaded, not by
 
 ### ADC Environment Variables (`${ENV}`)
 
-Use the `${ENV}` syntax for variables resolved by ADC itself when processing the configuration file. This is useful for externalizing secrets or environment-specific values:
+Use `${ENV}` for variables resolved by ADC while it loads the configuration file. This is useful for externalizing secrets or environment-specific values:
 
 ```yaml
 consumers:
@@ -139,7 +139,7 @@ consumers:
 Set the environment variable before running ADC:
 
 ```bash
-export API_KEY="my-secret-key"
+export API_KEY="<api-key>"
 adc sync -f adc.yaml
 ```
 
@@ -147,7 +147,7 @@ Use `\${VAR_NAME}` to escape a literal `${VAR_NAME}` and prevent ADC from interp
 
 ### Built-in Variables (`\${}`)
 
-Use the `\${}` syntax (escaped dollar sign) to reference built-in variables that are evaluated per-request by the gateway:
+Use `\${}` with an escaped dollar sign to reference built-in variables that the gateway evaluates per request.
 
 In YAML double-quoted strings, write the escape sequence as `\\${...}` so that ADC receives `\${...}` after YAML parsing. In single-quoted strings or unquoted values, you can write `\${...}` directly.
 
@@ -164,60 +164,60 @@ plugins:
 
 ### Service
 
-| Field                | Type    | Required | Description                                        |
-| --------------------- | ------- | -------- | --------------------------------------------------- |
-| `name`               | string  | Yes      | Unique service name. This is not the service ID, which is generated by the backend. |
-| `description`        | string  | No       | Free-form description.                             |
-| `labels`             | object  | No       | Key-value labels.                                  |
-| `upstream`           | object  | No       | Upstream configuration.                            |
-| `routes`             | array   | No       | Route definitions.                                 |
-| `stream_routes`      | array   | No       | Stream (TCP/UDP) route definitions.                |
-| `plugins`            | object  | No       | Service-level plugins.                              |
-| `path_prefix`        | string  | No       | Prefix prepended to every route URI in this service. |
-| `strip_path_prefix`  | boolean | No       | Strip the matched route prefix before forwarding.   |
+| Field               | Type    | Required | Description                                                                         |
+| ------------------- | ------- | -------- | ----------------------------------------------------------------------------------- |
+| `name`              | string  | Yes      | Unique service name. This is not the service ID, which is generated by the backend. |
+| `description`       | string  | No       | Free-form description.                                                              |
+| `labels`            | object  | No       | Key-value labels.                                                                   |
+| `upstream`          | object  | No       | Upstream configuration.                                                             |
+| `routes`            | array   | No       | Route definitions.                                                                  |
+| `stream_routes`     | array   | No       | Stream (TCP/UDP) route definitions.                                                 |
+| `plugins`           | object  | No       | Service-level plugins.                                                              |
+| `path_prefix`       | string  | No       | Prefix prepended to every route URI in this service.                                |
+| `strip_path_prefix` | boolean | No       | Strip the matched route prefix before forwarding.                                   |
 
 ### Route (nested under service)
 
-| Field              | Type    | Required | Description                                  |
-| ------------------- | ------- | -------- | ---------------------------------------------- |
-| `name`             | string  | Yes      | Route name (unique within the service).       |
-| `uris`             | array   | Yes      | URI paths to match.                            |
-| `methods`          | array   | No       | HTTP methods to match.                         |
-| `hosts`            | array   | No       | Host headers to match.                         |
-| `labels`           | object  | No       | Key-value labels.                              |
-| `plugins`          | object  | No       | Route-level plugins.                           |
-| `priority`         | integer | No       | Route matching priority (higher wins).         |
-| `enable_websocket` | boolean | No       | Enable WebSocket proxying.                     |
+| Field              | Type    | Required | Description                             |
+| ------------------ | ------- | -------- | --------------------------------------- |
+| `name`             | string  | Yes      | Route name (unique within the service). |
+| `uris`             | array   | Yes      | URI paths to match.                     |
+| `methods`          | array   | No       | HTTP methods to match.                  |
+| `hosts`            | array   | No       | Host headers to match.                  |
+| `labels`           | object  | No       | Key-value labels.                       |
+| `plugins`          | object  | No       | Route-level plugins.                    |
+| `priority`         | integer | No       | Route matching priority (higher wins).  |
+| `enable_websocket` | boolean | No       | Enable WebSocket proxying.              |
 
 ### Upstream (nested under service)
 
-| Field             | Type   | Required | Description                                                             |
-| ------------------ | ------ | -------- | -------------------------------------------------------------------------- |
-| `name`            | string | No       | Upstream name.                                                          |
-| `scheme`          | string | No       | Protocol: `http`, `https`, `grpc`, `grpcs`.                             |
-| `type`            | string | No       | Load balancing algorithm: `roundrobin`, `chash`, `ewma`, `least_conn`.  |
-| `hash_on`         | string | No       | Hash key source for `chash`: `vars`, `header`, `cookie`, `consumer`.    |
-| `nodes`           | array  | Yes      | Backend nodes (`host`, `port`, `weight`, `priority`).                   |
-| `timeout`         | object | No       | Timeout settings (`connect`, `send`, `read`) in seconds.                |
-| `pass_host`       | string | No       | Host header behavior: `pass`, `node`, `rewrite`.                        |
-| `keepalive_pool`  | object | No       | Connection pool settings.                                               |
-| `retry_timeout`   | number | No       | Retry timeout in seconds (`0` = no limit).                              |
-| `checks`          | object | No       | Active/passive health check configuration.                              |
+| Field            | Type   | Required | Description                                                            |
+| ---------------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `name`           | string | No       | Upstream name.                                                         |
+| `scheme`         | string | No       | Protocol: `http`, `https`, `grpc`, `grpcs`.                            |
+| `type`           | string | No       | Load balancing algorithm: `roundrobin`, `chash`, `ewma`, `least_conn`. |
+| `hash_on`        | string | No       | Hash key source for `chash`: `vars`, `header`, `cookie`, `consumer`.   |
+| `nodes`          | array  | Yes      | Backend nodes (`host`, `port`, `weight`, `priority`).                  |
+| `timeout`        | object | No       | Timeout settings (`connect`, `send`, `read`) in seconds.               |
+| `pass_host`      | string | No       | Host header behavior: `pass`, `node`, `rewrite`.                       |
+| `keepalive_pool` | object | No       | Connection pool settings.                                              |
+| `retry_timeout`  | number | No       | Retry timeout in seconds (`0` = no limit).                             |
+| `checks`         | object | No       | Active/passive health check configuration.                             |
 
 ### Consumer
 
-| Field         | Type   | Required | Description                     |
-| -------------- | ------ | -------- | ---------------------------------- |
-| `username`    | string | Yes      | Unique consumer name.            |
-| `labels`      | object | No       | Key-value labels.                 |
-| `credentials` | array  | No       | Authentication credentials.       |
-| `plugins`     | object | No       | Consumer-level plugins.           |
+| Field         | Type   | Required | Description                 |
+| ------------- | ------ | -------- | --------------------------- |
+| `username`    | string | Yes      | Unique consumer name.       |
+| `labels`      | object | No       | Key-value labels.           |
+| `credentials` | array  | No       | Authentication credentials. |
+| `plugins`     | object | No       | Consumer-level plugins.     |
 
 ### Credential (nested under consumer)
 
-| Field    | Type   | Required | Description                                                            |
-| --------- | ------ | -------- | -------------------------------------------------------------------------- |
-| `name`   | string | Yes      | Credential name.                                                       |
+| Field    | Type   | Required | Description                                                             |
+| -------- | ------ | -------- | ----------------------------------------------------------------------- |
+| `name`   | string | Yes      | Credential name.                                                        |
 | `type`   | string | Yes      | Authentication type: `key-auth`, `basic-auth`, `jwt-auth`, `hmac-auth`. |
 | `config` | object | Yes      | Type-specific configuration.                                            |
 | `labels` | object | No       | Key-value labels.                                                       |

--- a/docs/reference/openapi-converter.md
+++ b/docs/reference/openapi-converter.md
@@ -4,10 +4,10 @@
 
 | Direction      | Supported |
 | -------------- | --------- |
-| OpenAPI to ADC | ✅        |
-| ADC to OpenAPI | ❎        |
+| OpenAPI to ADC | Yes       |
+| ADC to OpenAPI | No        |
 
-A plain OpenAPI document only describes endpoints — it has no notion of ADC-specific concepts like plugins, labels, or upstream defaults. To configure those on the converted output, annotate the specification with `x-adc-*` extension fields.
+A plain OpenAPI document only describes endpoints. It has no notion of ADC-specific concepts like plugins, labels, or upstream defaults. To configure those on the converted output, annotate the specification with `x-adc-*` extension fields.
 
 ## Supported Extension Fields
 
@@ -16,7 +16,7 @@ Extensions are recognized at up to four levels of a specification:
 - **Root level**: the root of the OAS document. Applies to the entire generated service.
 - **Path level**: on each path object. Applies to every operation (HTTP method) under that path.
 - **Operation level**: on each HTTP method object within a path. Applies to that specific route.
-- **Server level**: on each item of a `servers:` field, which can itself appear at the root, path, or operation level. Applies to the upstream node(s) derived from that server entry. Only meaningful for OpenAPI 3.x — OpenAPI 2.0 (Swagger) has no `servers:` field.
+- **Server level**: on each item of a `servers:` field, which can itself appear at the root, path, or operation level. Applies to the upstream node(s) derived from that server entry. Only meaningful for OpenAPI 3.x. OpenAPI 2.0 (Swagger) has no `servers:` field.
 
 <table>
   <thead>
@@ -95,10 +95,10 @@ Extensions are recognized at up to four levels of a specification:
 
 ```yaml
 servers:
-  - url: "https://httpbin.org"
+  - url: 'https://httpbin.org'
     x-adc-upstream-node-defaults:
       priority: 100
-  - url: "http://httpbin.org"
+  - url: 'http://httpbin.org'
     x-adc-upstream-node-defaults:
       priority: 100
 ```
@@ -217,6 +217,7 @@ The difference between the two:
 <td>
 
 ```yaml
+
 ...
 paths:
   /anything:
@@ -230,6 +231,7 @@ paths:
 <td>
 
 ```yaml
+
 ...
 services:
   - name: demo
@@ -280,6 +282,7 @@ paths:
 <td>
 
 ```yaml
+
 ...
 services:
   - name: demo
@@ -349,11 +352,14 @@ Running `adc convert openapi -f openapi.yaml -o adc.yaml` produces:
 ```yaml title="adc.yaml"
 services:
   - description: httpbin API example.
-    labels:                              # inherited from root x-adc-labels
+    # inherited from root x-adc-labels
+    labels:
       api: httpbin
       server: production
-    name: httpbin-API_anything*_get      # auto-generated from title + path + method
-    plugins:                             # inherited from root x-adc-plugins
+    # auto-generated from title + path + method
+    name: httpbin-API_anything*_get
+    # inherited from root x-adc-plugins
+    plugins:
       key-auth:
         _meta:
           disable: false
@@ -361,18 +367,22 @@ services:
       - description: Returns anything that is passed into the request.
         methods:
           - GET
-        name: httpbin-anything           # from operation x-adc-name
+        # from operation x-adc-name
+        name: httpbin-anything
         uris:
-          - /api/anything/*              # path_prefix from x-adc-service-defaults is
-                                          # inlined into the URI for APISIX compatibility
+          # path_prefix from x-adc-service-defaults is inlined into the URI
+          # for APISIX compatibility
+          - /api/anything/*
     upstream:
       nodes:
-        - host: httpbin.org              # derived from servers[0].url
+        # derived from servers[0].url
+        - host: httpbin.org
           port: 80
           weight: 100
       pass_host: pass
       scheme: http
-      timeout:                           # from operation x-adc-upstream-defaults
+      # from operation x-adc-upstream-defaults
+      timeout:
         connect: 10
         read: 10
         send: 10


### PR DESCRIPTION
## Summary

- Restructure the ADC README and docs entry points for a clearer user flow
- Rewrite workflow, label selector, resource ID, CLI, configuration, and OpenAPI converter references
- Preserve product-authored details from the original draft while making behavior easier to scan and verify from source/tests

## Information preservation

- Rechecked this PR against the original `bzp/docs-initial` draft before marking it ready.
- No product-authored operational information was intentionally removed; content was moved into a clearer guide/reference structure, condensed where repetitive, or corrected where source code showed a more precise behavior.
- The main retained topics are backend setup, `.env`/flag precedence, common commands, `dump --with-id`, resource ID behavior, label selector remote filtering and local label injection, OpenAPI conversion, `x-adc-*` extension behavior, and backend/component references.

## Source / test check

- Checked CLI flags and environment variables against `apps/cli/src/command/*`.
- Checked label selector behavior against local loading/filtering code and API7/APISIX remote filtering paths.
- Checked resource ID behavior against SDK differ metadata and differ/backend tests.
- Checked OpenAPI converter behavior against `libs/converter-openapi/src/*` and the converter test fixtures.

## Validation

- `pnpm exec prettier --check README.md docs/README.md docs/guides/workflow.md docs/guides/resource-ids.md docs/guides/label-selector.md docs/reference/cli.md docs/reference/configuration.md docs/reference/openapi-converter.md`
- `git diff --check`
- `pnpm exec nx test converter-openapi`

## Notes

This PR targets `bzp/docs-initial` so the changes can be merged back into the original docs draft PR before updating that PR title/body.