### PR TITLE
fix(apisix): tolerate consumer_credentials no name

### DIFF
--- a/libs/backend-apisix/src/transformer.ts
+++ b/libs/backend-apisix/src/transformer.ts
@@ -88,7 +88,7 @@ export class ToADC {
       return;
     return ADCSDK.utils.recursiveOmitUndefined<ADCSDK.ConsumerCredential>({
       id: credential.id,
-      name: credential.name,
+      name: credential.name ?? credential.id!,
       description: credential.desc,
       labels: credential.labels,
       type: pluginName as ADCSDK.ConsumerCredential['type'],
@@ -113,7 +113,7 @@ export class ToADC {
       labels: ssl.labels,
 
       type: ssl.type,
-      snis: ssl.sni ? [ssl.sni] : ssl.snis ?? [],
+      snis: ssl.sni ? [ssl.sni] : (ssl.snis ?? []),
       certificates: certificates,
       client: ssl.client
         ? {

--- a/libs/backend-apisix/src/typing.ts
+++ b/libs/backend-apisix/src/typing.ts
@@ -77,7 +77,7 @@ export interface Service {
 }
 export interface ConsumerCredential {
   id?: string;
-  name: string;
+  name?: string;
   desc?: string;
   labels?: Labels;
 

--- a/libs/backend-apisix/test/transformer.spec.ts
+++ b/libs/backend-apisix/test/transformer.spec.ts
@@ -57,4 +57,19 @@ describe('Transformer', () => {
       },
     });
   });
+
+  it('should fall back consumer credential name to id when APISIX returns none', () => {
+    const toADC = new ToADC();
+    expect(
+      toADC.transformConsumerCredential({
+        id: 'jack-key',
+        plugins: { 'key-auth': { key: 'secret' } },
+      }),
+    ).toEqual({
+      id: 'jack-key',
+      name: 'jack-key',
+      type: 'key-auth',
+      config: { key: 'secret' },
+    });
+  });
 });

--- a/rust/crates/adc-backend-apisix/src/transformer.rs
+++ b/rust/crates/adc-backend-apisix/src/transformer.rs
@@ -132,14 +132,26 @@ impl TryFrom<typing::Service> for adc::Service {
 fn parse_discovery_map_nodes(map: HashMap<String, i64>) -> Result<Vec<adc::UpstreamNode>, String> {
     map.into_iter()
         .map(|(node, weight)| {
-            let url = Url::parse(&format!("adc://{node}")).map_err(|_| format!("invalid upstream node {node:?}"))?;
-            let host = match url.host().ok_or_else(|| format!("upstream node {node:?} has no host"))? {
+            let url = Url::parse(&format!("adc://{node}"))
+                .map_err(|_| format!("invalid upstream node {node:?}"))?;
+            let host = match url
+                .host()
+                .ok_or_else(|| format!("upstream node {node:?} has no host"))?
+            {
                 Host::Domain(host) => host.to_string(),
                 Host::Ipv4(ip) => ip.to_string(),
                 Host::Ipv6(ip) => ip.to_string(),
             };
-            let port = url.port().ok_or_else(|| format!("upstream node {node:?} has no port"))?;
-            Ok(adc::UpstreamNode { host, port, weight, priority: 0, metadata: None })
+            let port = url
+                .port()
+                .ok_or_else(|| format!("upstream node {node:?} has no port"))?;
+            Ok(adc::UpstreamNode {
+                host,
+                port,
+                weight,
+                priority: 0,
+                metadata: None,
+            })
         })
         .collect()
 }
@@ -197,9 +209,7 @@ impl TryFrom<typing::Upstream> for adc::Upstream {
         let nodes = match upstream.nodes {
             None => None,
             Some(typing::UpstreamNodes::List(nodes)) => Some(nodes),
-            Some(typing::UpstreamNodes::Map(map)) => {
-                Some(parse_discovery_map_nodes(map)?)
-            }
+            Some(typing::UpstreamNodes::Map(map)) => Some(parse_discovery_map_nodes(map)?),
         };
 
         // The service-association label is fetcher-internal bookkeeping
@@ -304,9 +314,16 @@ impl TryFrom<typing::ConsumerCredential> for adc::ConsumerCredential {
             ));
         };
 
+        let name = credential.name.unwrap_or_else(|| {
+            credential
+                .id
+                .clone()
+                .expect("APISIX always assigns credentials an id")
+        });
+
         Ok(adc::ConsumerCredential {
             id: credential.id,
-            name: credential.name,
+            name,
             description: credential.desc,
             labels: credential.labels,
             r#type: plugin_name,
@@ -564,7 +581,7 @@ impl From<adc::ConsumerCredential> for typing::ConsumerCredential {
 
         typing::ConsumerCredential {
             id: credential.id,
-            name: credential.name,
+            name: Some(credential.name),
             desc: credential.description,
             labels: transform_labels_to_apisix(credential.labels),
             plugins: Some(plugins),
@@ -730,7 +747,10 @@ mod tests {
             ..Default::default()
         };
         let adc = health_check_to_adc(checks);
-        assert_eq!(adc.active.http_req_headers, Some(vec!["X-Foo: bar".to_string()]));
+        assert_eq!(
+            adc.active.http_req_headers,
+            Some(vec!["X-Foo: bar".to_string()])
+        );
         assert_eq!(adc.active.http_req_body, "ping");
     }
 
@@ -745,7 +765,10 @@ mod tests {
             passive: None,
         };
         let wire = health_check_from_adc(checks);
-        assert_eq!(wire.active.req_headers, Some(vec!["X-Foo: bar".to_string()]));
+        assert_eq!(
+            wire.active.req_headers,
+            Some(vec!["X-Foo: bar".to_string()])
+        );
         assert_eq!(wire.active.http_req_body, Some("ping".to_string()));
     }
 }

--- a/rust/crates/adc-backend-apisix/src/typing.rs
+++ b/rust/crates/adc-backend-apisix/src/typing.rs
@@ -20,8 +20,9 @@ use std::collections::HashMap;
 
 use adc_sdk::resources::{
     Expr, HttpMethod, Labels, Plugins, SslClient, SslProtocol, SslType, Timeout, UpstreamBalancer,
-    UpstreamHealthCheckActiveHealthy, UpstreamHealthCheckActiveUnhealthy, UpstreamHealthCheckPassive,
-    UpstreamHealthCheckType, UpstreamKeepalivePool, UpstreamNode, UpstreamPassHost, UpstreamScheme, UpstreamTls,
+    UpstreamHealthCheckActiveHealthy, UpstreamHealthCheckActiveUnhealthy,
+    UpstreamHealthCheckPassive, UpstreamHealthCheckType, UpstreamKeepalivePool, UpstreamNode,
+    UpstreamPassHost, UpstreamScheme, UpstreamTls,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -125,7 +126,8 @@ pub struct Service {
 pub struct ConsumerCredential {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub desc: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/rust/crates/adc-backend-apisix/tests/transformer.rs
+++ b/rust/crates/adc-backend-apisix/tests/transformer.rs
@@ -292,10 +292,20 @@ fn ssl_with_a_redacted_key_degrades_to_an_empty_placeholder_instead_of_failing()
 }
 
 #[test]
+fn consumer_credential_falls_back_to_id_when_name_is_absent() {
+    let mut plugins = adc::Plugins::new();
+    plugins.insert("key-auth".into(), json!({ "key": "secret" }));
+    let credential = typing::ConsumerCredential { id: Some("jack-key".into()), name: None, desc: None, labels: None, plugins: Some(plugins) };
+
+    let adc_credential: adc::ConsumerCredential = credential.try_into().unwrap();
+    assert_eq!(adc_credential.name, "jack-key");
+}
+
+#[test]
 fn consumer_credential_only_converts_recognized_plugins() {
     let mut plugins = adc::Plugins::new();
     plugins.insert("key-auth".into(), json!({ "key": "secret" }));
-    let credential = typing::ConsumerCredential { id: Some("c1".into()), name: "c1".into(), desc: None, labels: None, plugins: Some(plugins) };
+    let credential = typing::ConsumerCredential { id: Some("c1".into()), name: Some("c1".into()), desc: None, labels: None, plugins: Some(plugins) };
 
     let adc_credential: adc::ConsumerCredential = credential.try_into().unwrap();
     assert_eq!(adc_credential.r#type, "key-auth");
@@ -306,7 +316,7 @@ fn consumer_credential_only_converts_recognized_plugins() {
 fn consumer_credential_rejects_unsupported_plugins() {
     let mut plugins = adc::Plugins::new();
     plugins.insert("proxy-rewrite".into(), json!({}));
-    let credential = typing::ConsumerCredential { id: None, name: "c1".into(), desc: None, labels: None, plugins: Some(plugins) };
+    let credential = typing::ConsumerCredential { id: None, name: Some("c1".into()), desc: None, labels: None, plugins: Some(plugins) };
 
     assert!(adc::ConsumerCredential::try_from(credential).is_err());
 }
@@ -325,8 +335,8 @@ fn consumer_drops_credentials_that_fail_to_convert_but_keeps_the_rest() {
         group_id: None,
         plugins: None,
         credentials: Some(vec![
-            typing::ConsumerCredential { id: Some("good".into()), name: "good".into(), desc: None, labels: None, plugins: Some(good) },
-            typing::ConsumerCredential { id: Some("bad".into()), name: "bad".into(), desc: None, labels: None, plugins: Some(bad) },
+            typing::ConsumerCredential { id: Some("good".into()), name: Some("good".into()), desc: None, labels: None, plugins: Some(good) },
+            typing::ConsumerCredential { id: Some("bad".into()), name: Some("bad".into()), desc: None, labels: None, plugins: Some(bad) },
         ]),
     };
 


### PR DESCRIPTION
### Description

Fix #561 

Allow resources with `consumer_credentials` that lack a `name` field.

Some older credentials created via the Admin API may lack a `name` field, but the ADC treats this as a required field, causing an internal error. Because it attempts to generate a hashed ID for a value that is undefined.

This PR provides a fallback mechanism: if a credential lacks a `name` field, the `id` is used to populate it to prevent errors. It also improves the cascading deletion supported by APISIX; if the consumer to which a credential belongs is also deleted, the credential is skipped without issuing a request, thereby reducing synchronization time.


### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Consumer credentials imported without a name now use their credential ID as a fallback name.
  - Credential configurations, including key-auth settings, are preserved when names are missing.
  - APISIX integrations now handle optional credential names more reliably across supported environments.

- **Tests**
  - Added coverage for credentials missing names and verified fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->