### PR TITLE
feat: rust internalize only sub event type

### DIFF
--- a/rust/crates/adc-backend-apisix-standalone/src/operator.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/operator.rs
@@ -450,7 +450,6 @@ fn upsert_or_delete<T>(
                 None => Ok(false),
             }
         }
-        EventType::OnlySubEvents => Ok(false),
     }
 }
 
@@ -591,7 +590,6 @@ fn apply_event_for_service_inlined_upstream(
                 increase_version.insert(ResourceType::Upstream);
             }
         }
-        EventType::OnlySubEvents => {}
     }
     Ok(())
 }

--- a/rust/crates/adc-backend-apisix/src/operator.rs
+++ b/rust/crates/adc-backend-apisix/src/operator.rs
@@ -344,7 +344,6 @@ fn build_requests(event: &Event, version: &Version) -> Result<Vec<BuiltRequest>,
                     paths.insert(0, (upstream_path, RequestKind::Upstream, method));
                 }
             }
-            EventType::OnlySubEvents => {}
         }
     }
 

--- a/rust/crates/adc-cli/src/main.rs
+++ b/rust/crates/adc-cli/src/main.rs
@@ -316,7 +316,6 @@ fn print_diff_summary(events: &[Event]) {
             EventType::Create => created += 1,
             EventType::Delete => deleted += 1,
             EventType::Update => updated += 1,
-            EventType::OnlySubEvents => continue,
         }
         println!(
             "{} {}: \"{}\"",
@@ -335,6 +334,5 @@ fn event_verb(event: &Event) -> &'static str {
         EventType::Create => "create",
         EventType::Delete => "delete",
         EventType::Update => "update",
-        _ => "",
     }
 }

--- a/rust/crates/adc-differ/src/differ_v4.rs
+++ b/rust/crates/adc-differ/src/differ_v4.rs
@@ -17,9 +17,11 @@ type ResourceTuple = (String, String, Value);
 /// this resource's `{listType: Map, nested: true}` fields). `sub_events` is
 /// build-time-only bookkeeping consumed by `DifferV4::diff`, which lifts each
 /// entry up one level into the final flattened list — it never appears on the
-/// public `Event` type itself.
+/// public `Event` type itself. `event` is `None` when this resource itself
+/// didn't change but a nested one did — `handle_update`'s only producer of
+/// that case — so there's nothing of its own to lift alongside `sub_events`.
 struct BuiltEvent {
-    event: Event,
+    event: Option<Event>,
     sub_events: Vec<Event>,
 }
 
@@ -47,13 +49,10 @@ impl DifferV4 {
             result.extend(differ.diff_resource(resource_type, &meta, local_tuples, remote_tuples));
         }
 
-        // Unwrap one level of subEvents and drop ONLY_SUB_EVENTS placeholder
-        // events, which exist only to carry subEvents up to this point.
+        // Unwrap one level of sub_events into the flattened list.
         let mut unwrapped: Vec<Event> = Vec::new();
         for BuiltEvent { event, sub_events } in result {
-            if event.event_type() != EventType::OnlySubEvents {
-                unwrapped.push(event);
-            }
+            unwrapped.extend(event);
             unwrapped.extend(sub_events);
         }
 
@@ -122,7 +121,7 @@ impl DifferV4 {
             .collect();
 
         let event = Event::new(resource_type, EventKind::Delete { old_value: remote_item }, remote_id, remote_name);
-        BuiltEvent { event, sub_events }
+        BuiltEvent { event: Some(event), sub_events }
     }
 
     fn handle_create(
@@ -150,7 +149,7 @@ impl DifferV4 {
         strip_nested_ids(meta, &mut local_item);
 
         let event = Event::new(resource_type, EventKind::Create { new_value: local_item }, local_id, local_name);
-        BuiltEvent { event, sub_events }
+        BuiltEvent { event: Some(event), sub_events }
     }
 
     fn handle_update(
@@ -251,12 +250,12 @@ impl DifferV4 {
 
         let only_sub_events = !sub_events.is_empty() && !plugin_changed && diff.is_none();
 
-        let kind = if only_sub_events {
-            EventKind::OnlySubEvents
+        let event = if only_sub_events {
+            None
         } else {
-            EventKind::Update { old_value: output_remote_item, new_value: output_local_item, diff }
+            let kind = EventKind::Update { old_value: output_remote_item, new_value: output_local_item, diff };
+            Some(Event::new(resource_type, kind, remote_id, remote_name))
         };
-        let event = Event::new(resource_type, kind, remote_id, remote_name);
         Some(BuiltEvent { event, sub_events })
     }
 

--- a/rust/crates/adc-sdk/src/event.rs
+++ b/rust/crates/adc-sdk/src/event.rs
@@ -12,8 +12,6 @@ pub enum EventType {
     Create,
     Delete,
     Update,
-    /// Internal use only, the backend does not need to handle such event type
-    OnlySubEvents,
 }
 
 /// The kind of change a differ event represents, together with the payload that
@@ -40,10 +38,6 @@ pub enum EventKind {
         #[serde(skip_serializing_if = "Option::is_none")]
         diff: Option<Vec<ValueDiff>>,
     },
-    /// Internal use only: exists to carry `sub_events` up to the caller during
-    /// tree construction. Never appears in the differ's final flattened event
-    /// list, so it carries no payload of its own.
-    OnlySubEvents,
 }
 
 impl EventKind {
@@ -52,28 +46,27 @@ impl EventKind {
             EventKind::Create { .. } => EventType::Create,
             EventKind::Delete { .. } => EventType::Delete,
             EventKind::Update { .. } => EventType::Update,
-            EventKind::OnlySubEvents => EventType::OnlySubEvents,
         }
     }
 
     pub fn old_value(&self) -> Option<&Value> {
         match self {
             EventKind::Delete { old_value } | EventKind::Update { old_value, .. } => Some(old_value),
-            EventKind::Create { .. } | EventKind::OnlySubEvents => None,
+            EventKind::Create { .. } => None,
         }
     }
 
     pub fn new_value(&self) -> Option<&Value> {
         match self {
             EventKind::Create { new_value } | EventKind::Update { new_value, .. } => Some(new_value),
-            EventKind::Delete { .. } | EventKind::OnlySubEvents => None,
+            EventKind::Delete { .. } => None,
         }
     }
 
     pub fn diff(&self) -> Option<&[ValueDiff]> {
         match self {
             EventKind::Update { diff, .. } => diff.as_deref(),
-            EventKind::Create { .. } | EventKind::Delete { .. } | EventKind::OnlySubEvents => None,
+            EventKind::Create { .. } | EventKind::Delete { .. } => None,
         }
     }
 }


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

Fixes # (issue)

### Checklist

- [ ] I have explained the need for this PR and the problem it solves
- [ ] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [ ] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for nested resources.
  * Prevented placeholder events from appearing when only nested changes occur.
  * Ensured create, update, and delete events are reported consistently.
* **Refactor**
  * Simplified event handling across the CLI, SDK, and API integrations.
  * Removed an internal event type that could produce unnecessary no-op entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->