### PR TITLE
fix: api7 format fp numbers for timeout correctly

### DIFF
--- a/rust/crates/adc-backend-api7/src/typing.rs
+++ b/rust/crates/adc-backend-api7/src/typing.rs
@@ -31,8 +31,37 @@ use adc_sdk::resources::{
     Expr, Plugins, SslClient, SslType, Timeout, UpstreamBalancer, UpstreamHealthCheck,
     UpstreamKeepalivePool, UpstreamNode, UpstreamPassHost, UpstreamScheme, UpstreamTls,
 };
-use serde::{Deserialize, Serialize};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
+
+/// API7's `UpstreamTimeout.{connect,send,read}` fields are `int` on
+/// some old gateway versions; `serde_json` always emits a decimal point
+/// for an `f64`, even a whole number like `111.0`, and Go's `int` unmarshal
+/// rejects that outright.
+/// A bare integer JSON literal is valid input either way, so whole-number
+/// values are always written as one.
+fn serialize_timeout<S: Serializer>(
+    timeout: &Option<Timeout>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let Some(timeout) = timeout else {
+        return serializer.serialize_none();
+    };
+    let mut map = serializer.serialize_map(Some(3))?;
+    for (key, value) in [
+        ("connect", timeout.connect),
+        ("send", timeout.send),
+        ("read", timeout.read),
+    ] {
+        if value.fract() == 0.0 {
+            map.serialize_entry(key, &(value as i64))?;
+        } else {
+            map.serialize_entry(key, &value)?;
+        }
+    }
+    map.end()
+}
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct Route {
@@ -67,7 +96,11 @@ pub struct Route {
     pub enable_websocket: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub priority: Option<i64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_timeout"
+    )]
     pub timeout: Option<Timeout>,
 }
 
@@ -261,7 +294,11 @@ pub struct Upstream {
     pub retries: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retry_timeout: Option<f64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_timeout"
+    )]
     pub timeout: Option<Timeout>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls: Option<UpstreamTls>,
@@ -282,4 +319,68 @@ pub struct ListResponse<T> {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ValueResponse<T> {
     pub value: T,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn timeout(connect: f64, send: f64, read: f64) -> Timeout {
+        Timeout {
+            connect,
+            send,
+            read,
+        }
+    }
+
+    #[test]
+    fn a_route_s_whole_number_timeout_has_no_decimal_point() {
+        let route = Route {
+            timeout: Some(timeout(111.0, 222.0, 333.0)),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(&route).unwrap()["timeout"],
+            json!({"connect": 111, "send": 222, "read": 333})
+        );
+    }
+
+    #[test]
+    fn a_fractional_timeout_value_keeps_its_decimal_point() {
+        let route = Route {
+            timeout: Some(timeout(1.5, 222.0, 333.0)),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(&route).unwrap()["timeout"],
+            json!({"connect": 1.5, "send": 222, "read": 333})
+        );
+    }
+
+    #[test]
+    fn no_timeout_omits_the_field_entirely() {
+        let route = Route::default();
+
+        assert_eq!(serde_json::to_value(&route).unwrap().get("timeout"), None);
+    }
+
+    #[test]
+    fn a_service_s_inline_default_upstream_timeout_is_also_normalized() {
+        let service = Service {
+            upstream: Some(Upstream {
+                timeout: Some(timeout(60.0, 60.0, 60.0)),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            serde_json::to_value(&service).unwrap()["upstream"]["timeout"],
+            json!({"connect": 60, "send": 60, "read": 60})
+        );
+    }
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout value serialization in API7 payloads.
  * Whole-number timeouts are now represented as integers, while fractional values remain precise.
  * Applied consistent formatting to route and upstream timeout settings.
  * Preserved correct handling for omitted timeout values and inline upstream configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->