### PR TITLE
feat(docker): reduce base image vulnerabilities

### DIFF
--- a/libs/tools/src/docker/Dockerfile
+++ b/libs/tools/src/docker/Dockerfile
@@ -13,8 +13,8 @@ RUN pnpm install nx -g \
   && pnpm install \
   && NODE_ENV=production nx build cli
 
-FROM node:lts-bookworm-slim
+FROM gcr.io/distroless/nodejs24-debian13:nonroot
 
 COPY --from=builder /build/dist/apps/cli/main.cjs .
 
-ENTRYPOINT [ "node", "main.cjs" ]
+ENTRYPOINT [ "/nodejs/bin/node", "main.cjs" ]


### PR DESCRIPTION
### Description

Switch the base image to `gcr.io/distroless/nodejs24-debian13:nonroot`. This will reduce the number of vulnerabilities in the base image to 0, and since ADC itself does not introduce any vulnerabilities, all vulnerabilities have been eliminated.

The trade-off is that the image now does not include any shell, package manager, or unnecessary packages. Therefore, it is no longer possible to use commands like `docker exec` to access the container shell for debugging. However, launching the inspector using Node.js options is still possible.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the application’s runtime container to use a slimmer, security-focused base image.
  * Preserved existing startup behavior while improving the production container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->