### PR TITLE
fix: rust standalone dump race condition

### DIFF
--- a/rust/crates/adc-backend-apisix-standalone/src/backend.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/backend.rs
@@ -21,6 +21,7 @@ use crate::cache::{Cache, CachedEntry};
 use crate::fetcher::Fetcher;
 use crate::operator::{Operator, SyncOutcome};
 use crate::typing::ApisixStandalone;
+use crate::utils::stable_timestamp;
 
 /// One target server plus the client already configured with its own
 /// (server-specific, since standalone clusters can each carry a different
@@ -187,8 +188,10 @@ impl adc_sdk::Backend for Backend {
         if self.bypass_cache {
             Cache::global().invalidate(&self.cache_key).await;
         }
-        // `config` and `raw_config` must come from the same moment, or the
-        // value pinned below could mismatch what's cached.
+        // Cheap fast path: no lock held across anything, so it can't block
+        // a concurrent `sync` on this key. `config` and `raw_config` must
+        // come from the same moment, or the value pinned below could
+        // mismatch what's cached.
         if let Some(entry) = Cache::global().get_live(&self.cache_key).await
             && let Some(config) = entry.config
         {
@@ -198,14 +201,43 @@ impl adc_sdk::Backend for Backend {
             return Ok(config);
         }
 
+        // Resolved before the lock below: it may itself read or write this
+        // same cache_key's cached `version` field, which would deadlock
+        // against a lock this call is about to hold.
         let version = self.resolved_version().await?;
-        let (config, raw_config) = Fetcher::new(self.servers.clone(), version).dump().await?;
 
-        // A concurrent reader must never observe just some of the three
-        // fields updated and not the others.
-        Cache::global()
-            .set_dump_result(&self.cache_key, highest_conf_version(&raw_config), config.clone(), raw_config.clone())
-            .await;
+        // Held across the re-check, the fetch, and the commit below —
+        // `Backend::sync` takes this same per-key lock for its own
+        // read-then-write, so a slow fetch here, started from data read
+        // before this point, can never land after (and silently overwrite)
+        // a `sync` that already committed newer data in the meantime.
+        let mut entry = Cache::global().lock(&self.cache_key).await;
+        if Cache::global().is_fresh(&entry) && let Some(config) = entry.config.clone() {
+            // Someone else populated the cache while this call resolved
+            // the version or waited for this lock.
+            if let Some(raw_config) = entry.raw_config.clone() {
+                *self.dumped_raw_config.lock().unwrap() = Some(raw_config);
+            }
+            return Ok(config);
+        }
+
+        let (config, raw_config) = Fetcher::new(self.servers.clone(), version).dump().await?;
+        let highest = highest_conf_version(&raw_config);
+        // Built in full before it touches `entry`, then swapped in as one
+        // assignment — a panic while computing the new state leaves the
+        // old entry untouched instead of a torn mix of old and new fields.
+        // Applied directly to the guard already held above, not through
+        // `Cache::set_dump_result` — that would try to lock this same key
+        // again and deadlock.
+        let new_entry = CachedEntry {
+            version: entry.version.clone(),
+            latest_version: Some(entry.latest_version.map_or(highest, |current| current.max(highest))),
+            config: Some(config.clone()),
+            raw_config: Some(raw_config.clone()),
+            updated_at: Some(stable_timestamp()),
+        };
+        *entry = new_entry;
+        drop(entry);
         *self.dumped_raw_config.lock().unwrap() = Some(raw_config);
         Ok(config)
     }

--- a/rust/crates/adc-backend-apisix-standalone/src/cache.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/cache.rs
@@ -429,12 +429,15 @@ mod tests {
         });
         holding_rx.await.unwrap(); // `slow` now holds the lock
 
+        let (attempting_tx, attempting_rx) = tokio::sync::oneshot::channel();
         let fast_cache = cache.clone();
         let fast = tokio::spawn(async move {
+            attempting_tx.send(()).unwrap(); // signals before contending for the lock, still held by `slow`
             let mut entry = fast_cache.lock("k").await; // blocks until `slow` releases
             assert_eq!(entry.latest_version, Some(1)); // sees `slow`'s committed value, not a stale pre-fetch read
             entry.latest_version = Some(2);
         });
+        attempting_rx.await.unwrap(); // `fast` has started waiting on the lock while `slow` still holds it
 
         release_tx.send(()).unwrap(); // let `slow` finish its "fetch" and commit
         slow.await.unwrap();

