### PR TITLE
fix(apisix): use req_headers for active health checks

### DIFF
--- a/apps/cli/src/linter/specs/upstream.spec.ts
+++ b/apps/cli/src/linter/specs/upstream.spec.ts
@@ -129,6 +129,41 @@ describe('Upstream Linter', () => {
       expect: true,
     },
     {
+      name: 'should accept req_headers on active health check',
+      input: {
+        services: [
+          {
+            name: 'HealthCheck_RequestHeaders',
+            upstream: {
+              nodes: [
+                {
+                  host: '1.1.1.1',
+                  port: 443,
+                  weight: 100,
+                },
+              ],
+              checks: {
+                active: {
+                  type: 'https',
+                  http_path: '/',
+                  req_headers: ['User-Agent: adc-health-check'],
+                  healthy: {
+                    interval: 2,
+                    successes: 1,
+                  },
+                  unhealthy: {
+                    interval: 1,
+                    timeouts: 3,
+                  },
+                },
+              },
+            },
+          },
+        ],
+      } as ADCSDK.Configuration,
+      expect: true,
+    },
+    {
       name: 'should only allow upstream mtls in client_cert and client_key',
       input: {
         services: [

--- a/libs/backend-apisix-standalone/src/typing.ts
+++ b/libs/backend-apisix-standalone/src/typing.ts
@@ -147,7 +147,7 @@ const UpstreamSchema = z.strictObject({
         port: z.coerce.number().int().min(1).max(65535).optional(),
         http_path: z.string().default('/').optional(),
         https_verify_certificate: z.boolean().default(true).optional(),
-        http_request_headers: z.array(z.string()).min(1).optional(),
+        req_headers: z.array(z.string()).min(1).optional(),
         healthy: z
           .strictObject({
             ...upstreamHealthCheckPassiveHealthy.shape,

--- a/libs/sdk/src/core/schema.ts
+++ b/libs/sdk/src/core/schema.ts
@@ -123,7 +123,7 @@ const upstreamSchema = (extend?: ZodRawShape) =>
             port: portSchema.optional(),
             http_path: z.string().default('/').optional(),
             https_verify_certificate: z.boolean().default(true).optional(),
-            http_request_headers: z.array(z.string()).min(1).optional(),
+            req_headers: z.array(z.string()).min(1).optional(),
             healthy: z
               .strictObject({
                 ...upstreamHealthCheckPassiveHealthy.shape,

--- a/schema.json
+++ b/schema.json
@@ -128,7 +128,7 @@
                         "default": true,
                         "type": "boolean"
                       },
-                      "http_request_headers": {
+                      "req_headers": {
                         "minItems": 1,
                         "type": "array",
                         "items": {
@@ -560,7 +560,7 @@
                           "default": true,
                           "type": "boolean"
                         },
-                        "http_request_headers": {
+                        "req_headers": {
                           "minItems": 1,
                           "type": "array",
                           "items": {


### PR DESCRIPTION
### Description

Apache APISIX defines custom request headers for active upstream health checks as `checks.active.req_headers`, but ADC currently defines the field as `http_request_headers` in both its configuration schema and APISIX standalone typing.

Because these schemas use `z.strictObject`, a valid APISIX configuration containing `req_headers` is rejected by `adc lint`, `adc sync`, and other commands that run the local lint stage. Conversely, the ADC-only field name cannot be accepted by the APISIX upstream schema.

The canonical APISIX field is defined in [`apisix/schema_def.lua`](https://github.com/apache/apisix/blob/b8738ef13e4b074dfa993aaeb154096c40e9ebca/apisix/schema_def.lua#L231-L239) and documented as [`upstream.checks.active.req_headers`](https://apisix.apache.org/docs/apisix/3.15/tutorials/health-check/).

### Environment

- Affected ADC image: `ghcr.io/api7/adc:0.27.1`
- Image digest: `sha256:f65f53dd966827ff485471d00b9ce8ca146f7aba187519817b7453e476a274b8`
- ADC base commit tested before the fix: `99142525450f`
- Host: macOS 26.5.1, arm64
- Docker client/server: 29.5.2 / 28.4.0
- Node.js: 22.22.3
- pnpm: 11.17.0

The reproduction only uses `adc lint`, so it does not require a running APISIX instance.

### Why this update is needed

APISIX has used `req_headers` for active health-check request headers across its supported upstream schema. ADC's `http_request_headers` name does not match the Admin API/standalone configuration contract.

This mismatch currently requires downstream users to patch the compiled `/main.cjs` bundle with `sed`. Fixing the source schemas removes that image-level workaround and keeps ADC configuration validation aligned with APISIX.

### How to reproduce

Create `adc.yaml`:

```yaml
services:
  - name: health-check-service
    upstream:
      nodes:
        - host: 127.0.0.1
          port: 8080
          weight: 1
      checks:
        active:
          type: http
          http_path: /health
          req_headers:
            - "User-Agent: adc-health-check"
```

Run ADC 0.27.1:

```bash
docker run --rm \
  -v "$PWD/adc.yaml:/work/adc.yaml:ro" \
  ghcr.io/api7/adc:0.27.1 \
  lint -f /work/adc.yaml
```

Actual result before this change (exit status 1):

```text
The following errors were found in configuration:
✖ Unrecognized key: "req_headers"
  → at services[0].upstream.checks.active
```

Expected result:

```text
All is well, see you next time!
```

The locally built CLI with this change returns exit status 0 for the same file.

### Changes

- Rename `http_request_headers` to `req_headers` in the SDK upstream schema.
- Rename the field in APISIX standalone upstream typing.
- Regenerate `schema.json` so both inline and referenced upstream definitions expose `req_headers`.
- Add a CLI linter regression test that validates an active health check with `req_headers`.

### Verification

```bash
pnpm exec vitest run apps/cli/src/linter/specs/upstream.spec.ts \
  --config apps/cli/vitest.config.ts
pnpm exec nx run cli:test --skip-nx-cache
pnpm exec nx run sdk:test --skip-nx-cache
pnpm exec nx run-many --target=typecheck --all --skip-nx-cache
pnpm exec nx run-many --target=lint --all --skip-nx-cache
pnpm exec nx run cli:build --configuration=production --skip-nx-cache
```

Results:

- Targeted upstream linter tests: 8 passed.
- CLI unit tests: 29 passed.
- SDK unit tests: 11 passed.
- Type checking: all 7 projects passed.
- Lint: all targets passed with pre-existing warnings only and no errors.
- Production CLI build: passed.
- Built `dist/apps/cli/main.cjs`: 2 occurrences of `req_headers:` and 0 occurrences of `http_request_headers:`.
- ADC 0.27.1 reproduction: failed as expected with exit status 1.
- Fixed local build: passed the same configuration with exit status 0.

### Compatibility

This intentionally replaces the incorrect ADC-only field name. Configurations using `http_request_headers` must rename it to `req_headers`; the old name is not valid in the APISIX upstream schema and cannot be synchronized successfully to APISIX.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the generated schema documentation to reflect this change
- [ ] I have verified that this change is backward compatible (see compatibility note above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring request headers on HTTPS active health checks using the `req_headers` setting.

* **Bug Fixes**
  * Updated configuration validation to consistently recognize `req_headers` for services and upstreams.
  * Added validation coverage to ensure valid request-header configurations pass linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->