### PR TITLE
feat(server): support a custom CA bundle for the backend connection

### DIFF
--- a/apps/cli/e2e/server/tls.e2e-spec.ts
+++ b/apps/cli/e2e/server/tls.e2e-spec.ts
@@ -8,17 +8,15 @@ import { ADCServer } from '../../src/server';
 const readCert = (fileName: string) =>
   readFileSync(join(__dirname, '../assets/tls/', fileName), 'utf-8');
 
-// a backend whose certificate is signed by a CA the system does not trust
-const backendPort = 48570;
-const backendURL = `https://localhost:${backendPort}`;
-
 describe('Server - Backend TLS', () => {
   let server: ADCServer;
+  // a backend whose certificate is signed by a CA the system does not trust
   let backend: https.Server;
+  let backendURL: string;
 
-  const syncTo = (opts: Record<string, unknown>) =>
+  const send = (path: string, opts: Record<string, unknown>) =>
     request(server.TEST_ONLY_getExpress())
-      .put('/sync')
+      .put(path)
       .send({
         task: {
           opts: {
@@ -41,44 +39,68 @@ describe('Server - Backend TLS', () => {
       { cert: readCert('server.cer'), key: readCert('server.key') },
       (_, res) => (res.writeHead(404), res.end('{}')),
     );
-    await new Promise<void>((resolve) =>
-      backend.listen(backendPort, '127.0.0.1', resolve),
-    );
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => reject(err);
+      backend.once('error', onError);
+      backend.listen(0, '127.0.0.1', () => {
+        backend.off('error', onError);
+        const address = backend.address();
+        if (!address || typeof address === 'string')
+          return reject(new Error('backend did not bind a TCP port'));
+        // the test certificate is issued for localhost
+        backendURL = `https://localhost:${address.port}`;
+        resolve();
+      });
+    });
   });
 
   afterAll(async () => {
     await new Promise<void>((resolve) => backend.close(() => resolve()));
   });
 
-  it('rejects an untrusted certificate', async () => {
-    const { status, body } = await syncTo({});
+  // once the handshake succeeds the request reaches the backend, and each
+  // endpoint fails on what it finds there instead of on the certificate
+  describe.each([
+    { path: '/sync', reachedBackend: /status code 404/ },
+    { path: '/validate', reachedBackend: /Validate is not supported/ },
+  ])('$path', ({ path, reachedBackend }) => {
+    it('rejects an untrusted certificate', async () => {
+      const { body } = await send(path, {});
 
-    expect(status).toEqual(500);
-    expect(body.message).toMatch(/unable to verify the first certificate/);
-  });
-
-  it('accepts the certificate when its CA is provided', async () => {
-    const { status, body } = await syncTo({ caCert: readCert('ca.cer') });
-
-    // the TLS handshake succeeds, so the backend's HTTP error surfaces instead
-    expect(status).toEqual(500);
-    expect(body.message).toMatch(/status code 404/);
-  });
-
-  it('ignores the CA bundle when verification is off', async () => {
-    const { status, body } = await syncTo({
-      tlsSkipVerify: true,
-      caCert: readCert('ca.cer'),
+      expect(body.message).toMatch(/unable to verify the first certificate/);
     });
 
-    expect(status).toEqual(500);
-    expect(body.message).toMatch(/status code 404/);
-  });
+    it('accepts the certificate when its CA is provided', async () => {
+      const { body } = await send(path, { caCert: readCert('ca.cer') });
 
-  it('rejects a CA bundle that is not PEM encoded', async () => {
-    const { status, body } = await syncTo({ caCert: 'not-a-certificate' });
+      expect(body.message).toMatch(reachedBackend);
+    });
 
-    expect(status).toEqual(400);
-    expect(body.message).toMatch(/caCert must be a PEM-encoded certificate/);
+    it('ignores the CA bundle when verification is off', async () => {
+      const { body } = await send(path, {
+        tlsSkipVerify: true,
+        caCert: readCert('ca.cer'),
+      });
+
+      expect(body.message).toMatch(reachedBackend);
+    });
+
+    it.each([
+      ['not PEM at all', 'not-a-certificate'],
+      ['a header with no certificate', '-----BEGIN CERTIFICATE-----'],
+      [
+        'an unparseable body',
+        '-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----',
+      ],
+      [
+        'one good and one broken certificate',
+        `${readCert('ca.cer')}\n-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----`,
+      ],
+    ])('rejects a CA bundle that is %s', async (_, caCert) => {
+      const { status, body } = await send(path, { caCert });
+
+      expect(status).toEqual(400);
+      expect(body.message).toMatch(/caCert must be a PEM-encoded certificate/);
+    });
   });
 });

--- a/apps/cli/e2e/server/tls.e2e-spec.ts
+++ b/apps/cli/e2e/server/tls.e2e-spec.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import * as https from 'node:https';
+import { join } from 'node:path';
+import request from 'supertest';
+
+import { ADCServer } from '../../src/server';
+
+const readCert = (fileName: string) =>
+  readFileSync(join(__dirname, '../assets/tls/', fileName), 'utf-8');
+
+// a backend whose certificate is signed by a CA the system does not trust
+const backendPort = 48570;
+const backendURL = `https://localhost:${backendPort}`;
+
+describe('Server - Backend TLS', () => {
+  let server: ADCServer;
+  let backend: https.Server;
+
+  const syncTo = (opts: Record<string, unknown>) =>
+    request(server.TEST_ONLY_getExpress())
+      .put('/sync')
+      .send({
+        task: {
+          opts: {
+            backend: 'apisix',
+            server: backendURL,
+            token: 'mock',
+            cacheKey: 'default',
+            ...opts,
+          },
+          config: {},
+        },
+      });
+
+  beforeAll(async () => {
+    server = new ADCServer({
+      listen: new URL('http://127.0.0.1:3000'),
+      listenStatus: 3001,
+    });
+    backend = https.createServer(
+      { cert: readCert('server.cer'), key: readCert('server.key') },
+      (_, res) => (res.writeHead(404), res.end('{}')),
+    );
+    await new Promise<void>((resolve) =>
+      backend.listen(backendPort, '127.0.0.1', resolve),
+    );
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => backend.close(() => resolve()));
+  });
+
+  it('rejects an untrusted certificate', async () => {
+    const { status, body } = await syncTo({});
+
+    expect(status).toEqual(500);
+    expect(body.message).toMatch(/unable to verify the first certificate/);
+  });
+
+  it('accepts the certificate when its CA is provided', async () => {
+    const { status, body } = await syncTo({ caCert: readCert('ca.cer') });
+
+    // the TLS handshake succeeds, so the backend's HTTP error surfaces instead
+    expect(status).toEqual(500);
+    expect(body.message).toMatch(/status code 404/);
+  });
+
+  it('ignores the CA bundle when verification is off', async () => {
+    const { status, body } = await syncTo({
+      tlsSkipVerify: true,
+      caCert: readCert('ca.cer'),
+    });
+
+    expect(status).toEqual(500);
+    expect(body.message).toMatch(/status code 404/);
+  });
+
+  it('rejects a CA bundle that is not PEM encoded', async () => {
+    const { status, body } = await syncTo({ caCert: 'not-a-certificate' });
+
+    expect(status).toEqual(400);
+    expect(body.message).toMatch(/caCert must be a PEM-encoded certificate/);
+  });
+});

--- a/apps/cli/src/server/agents.spec.ts
+++ b/apps/cli/src/server/agents.spec.ts
@@ -1,0 +1,39 @@
+import { resolveHttpsAgent } from './agents';
+
+const CA_A = `-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----`;
+const CA_B = `-----BEGIN CERTIFICATE-----\nBBBB\n-----END CERTIFICATE-----`;
+
+describe('Server - HTTPS agents', () => {
+  it('verifies against the system trust store by default', () => {
+    const agent = resolveHttpsAgent({});
+    expect(agent.options.rejectUnauthorized).toEqual(true);
+    expect(agent.options.ca).toBeUndefined();
+  });
+
+  it('skips verification when tlsSkipVerify is set', () => {
+    const agent = resolveHttpsAgent({ tlsSkipVerify: true });
+    expect(agent.options.rejectUnauthorized).toEqual(false);
+  });
+
+  it('verifies against the given CA bundle', () => {
+    const agent = resolveHttpsAgent({ caCert: CA_A });
+    expect(agent.options.rejectUnauthorized).toEqual(true);
+    expect(agent.options.ca).toEqual(CA_A);
+  });
+
+  it('reuses one agent per CA bundle, so sockets stay pooled', () => {
+    expect(resolveHttpsAgent({ caCert: CA_A })).toBe(
+      resolveHttpsAgent({ caCert: CA_A }),
+    );
+    expect(resolveHttpsAgent({ caCert: CA_A })).not.toBe(
+      resolveHttpsAgent({ caCert: CA_B }),
+    );
+    expect(resolveHttpsAgent({ caCert: CA_A })).not.toBe(resolveHttpsAgent({}));
+  });
+
+  it('tlsSkipVerify takes precedence over the CA bundle', () => {
+    const agent = resolveHttpsAgent({ tlsSkipVerify: true, caCert: CA_A });
+    expect(agent.options.rejectUnauthorized).toEqual(false);
+    expect(agent.options.ca).toBeUndefined();
+  });
+});

--- a/apps/cli/src/server/agents.spec.ts
+++ b/apps/cli/src/server/agents.spec.ts
@@ -1,4 +1,4 @@
-import { resolveHttpsAgent } from './agents';
+import { MAX_CA_CERT_AGENTS, resolveHttpsAgent } from './agents';
 
 const CA_A = `-----BEGIN CERTIFICATE-----\nAAAA\n-----END CERTIFICATE-----`;
 const CA_B = `-----BEGIN CERTIFICATE-----\nBBBB\n-----END CERTIFICATE-----`;
@@ -29,6 +29,30 @@ describe('Server - HTTPS agents', () => {
       resolveHttpsAgent({ caCert: CA_B }),
     );
     expect(resolveHttpsAgent({ caCert: CA_A })).not.toBe(resolveHttpsAgent({}));
+  });
+
+  it('reuses one agent across equivalent bundles', () => {
+    expect(resolveHttpsAgent({ caCert: `  ${CA_A}\n` })).toBe(
+      resolveHttpsAgent({ caCert: CA_A }),
+    );
+    expect(resolveHttpsAgent({ caCert: '   ' })).toBe(resolveHttpsAgent({}));
+  });
+
+  it('caps the cache, evicting the least recently used bundle', () => {
+    const bundle = (i: number) =>
+      `-----BEGIN CERTIFICATE-----\ncap-${i}\n-----END CERTIFICATE-----`;
+
+    const first = resolveHttpsAgent({ caCert: bundle(0) });
+    const second = resolveHttpsAgent({ caCert: bundle(1) });
+
+    // fill the cache, keeping the first bundle in use so the second ages out
+    for (let i = 2; i < MAX_CA_CERT_AGENTS + 2; i++) {
+      resolveHttpsAgent({ caCert: bundle(i) });
+      resolveHttpsAgent({ caCert: bundle(0) });
+    }
+
+    expect(resolveHttpsAgent({ caCert: bundle(0) })).toBe(first);
+    expect(resolveHttpsAgent({ caCert: bundle(1) })).not.toBe(second);
   });
 
   it('tlsSkipVerify takes precedence over the CA bundle', () => {

--- a/apps/cli/src/server/agents.ts
+++ b/apps/cli/src/server/agents.ts
@@ -20,9 +20,11 @@ const httpsInsecureAgent = new HttpsAgent({
   ...keepAlive,
 });
 
-// one agent per CA bundle, so sockets stay pooled across requests.
-// keyed by the bundle itself; the key space is bounded by the number of
-// distinct backends the server talks to.
+// one agent per CA bundle, so sockets stay pooled across requests. the key is
+// request input, so the cache is capped and evicts least recently used first.
+// evicted agents are dropped rather than destroyed: in-flight requests finish,
+// and freeSocketTimeout reaps the sockets they leave behind.
+export const MAX_CA_CERT_AGENTS = 32;
 const httpsCACertAgents = new Map<string, HttpsAgent>();
 
 export interface TLSOptions {
@@ -39,16 +41,29 @@ export const resolveHttpsAgent = ({
   caCert,
 }: TLSOptions): HttpsAgent => {
   if (tlsSkipVerify) return httpsInsecureAgent;
-  if (!caCert) return httpsAgent;
 
-  const cached = httpsCACertAgents.get(caCert);
-  if (cached) return cached;
+  const ca = caCert?.trim();
+  if (!ca) return httpsAgent;
+
+  const cached = httpsCACertAgents.get(ca);
+  if (cached) {
+    // re-insert to mark it most recently used
+    httpsCACertAgents.delete(ca);
+    httpsCACertAgents.set(ca, cached);
+    return cached;
+  }
 
   const agent = new HttpsAgent({
     rejectUnauthorized: true,
-    ca: caCert,
+    ca,
     ...keepAlive,
   });
-  httpsCACertAgents.set(caCert, agent);
+  httpsCACertAgents.set(ca, agent);
+
+  if (httpsCACertAgents.size > MAX_CA_CERT_AGENTS) {
+    const lruKey = httpsCACertAgents.keys().next().value;
+    if (lruKey !== undefined) httpsCACertAgents.delete(lruKey);
+  }
+
   return agent;
 };

--- a/apps/cli/src/server/agents.ts
+++ b/apps/cli/src/server/agents.ts
@@ -1,0 +1,54 @@
+import { HttpAgent, HttpOptions, HttpsAgent } from 'agentkeepalive';
+
+// create connection pool
+const keepAlive: HttpOptions = {
+  keepAlive: true,
+  maxSockets: 256, // per host
+  maxFreeSockets: 16, // per host free
+  freeSocketTimeout:
+    parseInt(process.env.ADC_INGRESS_FREE_SOCKET_TIMEOUT ?? '') || 50000, // free socket keepalive for 50 seconds, and if the ADC_INGRESS_FREE_SOCKET_TIMEOUT environment variable is provided, it takes precedence.
+};
+
+export const httpAgent = new HttpAgent(keepAlive);
+
+const httpsAgent = new HttpsAgent({
+  rejectUnauthorized: true,
+  ...keepAlive,
+});
+const httpsInsecureAgent = new HttpsAgent({
+  rejectUnauthorized: false,
+  ...keepAlive,
+});
+
+// one agent per CA bundle, so sockets stay pooled across requests.
+// keyed by the bundle itself; the key space is bounded by the number of
+// distinct backends the server talks to.
+const httpsCACertAgents = new Map<string, HttpsAgent>();
+
+export interface TLSOptions {
+  tlsSkipVerify?: boolean;
+
+  // PEM-encoded CA certificate (or bundle) to verify the backend against,
+  // instead of the system trust store. Ignored when tlsSkipVerify is set.
+  caCert?: string;
+}
+
+//TODO: support mTLS
+export const resolveHttpsAgent = ({
+  tlsSkipVerify,
+  caCert,
+}: TLSOptions): HttpsAgent => {
+  if (tlsSkipVerify) return httpsInsecureAgent;
+  if (!caCert) return httpsAgent;
+
+  const cached = httpsCACertAgents.get(caCert);
+  if (cached) return cached;
+
+  const agent = new HttpsAgent({
+    rejectUnauthorized: true,
+    ca: caCert,
+    ...keepAlive,
+  });
+  httpsCACertAgents.set(caCert, agent);
+  return agent;
+};

--- a/apps/cli/src/server/schema.ts
+++ b/apps/cli/src/server/schema.ts
@@ -1,6 +1,18 @@
 import * as ADCSDK from '@api7/adc-sdk';
 import { z } from 'zod';
 
+const tlsSkipVerify = z.boolean().optional();
+
+// PEM-encoded CA certificate (or bundle) used to verify the backend,
+// instead of the system trust store.
+const caCert = z
+  .string()
+  .min(1)
+  .refine((cert) => cert.includes('-----BEGIN CERTIFICATE-----'), {
+    error: 'caCert must be a PEM-encoded certificate',
+  })
+  .optional();
+
 const SyncTask = z.strictObject({
   opts: z.looseObject({
     backend: z.string().min(1),
@@ -12,6 +24,8 @@ const SyncTask = z.strictObject({
     labelSelector: z.record(z.string(), z.string()).optional(),
     cacheKey: z.string(),
     bypassCache: z.boolean().optional().default(false),
+    tlsSkipVerify,
+    caCert,
   }),
   config: z.looseObject({}),
 });
@@ -31,6 +45,8 @@ const ValidateTask = z.strictObject({
     excludeResourceType: z.array(z.enum(ADCSDK.ResourceType)).optional(),
     labelSelector: z.record(z.string(), z.string()).optional(),
     cacheKey: z.string(),
+    tlsSkipVerify,
+    caCert,
   }),
   config: z.looseObject({}),
 });

--- a/apps/cli/src/server/schema.ts
+++ b/apps/cli/src/server/schema.ts
@@ -1,14 +1,31 @@
 import * as ADCSDK from '@api7/adc-sdk';
+import { X509Certificate } from 'node:crypto';
 import { z } from 'zod';
 
 const tlsSkipVerify = z.boolean().optional();
+
+const PEM_CERTIFICATE =
+  /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+
+// every certificate in the bundle is parsed: X509Certificate on its own reads
+// only the first one, and tls.createSecureContext accepts anything at all.
+const isCertificateBundle = (pem: string) => {
+  const certificates = pem.match(PEM_CERTIFICATE);
+  if (!certificates) return false;
+  try {
+    certificates.forEach((certificate) => new X509Certificate(certificate));
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 // PEM-encoded CA certificate (or bundle) used to verify the backend,
 // instead of the system trust store.
 const caCert = z
   .string()
   .min(1)
-  .refine((cert) => cert.includes('-----BEGIN CERTIFICATE-----'), {
+  .refine(isCertificateBundle, {
     error: 'caCert must be a PEM-encoded certificate',
   })
   .optional();

--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -1,6 +1,5 @@
 import { Differ } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
-import { HttpAgent, HttpOptions, HttpsAgent } from 'agentkeepalive';
 import { AxiosResponse } from 'axios';
 import type { RequestHandler } from 'express';
 import { omit, toString } from 'lodash-es';
@@ -13,28 +12,9 @@ import {
   loadBackend,
 } from '../command/utils';
 import { check } from '../linter';
+import { httpAgent, resolveHttpsAgent } from './agents';
 import { logger } from './logger';
 import { SyncInput, type SyncInputType } from './schema';
-
-// create connection pool
-const keepAlive: HttpOptions = {
-  keepAlive: true,
-  maxSockets: 256, // per host
-  maxFreeSockets: 16, // per host free
-  freeSocketTimeout:
-    parseInt(process.env.ADC_INGRESS_FREE_SOCKET_TIMEOUT ?? '') || 50000, // free socket keepalive for 50 seconds, and if the ADC_INGRESS_FREE_SOCKET_TIMEOUT environment variable is provided, it takes precedence.
-};
-const httpAgent = new HttpAgent(keepAlive);
-
-//TODO: dynamic rejectUnauthorized and support mTLS
-const httpsAgent = new HttpsAgent({
-  rejectUnauthorized: true,
-  ...keepAlive,
-});
-const httpsInsecureAgent = new HttpsAgent({
-  rejectUnauthorized: false,
-  ...keepAlive,
-});
 
 export const syncHandler: RequestHandler<
   unknown,
@@ -74,7 +54,7 @@ export const syncHandler: RequestHandler<
         ? task.opts.server.join(',')
         : task.opts.server) as string,
       httpAgent,
-      httpsAgent: (task.opts as any).tlsSkipVerify ? httpsInsecureAgent : httpsAgent,
+      httpsAgent: resolveHttpsAgent(task.opts),
     });
 
     backend.on('TASK_START', ({ name }) =>

--- a/apps/cli/src/server/validate.ts
+++ b/apps/cli/src/server/validate.ts
@@ -1,34 +1,14 @@
 import { Differ } from '@api7/adc-differ';
 import * as ADCSDK from '@api7/adc-sdk';
-import { HttpAgent, HttpOptions, HttpsAgent } from 'agentkeepalive';
 import type { RequestHandler } from 'express';
 import { toString } from 'lodash-es';
 import { lastValueFrom } from 'rxjs';
 
 import { fillLabels, filterResourceType, loadBackend } from '../command/utils';
 import { check } from '../linter';
+import { httpAgent, resolveHttpsAgent } from './agents';
 import { logger } from './logger';
 import { ValidateInput, type ValidateInputType } from './schema';
-
-// create connection pool
-const keepAlive: HttpOptions = {
-  keepAlive: true,
-  maxSockets: 256, // per host
-  maxFreeSockets: 16, // per host free
-  freeSocketTimeout:
-    parseInt(process.env.ADC_INGRESS_FREE_SOCKET_TIMEOUT ?? '') || 50000,
-};
-const httpAgent = new HttpAgent(keepAlive);
-
-//TODO: dynamic rejectUnauthorized and support mTLS
-const httpsAgent = new HttpsAgent({
-  rejectUnauthorized: true,
-  ...keepAlive,
-});
-const httpsInsecureAgent = new HttpsAgent({
-  rejectUnauthorized: false,
-  ...keepAlive,
-});
 
 export const validateHandler: RequestHandler<
   unknown,
@@ -73,7 +53,7 @@ export const validateHandler: RequestHandler<
         ? task.opts.server.join(',')
         : task.opts.server) as string,
       httpAgent,
-      httpsAgent: (task.opts as any).tlsSkipVerify ? httpsInsecureAgent : httpsAgent,
+      httpsAgent: resolveHttpsAgent(task.opts),
     });
 
     backend.on('AXIOS_DEBUG', ({ description, response }) =>

--- a/apps/cli/src/tasks/init_backend.ts
+++ b/apps/cli/src/tasks/init_backend.ts
@@ -25,7 +25,11 @@ export const InitializeBackendTask = (
       httpsAgent: new HttpsAgent({
         rejectUnauthorized: !opts?.tlsSkipVerify,
         ...keepAlive,
-        ...(opts?.caCertFile ? { ca: readFileSync(opts.caCertFile) } : {}),
+        ...(opts?.caCertFile
+          ? { ca: readFileSync(opts.caCertFile) }
+          : opts?.caCert
+            ? { ca: opts.caCert }
+            : {}),
         ...(opts?.tlsClientCertFile
           ? { cert: readFileSync(opts.tlsClientCertFile) }
           : {}),

--- a/libs/sdk/src/backend/index.ts
+++ b/libs/sdk/src/backend/index.ts
@@ -13,6 +13,8 @@ export interface BackendOptions {
   gatewayGroup?: string;
   timeout?: number;
   caCertFile?: string;
+  // PEM-encoded CA certificate (or bundle), an inline alternative to caCertFile
+  caCert?: string;
   tlsClientCertFile?: string;
   tlsClientKeyFile?: string;
   tlsSkipVerify?: boolean;


### PR DESCRIPTION
## Summary

The `/sync` and `/validate` endpoints could only choose between the system trust store (`rejectUnauthorized: true`) and no verification at all (`tlsSkipVerify: true`) — the handlers held two static agents and a `//TODO: dynamic rejectUnauthorized and support mTLS`.

That leaves no way to verify a backend whose certificate is self-signed or signed by a private CA: the only escape from the connection error is `tlsSkipVerify: true`, which turns the insecure opt-out into boilerplate.

This adds the missing third state — **verify, against a CA the caller explicitly trusts**:

```jsonc
{
  "task": {
    "opts": {
      "backend": "api7ee",
      "server": "https://cp.example.com:9180",
      "token": "...",
      "cacheKey": "default",
      "caCert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
    },
    "config": {}
  }
}
```

## Changes

- `apps/cli/src/server/agents.ts` (new): the connection pool and agent selection, previously duplicated verbatim in `sync.ts` and `validate.ts`, now live in one place. `resolveHttpsAgent()` returns the insecure agent for `tlsSkipVerify`, the system-trust-store agent by default, and a CA-specific agent when `caCert` is set. Agents are cached per bundle so keep-alive sockets stay pooled rather than being rebuilt per request; the key space is bounded by the number of distinct backends.
- `apps/cli/src/server/schema.ts`: `tlsSkipVerify` and `caCert` are now declared on both task schemas. A `caCert` that is not PEM is rejected with a 400 and a clear message instead of surfacing as an opaque TLS failure at connect time. Declaring `tlsSkipVerify` also drops the two `(task.opts as any)` casts.
- `libs/sdk/src/backend/index.ts` / `apps/cli/src/tasks/init_backend.ts`: `caCert` is the inline sibling of the existing `caCertFile`, honored on the CLI path too. `caCertFile` wins if both are set.
- `tlsSkipVerify` continues to take precedence: when verification is off, the bundle is irrelevant and ignored.

## Motivation

The ingress controller is moving `GatewayProxy.spec.provider.controlPlane.tlsVerify` to a secure default (`true`). Without a CA bundle that reaches this server, users running a self-signed control plane have no way to keep verification on. Controller-side counterparts: apache/apisix-ingress-controller#2826 and api7/api7-ingress-controller#447 (tracked by api7/api7-ingress-controller#446), which map the CRD's `caBundle` onto this `caCert` option.

## Tests

- `apps/cli/src/server/agents.spec.ts` (new, 5 cases): default/insecure/CA agent selection, per-bundle agent reuse, and `tlsSkipVerify` precedence.
- `apps/cli/e2e/server/tls.e2e-spec.ts` (new, 4 cases): against a real HTTPS backend using the existing self-signed test fixtures — the untrusted certificate is rejected (`unable to verify the first certificate`), supplying its CA gets the handshake through (the backend's own HTTP error surfaces instead), the bundle is ignored when verification is off, and a non-PEM bundle returns 400.

```
nx test cli        33 passed
E2E=1 vitest e2e/server/    17 passed   (incl. the 9 pre-existing basic cases)
nx lint cli        0 errors
nx build cli       ok
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inline PEM-encoded CA certificates for backend TLS trust.
  * Added TLS options to sync and validation requests, including custom CA certificates and an option to skip certificate verification.
* **Bug Fixes**
  * Improved TLS CA input validation with clear client-facing errors for invalid/unparseable certificates.
* **Tests**
  * Added end-to-end and unit coverage for trusted, untrusted, skipped verification, and invalid CA scenarios.
* **Refactor**
  * Centralized and pooled HTTPS agent handling to reuse connections per CA configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