--- a/rust/crates/adc-backend-apisix-standalone/src/cache.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/cache.rs
@@ -128,12 +128,16 @@ impl Cache {
 
     /// Locks the whole cached entry for `key`, for a caller that needs to
     /// read then later write it as one atomic step spanning more than a
-    /// single field access — see `Backend::sync`'s use of this. Every
-    /// other method here (`raw_config`, `set_raw_config`, ...) takes and
-    /// releases this same lock internally, just for the one field it
-    /// touches, so ordinary callers never need this directly. Not exposed
-    /// outside the crate: `CachedEntry`'s fields are crate-internal, so a
-    /// caller elsewhere couldn't do anything with the guard anyway.
+    /// single field access — see `Backend::sync`'s use of this, and
+    /// `Backend::dump`'s cache-miss path, which holds this same lock across
+    /// its own fetch-and-commit for exactly the same reason: two callers
+    /// racing on the same key must run their whole read-then-write
+    /// sequence one after the other, never interleaved. Every other method
+    /// here (`raw_config`, `set_raw_config`, ...) takes and releases this
+    /// same lock internally, just for the one field it touches, so
+    /// ordinary callers never need this directly. Not exposed outside the
+    /// crate: `CachedEntry`'s fields are crate-internal, so a caller
+    /// elsewhere couldn't do anything with the guard anyway.
     ///
     /// Deliberately does *not* reset an expired entry the way `touch` does:
     /// `Backend::sync` uses this to read the last-known real `raw_config`
@@ -149,6 +153,14 @@ impl Cache {
         let entry = self.entry(key).lock_owned().await;
         self.evict_if_over_capacity();
         entry
+    }
+
+    /// Whether an already-locked entry is still within this cache's TTL —
+    /// for a caller (`Backend::dump`) that holds a guard from `lock` and
+    /// needs the same freshness check `get_live` applies internally,
+    /// without a second lock acquisition.
+    pub(crate) fn is_fresh(&self, entry: &CachedEntry) -> bool {
+        !entry.is_expired(self.ttl)
     }
 
     /// Every field, read under one lock acquisition, so a caller pinning
@@ -243,6 +255,10 @@ impl Cache {
     /// acquisition, so a concurrent reader (another `dump`'s `get_live`)
     /// can never observe just some of the three updated and not the
     /// others.
+    // Only reached through the `test-utils`-gated re-export (see
+    // `crate::tests`) — dead as far as a plain `--lib` build (no consumer
+    // outside this crate's own tests) can tell.
+    #[cfg_attr(not(feature = "test-utils"), allow(dead_code))]
     pub async fn set_dump_result(&self, key: &str, latest_version: i64, config: Configuration, raw_config: ApisixStandalone) {
         self.touch(key, |entry| {
             entry.latest_version = Some(entry.latest_version.map_or(latest_version, |current| current.max(latest_version)));
@@ -387,6 +403,48 @@ mod tests {
         tasks.join_all().await;
 
         assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 200);
+    }
+
+    /// Models `Backend::dump`'s cache-miss path (holds the lock across a
+    /// slow "fetch", simulated with a delay, before committing) racing
+    /// `Backend::sync` (holds the same lock, writes immediately) on the
+    /// same key. Whichever side acquires the lock second must see (and
+    /// build its own write on top of) whatever the first side already
+    /// committed — not silently overwrite it with a decision made before
+    /// the first side ever ran. This is the property `Backend::dump`
+    /// holding `Cache::lock` across its own fetch-and-commit depends on.
+    #[tokio::test]
+    async fn a_slow_committer_holding_the_lock_across_its_fetch_cannot_be_clobbered_by_a_concurrent_writer() {
+        let cache = Arc::new(Cache::with_limits(16, Duration::from_secs(3600)));
+
+        let (holding_tx, holding_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+        let slow_cache = cache.clone();
+        let slow = tokio::spawn(async move {
+            let mut entry = slow_cache.lock("k").await;
+            holding_tx.send(()).unwrap();
+            release_rx.await.unwrap(); // simulates the in-flight network fetch
+            entry.latest_version = Some(1);
+        });
+        holding_rx.await.unwrap(); // `slow` now holds the lock
+
+        let fast_cache = cache.clone();
+        let fast = tokio::spawn(async move {
+            let mut entry = fast_cache.lock("k").await; // blocks until `slow` releases
+            assert_eq!(entry.latest_version, Some(1)); // sees `slow`'s committed value, not a stale pre-fetch read
+            entry.latest_version = Some(2);
+        });
+
+        release_tx.send(()).unwrap(); // let `slow` finish its "fetch" and commit
+        slow.await.unwrap();
+        fast.await.unwrap();
+
+        // Read through `lock`, not `latest_version`/`get_live`: neither
+        // closure above touched `updated_at`, so the TTL check the latter
+        // applies would otherwise treat this entry as expired regardless
+        // of which write landed.
+        assert_eq!(cache.lock("k").await.latest_version, Some(2));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache synchronization during data retrieval and updates.
  * Prevented outdated results from overwriting newer values during concurrent operations.
  * Revalidated cached entries after waiting for an in-progress update.
  * Preserved version information when replacing cached data.
  * Improved reliability for slow or overlapping requests by ensuring subsequent operations observe the latest committed value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->