### PR TITLE
feat(apisix): support native stream route name field

### DIFF
--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -308,7 +308,7 @@ describe('Sync and Dump - 1', () => {
 
         // Written directly, bypassing ADC entirely: only the legacy label
         // carries a name, no native `name` field at all.
-        await fetch(
+        const putResponse = await fetch(
           `${server}/apisix/admin/stream_routes/${streamRouteId}`,
           {
             method: 'PUT',
@@ -323,6 +323,7 @@ describe('Sync and Dump - 1', () => {
             }),
           },
         );
+        expect(putResponse.ok).toBe(true);
 
         const beforeMigration = (await dumpConfiguration(
           backend,
@@ -343,10 +344,12 @@ describe('Sync and Dump - 1', () => {
         migrateEvent = { ...migrateEvent, resourceId: streamRouteId };
         await syncEvents(backend, [migrateEvent]);
 
-        const raw = (await fetch(
+        const getResponse = await fetch(
           `${server}/apisix/admin/stream_routes/${streamRouteId}`,
           { headers: { 'X-API-KEY': token } },
-        ).then((res) => res.json())) as {
+        );
+        expect(getResponse.ok).toBe(true);
+        const raw = (await getResponse.json()) as {
           value: { name?: string; labels?: Record<string, string> };
         };
         expect(raw.value.name).toEqual('legacy-stream-route');

--- a/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
+++ b/libs/backend-apisix/e2e/sync-and-dump-1.e2e-spec.ts
@@ -6,8 +6,9 @@ import { join } from 'node:path';
 import { gte, lt } from 'semver';
 
 import { BackendAPISIX } from '../src';
-import { defaultBackendOptions } from './support/constants';
+import { defaultBackendOptions, server, token } from './support/constants';
 import {
+  cleanup,
   conditionalDescribe,
   conditionalIt,
   createEvent,
@@ -271,6 +272,85 @@ describe('Sync and Dump - 1', () => {
           backend,
         )) as ADCSDK.Configuration;
         expect(result.services).toHaveLength(0);
+      });
+    },
+  );
+
+  // A stream route written under the pre-3.13.0 __ADC_NAME label scheme
+  // (simulated here with a raw Admin API call, standing in for a route ADC
+  // itself wrote before either it or the server was upgraded) must still
+  // read its name correctly from a server that now supports the native
+  // field — and re-syncing it should migrate it to the native field,
+  // dropping the label.
+  conditionalDescribe(semverCondition(gte, '3.13.0'))(
+    'Migrate a legacy label-named stream route to the native name field',
+    () => {
+      const serviceName = 'stream-migrate-service';
+      const streamRouteId = 'stream-migrate-route';
+
+      afterAll(() => cleanup(backend));
+
+      it('should recover the name and migrate it on re-sync', async () => {
+        await syncEvents(backend, [
+          createEvent(ADCSDK.ResourceType.SERVICE, serviceName, {
+            name: serviceName,
+            upstream: {
+              nodes: [{ host: '127.0.0.1', port: 1980, weight: 1 }],
+            },
+          } as ADCSDK.Service),
+        ]);
+
+        const dumpedService = ((await dumpConfiguration(
+          backend,
+        )) as ADCSDK.Configuration).services!.find(
+          (service) => service.name === serviceName,
+        )!;
+
+        // Written directly, bypassing ADC entirely: only the legacy label
+        // carries a name, no native `name` field at all.
+        await fetch(
+          `${server}/apisix/admin/stream_routes/${streamRouteId}`,
+          {
+            method: 'PUT',
+            headers: {
+              'X-API-KEY': token,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              server_port: 33063,
+              service_id: dumpedService.id,
+              labels: { __ADC_NAME: 'legacy-stream-route' },
+            }),
+          },
+        );
+
+        const beforeMigration = (await dumpConfiguration(
+          backend,
+        )) as ADCSDK.Configuration;
+        const beforeRoute = beforeMigration.services!.find(
+          (service) => service.name === serviceName,
+        )!.stream_routes![0];
+        expect(beforeRoute.name).toEqual('legacy-stream-route');
+
+        // Re-syncing through ADC against a >= 3.13.0 server writes the
+        // native field instead of the label.
+        let migrateEvent = createEvent(
+          ADCSDK.ResourceType.STREAM_ROUTE,
+          'legacy-stream-route',
+          { name: 'legacy-stream-route', server_port: 33063 } as ADCSDK.StreamRoute,
+          serviceName,
+        );
+        migrateEvent = { ...migrateEvent, resourceId: streamRouteId };
+        await syncEvents(backend, [migrateEvent]);
+
+        const raw = (await fetch(
+          `${server}/apisix/admin/stream_routes/${streamRouteId}`,
+          { headers: { 'X-API-KEY': token } },
+        ).then((res) => res.json())) as {
+          value: { name?: string; labels?: Record<string, string> };
+        };
+        expect(raw.value.name).toEqual('legacy-stream-route');
+        expect(raw.value.labels?.__ADC_NAME).toBeUndefined();
       });
     },
   );

--- a/libs/backend-apisix/src/operator.ts
+++ b/libs/backend-apisix/src/operator.ts
@@ -18,9 +18,9 @@ import {
   tap,
   throwError,
 } from 'rxjs';
-import { SemVer, gte as semVerGTE, lt as semVerLT } from 'semver';
+import { SemVer, lt as semVerLT } from 'semver';
 
-import { FromADC } from './transformer';
+import { FromADC, streamRouteNameModeForVersion } from './transformer';
 import * as typing from './typing';
 import { capitalizeFirstLetter, resourceTypeToAPIName } from './utils';
 
@@ -267,7 +267,7 @@ export class Operator extends ADCSDK.backend.BackendEventSource {
         const route = fromADC.transformStreamRoute(
           event.newValue as ADCSDK.StreamRoute,
           event.parentId!,
-          semVerGTE(version, '3.8.0'),
+          streamRouteNameModeForVersion(version),
         );
         if (event.parentId) route.service_id = event.parentId;
         return route;

--- a/libs/backend-apisix/src/transformer.ts
+++ b/libs/backend-apisix/src/transformer.ts
@@ -1,7 +1,34 @@
 import * as ADCSDK from '@api7/adc-sdk';
 import { filter, isEmpty, omit, unset } from 'lodash-es';
+import { SemVer, gte as semVerGTE } from 'semver';
 
 import * as typing from './typing';
+
+/**
+ * How a stream route's ADC name gets persisted, decided by the caller from
+ * the target APISIX version (see {@link streamRouteNameModeForVersion}) and
+ * passed to {@link FromADC.transformStreamRoute}:
+ * - `unsupported`: below 3.8.0, stream routes don't even support `labels`,
+ *   so the name can't be persisted at all.
+ * - `label`: `[3.8.0, 3.13.0)` — `labels` exist but there's no native
+ *   `name` field yet, so ADC smuggles one through the `__ADC_NAME` label.
+ * - `native`: `>= 3.13.0` — written straight to the (now native) `name`
+ *   field; no label needed. A route last synced under `label` mode still
+ *   carries the old label until it's synced again under `native` mode, at
+ *   which point this stops re-adding it and it falls off on its own — see
+ *   {@link ToADC.transformStreamRoute}'s read side, which prefers the
+ *   native field but still falls back to the label.
+ */
+export type StreamRouteNameMode = 'unsupported' | 'label' | 'native';
+
+export const streamRouteNameModeForVersion = (
+  version: SemVer,
+): StreamRouteNameMode =>
+  semVerGTE(version, '3.13.0')
+    ? 'native'
+    : semVerGTE(version, '3.8.0')
+      ? 'label'
+      : 'unsupported';
 
 export class ToADC {
   private static transformLabels(
@@ -159,7 +186,12 @@ export class ToADC {
   ): ADCSDK.StreamRoute {
     return ADCSDK.utils.recursiveOmitUndefined({
       id: streamRoute.id,
-      name: streamRoute.labels?.__ADC_NAME ?? streamRoute.id,
+      // Native `name` wins when present (APISIX >= 3.13.0). Older servers,
+      // and routes never re-synced since upgrading past 3.13.0, only have
+      // the magic label ADC used to smuggle a name through; `id` is the
+      // last resort when neither was ever set.
+      name:
+        streamRoute.name ?? streamRoute.labels?.__ADC_NAME ?? streamRoute.id,
       description: streamRoute.desc,
       labels: ToADC.transformLabels(streamRoute.labels),
 
@@ -412,18 +444,20 @@ export class FromADC {
   public transformStreamRoute(
     streamRoute: ADCSDK.StreamRoute,
     parentId: string,
-    injectName = true,
+    nameMode: StreamRouteNameMode = 'label',
   ): typing.StreamRoute {
     const labels = FromADC.transformLabels(streamRoute.labels);
     return ADCSDK.utils.recursiveOmitUndefined({
       id: undefined,
+      name: nameMode === 'native' ? streamRoute.name : undefined,
       desc: streamRoute.description,
-      labels: injectName
-        ? {
-            ...labels,
-            __ADC_NAME: streamRoute.name,
-          }
-        : labels,
+      labels:
+        nameMode === 'label'
+          ? {
+              ...labels,
+              __ADC_NAME: streamRoute.name,
+            }
+          : labels,
       plugins: streamRoute.plugins,
       remote_addr: streamRoute.remote_addr,
       server_addr: streamRoute.server_addr,

--- a/libs/backend-apisix/src/typing.ts
+++ b/libs/backend-apisix/src/typing.ts
@@ -135,9 +135,12 @@ export interface GlobalRule {
 export type PluginMetadata = ADCPluginMetadata;
 export interface StreamRoute {
   id: string;
+  // Native as of APISIX 3.13.0 (absent, and unrecognized, on older
+  // servers) — see FromADC.transformStreamRoute's doc comment for how ADC
+  // decides between this and the __ADC_NAME magic label.
+  name?: string;
   desc?: string;
   labels?: Labels;
-  //name: string; // As of 3.9.1, APISIX does not support name on the stream route
 
   remote_addr?: string;
   server_addr?: string;

--- a/libs/backend-apisix/test/transformer.spec.ts
+++ b/libs/backend-apisix/test/transformer.spec.ts
@@ -1,4 +1,7 @@
+import * as ADCSDK from '@api7/adc-sdk';
+
 import { FromADC, ToADC } from '../src/transformer';
+import * as typing from '../src/typing';
 
 describe('Transformer', () => {
   it('should transform upstream nodes to array', () => {
@@ -70,6 +73,63 @@ describe('Transformer', () => {
       name: 'jack-key',
       type: 'key-auth',
       config: { key: 'secret' },
+    });
+  });
+
+  describe('stream route name persistence', () => {
+    const streamRoute = { name: 'my-stream-route' } as ADCSDK.StreamRoute;
+
+    it('should omit the name entirely in unsupported mode', () => {
+      const fromADC = new FromADC();
+      const wire = fromADC.transformStreamRoute(
+        streamRoute,
+        'svc1',
+        'unsupported',
+      );
+      expect(wire.name).toBeUndefined();
+      expect(wire.labels).toBeUndefined();
+    });
+
+    it('should inject the magic label in label mode', () => {
+      const fromADC = new FromADC();
+      const wire = fromADC.transformStreamRoute(streamRoute, 'svc1', 'label');
+      expect(wire.name).toBeUndefined();
+      expect(wire.labels).toEqual({ __ADC_NAME: 'my-stream-route' });
+    });
+
+    it('should use the native name field in native mode', () => {
+      const fromADC = new FromADC();
+      const wire = fromADC.transformStreamRoute(streamRoute, 'svc1', 'native');
+      expect(wire.name).toEqual('my-stream-route');
+      expect(wire.labels).toBeUndefined();
+    });
+
+    it('should prefer the native name over the magic label when reading', () => {
+      const toADC = new ToADC();
+      expect(
+        toADC.transformStreamRoute({
+          id: 'sr1',
+          name: 'native-name',
+          labels: { __ADC_NAME: 'stale-label-name' },
+        } as typing.StreamRoute),
+      ).toMatchObject({ name: 'native-name' });
+    });
+
+    it('should fall back to the magic label when there is no native name', () => {
+      const toADC = new ToADC();
+      expect(
+        toADC.transformStreamRoute({
+          id: 'sr1',
+          labels: { __ADC_NAME: 'my-stream-route' },
+        } as typing.StreamRoute),
+      ).toMatchObject({ name: 'my-stream-route' });
+    });
+
+    it('should fall back to id when neither a name nor the magic label exists', () => {
+      const toADC = new ToADC();
+      expect(
+        toADC.transformStreamRoute({ id: 'sr1' } as typing.StreamRoute),
+      ).toMatchObject({ name: 'sr1' });
     });
   });
 });

--- a/rust/crates/adc-backend-apisix/src/operator.rs
+++ b/rust/crates/adc-backend-apisix/src/operator.rs
@@ -23,13 +23,13 @@
 //!   creates, matching the differ's own topological ordering.
 
 use adc_backend_core::{
-    HttpClient, Method, RetryPolicy, concurrent_map, concurrent_map_until_err, deserialize_event_value,
-    encode_path_segment, missing_parent, to_request_body,
+    HttpClient, Method, RetryPolicy, concurrent_map, concurrent_map_until_err,
+    deserialize_event_value, encode_path_segment, missing_parent, to_request_body,
 };
 use adc_sdk::resources::{self as adc};
 use adc_sdk::{
-    BackendError, BackendSyncOptions, BackendSyncResult, DEFAULT_EXIT_ON_FAILURE, Event, EventType, PathSegment,
-    ResourceType, SYNC_EVENT_SPAN_NAME, ValueDiff,
+    BackendError, BackendSyncOptions, BackendSyncResult, DEFAULT_EXIT_ON_FAILURE, Event, EventType,
+    PathSegment, ResourceType, SYNC_EVENT_SPAN_NAME, ValueDiff,
 };
 use semver::Version;
 use serde_json::Value;
@@ -46,7 +46,11 @@ pub struct Operator {
 
 impl Operator {
     pub fn new(client: HttpClient, version: Version) -> Self {
-        Self { client, version, retry_policy: RetryPolicy::default() }
+        Self {
+            client,
+            version,
+            retry_policy: RetryPolicy::default(),
+        }
     }
 
     /// Applies `events`. A version-gate rejection (`check_version_support`)
@@ -60,20 +64,33 @@ impl Operator {
     /// dispatched at all, and every result — from this group and any
     /// accumulated from earlier ones — is discarded in favor of the single
     /// `Err`.
-    pub async fn sync(&self, events: Vec<Event>, opts: BackendSyncOptions) -> Result<Vec<BackendSyncResult>, BackendError> {
+    pub async fn sync(
+        &self,
+        events: Vec<Event>,
+        opts: BackendSyncOptions,
+    ) -> Result<Vec<BackendSyncResult>, BackendError> {
         let exit_on_failure = opts.exit_on_failure.unwrap_or(DEFAULT_EXIT_ON_FAILURE);
 
         let mut results = Vec::new();
         for group in group_events(events) {
             if exit_on_failure {
-                let group_results = concurrent_map_until_err(group, opts.concurrent, |event| self.apply(event)).await.map_err(|(_, error)| error)?;
+                let group_results =
+                    concurrent_map_until_err(group, opts.concurrent, |event| self.apply(event))
+                        .await
+                        .map_err(|(_, error)| error)?;
                 results.extend(group_results);
             } else {
-                let group_results = concurrent_map(group, opts.concurrent, |event| self.apply(event)).await;
+                let group_results =
+                    concurrent_map(group, opts.concurrent, |event| self.apply(event)).await;
                 for outcome in group_results {
                     match outcome {
                         Ok(result) => results.push(result),
-                        Err((event, error)) => results.push(BackendSyncResult { success: false, event: Some(event), error: Some(error), server: None }),
+                        Err((event, error)) => results.push(BackendSyncResult {
+                            success: false,
+                            event: Some(event),
+                            error: Some(error),
+                            server: None,
+                        }),
                     }
                 }
             }
@@ -130,25 +147,44 @@ impl Operator {
     #[allow(clippy::result_large_err)]
     async fn apply_inner(&self, event: Event) -> Result<BackendSyncResult, (Event, BackendError)> {
         if let Err(error) = self.check_version_support(&event) {
-            log::warn!("skipping {:?} {:?} \"{}\": {error}", event.event_type(), event.resource_type, event.resource_name);
-            return Ok(BackendSyncResult { success: false, event: Some(event), error: Some(error), server: None });
+            log::warn!(
+                "skipping {:?} {:?} \"{}\": {error}",
+                event.event_type(),
+                event.resource_type,
+                event.resource_name
+            );
+            return Ok(BackendSyncResult {
+                success: false,
+                event: Some(event),
+                error: Some(error),
+                server: None,
+            });
         }
 
         match self.operate(&event).await {
-            Ok(()) => Ok(BackendSyncResult { success: true, event: Some(event), error: None, server: None }),
+            Ok(()) => Ok(BackendSyncResult {
+                success: true,
+                event: Some(event),
+                error: None,
+                server: None,
+            }),
             Err(error) => Err((event, error)),
         }
     }
 
     fn check_version_support(&self, event: &Event) -> Result<(), BackendError> {
-        if event.resource_type == ResourceType::StreamRoute && self.version < Version::new(3, 7, 0) {
+        if event.resource_type == ResourceType::StreamRoute && self.version < Version::new(3, 7, 0)
+        {
             return Err(BackendError::Unsupported(
                 "stream routes are not supported on apisix versions below 3.7.0".to_string(),
             ));
         }
-        if event.resource_type == ResourceType::ConsumerCredential && self.version < Version::new(3, 11, 0) {
+        if event.resource_type == ResourceType::ConsumerCredential
+            && self.version < Version::new(3, 11, 0)
+        {
             return Err(BackendError::Unsupported(
-                "consumer credentials are not supported on apisix versions below 3.11.0".to_string(),
+                "consumer credentials are not supported on apisix versions below 3.11.0"
+                    .to_string(),
             ));
         }
         Ok(())
@@ -218,13 +254,19 @@ mod retry_tests {
 
     #[test]
     fn a_plain_4xx_api_error_is_not_retriable() {
-        let err = BackendError::Api { status: 400, message: "bad config".into() };
+        let err = BackendError::Api {
+            status: 400,
+            message: "bad config".into(),
+        };
         assert!(!is_retriable(&err));
     }
 
     #[test]
     fn a_5xx_api_error_is_still_retriable() {
-        let err = BackendError::Api { status: 502, message: "bad gateway".into() };
+        let err = BackendError::Api {
+            status: 502,
+            message: "bad gateway".into(),
+        };
         assert!(is_retriable(&err));
     }
 
@@ -262,18 +304,27 @@ fn group_events(events: Vec<Event>) -> Vec<Vec<Event>> {
 fn main_path(event: &Event) -> Result<String, BackendError> {
     let resource_id = encode_path_segment(&event.resource_id)?;
     if event.resource_type == ResourceType::ConsumerCredential {
-        let parent_id = event.parent_id.as_deref().ok_or_else(|| missing_parent(event))?;
+        let parent_id = event
+            .parent_id
+            .as_deref()
+            .ok_or_else(|| missing_parent(event))?;
         let parent_id = encode_path_segment(parent_id)?;
-        return Ok(format!("/apisix/admin/consumers/{parent_id}/credentials/{resource_id}"));
+        return Ok(format!(
+            "/apisix/admin/consumers/{parent_id}/credentials/{resource_id}"
+        ));
     }
-    let api_name = resource_type_to_api_name(event.resource_type)
-        .expect("ConsumerCredential is the only resource type with no api name, and it's handled above");
+    let api_name = resource_type_to_api_name(event.resource_type).expect(
+        "ConsumerCredential is the only resource type with no api name, and it's handled above",
+    );
     Ok(format!("/apisix/admin/{api_name}/{resource_id}"))
 }
 
 fn diff_path_is_upstream(diff: &ValueDiff) -> bool {
     let path = match diff {
-        ValueDiff::New { path, .. } | ValueDiff::Deleted { path, .. } | ValueDiff::Edit { path, .. } | ValueDiff::Array { path, .. } => path,
+        ValueDiff::New { path, .. }
+        | ValueDiff::Deleted { path, .. }
+        | ValueDiff::Edit { path, .. }
+        | ValueDiff::Array { path, .. } => path,
     };
     matches!(path.first(), Some(PathSegment::Key(key)) if key == "upstream")
 }
@@ -301,16 +352,27 @@ type BuiltRequest = (Method, String, Option<Value>, RequestKind);
 /// `transform_service` returns `None` when it doesn't, which the upstream
 /// sub-request must turn into a DELETE (nothing to PUT) rather than an error.
 fn service_has_upstream(event: &Event) -> bool {
-    event.kind.new_value().and_then(|v| v.get("upstream")).is_some_and(|v| !v.is_null())
+    event
+        .kind
+        .new_value()
+        .and_then(|v| v.get("upstream"))
+        .is_some_and(|v| !v.is_null())
 }
 
 fn build_requests(event: &Event, version: &Version) -> Result<Vec<BuiltRequest>, BackendError> {
     let is_delete = event.event_type() == EventType::Delete;
-    let main_method = if is_delete { Method::DELETE } else { Method::PUT };
+    let main_method = if is_delete {
+        Method::DELETE
+    } else {
+        Method::PUT
+    };
     let mut paths = vec![(main_path(event)?, RequestKind::Main, main_method)];
 
     if event.resource_type == ResourceType::Service {
-        let upstream_path = format!("/apisix/admin/upstreams/{}", encode_path_segment(&event.resource_id)?);
+        let upstream_path = format!(
+            "/apisix/admin/upstreams/{}",
+            encode_path_segment(&event.resource_id)?
+        );
         match event.event_type() {
             EventType::Delete => paths.push((upstream_path, RequestKind::Upstream, Method::DELETE)),
             EventType::Create => {
@@ -320,7 +382,13 @@ fn build_requests(event: &Event, version: &Version) -> Result<Vec<BuiltRequest>,
             }
             EventType::Update => {
                 let diff = event.kind.diff().filter(|d| !d.is_empty()).ok_or_else(|| {
-                    BackendError::Other(format!("service {:?} update event is missing diff info", event.resource_id).into())
+                    BackendError::Other(
+                        format!(
+                            "service {:?} update event is missing diff info",
+                            event.resource_id
+                        )
+                        .into(),
+                    )
                 })?;
                 let touches_non_upstream = diff.iter().any(|d| !diff_path_is_upstream(d));
                 let touches_upstream = diff.iter().any(diff_path_is_upstream);
@@ -366,7 +434,11 @@ fn build_requests(event: &Event, version: &Version) -> Result<Vec<BuiltRequest>,
     paths
         .into_iter()
         .map(|(path, kind, method)| {
-            let body = if method == Method::DELETE { None } else { Some(request_body(event, kind, version)?) };
+            let body = if method == Method::DELETE {
+                None
+            } else {
+                Some(request_body(event, kind, version)?)
+            };
             Ok((method, path, body, kind))
         })
         .collect()
@@ -375,11 +447,22 @@ fn build_requests(event: &Event, version: &Version) -> Result<Vec<BuiltRequest>,
 /// Builds the JSON body for one request. For a `SERVICE` event this is
 /// called once per request path, and `kind` says which of the (up to two)
 /// it's building for.
-fn request_body(event: &Event, kind: RequestKind, version: &Version) -> Result<Value, BackendError> {
-    let new_value = event.kind.new_value().ok_or_else(|| BackendError::Other("create/update event is missing new_value".into()))?;
+fn request_body(
+    event: &Event,
+    kind: RequestKind,
+    version: &Version,
+) -> Result<Value, BackendError> {
+    let new_value = event
+        .kind
+        .new_value()
+        .ok_or_else(|| BackendError::Other("create/update event is missing new_value".into()))?;
 
     match event.resource_type {
-        ResourceType::Consumer => to_request_body(typing::Consumer::from(deserialize_event_value::<adc::Consumer>(new_value)?)),
+        ResourceType::Consumer => {
+            to_request_body(typing::Consumer::from(deserialize_event_value::<
+                adc::Consumer,
+            >(new_value)?))
+        }
         ResourceType::ConsumerGroup => {
             let group: adc::ConsumerGroup = deserialize_event_value(new_value)?;
             let (mut wire, _consumers) = transformer::transform_consumer_group(group);
@@ -397,7 +480,9 @@ fn request_body(event: &Event, kind: RequestKind, version: &Version) -> Result<V
             credential.id = Some(event.resource_id.clone());
             to_request_body(typing::ConsumerCredential::from(credential))
         }
-        ResourceType::GlobalRule => Ok(serde_json::json!({ "plugins": { event.resource_id.clone(): new_value.clone() } })),
+        ResourceType::GlobalRule => {
+            Ok(serde_json::json!({ "plugins": { event.resource_id.clone(): new_value.clone() } }))
+        }
         ResourceType::PluginMetadata => Ok(new_value.clone()),
         ResourceType::Route => {
             // The differ's event carries the authoritative id
@@ -407,7 +492,10 @@ fn request_body(event: &Event, kind: RequestKind, version: &Version) -> Result<V
             // the URL, including when the body's id is empty.
             let mut route: adc::Route = deserialize_event_value(new_value)?;
             route.id = Some(event.resource_id.clone());
-            let parent_id = event.parent_id.clone().ok_or_else(|| missing_parent(event))?;
+            let parent_id = event
+                .parent_id
+                .clone()
+                .ok_or_else(|| missing_parent(event))?;
             to_request_body(transformer::transform_route(route, parent_id))
         }
         ResourceType::Service => {
@@ -417,7 +505,13 @@ fn request_body(event: &Event, kind: RequestKind, version: &Version) -> Result<V
             match kind {
                 RequestKind::Upstream => {
                     let upstream = wire_upstream.ok_or_else(|| {
-                        BackendError::Other(format!("service {:?} has no default upstream to write", event.resource_id).into())
+                        BackendError::Other(
+                            format!(
+                                "service {:?} has no default upstream to write",
+                                event.resource_id
+                            )
+                            .into(),
+                        )
                     })?;
                     to_request_body(upstream)
                 }
@@ -431,23 +525,32 @@ fn request_body(event: &Event, kind: RequestKind, version: &Version) -> Result<V
         }
         ResourceType::StreamRoute => {
             let route: adc::StreamRoute = deserialize_event_value(new_value)?;
-            let parent_id = event.parent_id.clone().ok_or_else(|| missing_parent(event))?;
-            let inject_name = *version >= Version::new(3, 8, 0);
-            to_request_body(transformer::transform_stream_route(route, parent_id, inject_name))
+            let parent_id = event
+                .parent_id
+                .clone()
+                .ok_or_else(|| missing_parent(event))?;
+            let name_mode = transformer::StreamRouteNameMode::for_version(version);
+            to_request_body(transformer::transform_stream_route(
+                route, parent_id, name_mode,
+            ))
         }
         ResourceType::Upstream => {
             let upstream: adc::Upstream = deserialize_event_value(new_value)?;
             let mut wire = typing::Upstream::from(upstream);
             if let Some(parent_id) = &event.parent_id {
                 let mut labels = wire.labels.unwrap_or_default();
-                labels.insert(typing::ADC_UPSTREAM_SERVICE_ID_LABEL.to_string(), adc::LabelValue::Single(parent_id.clone()));
+                labels.insert(
+                    typing::ADC_UPSTREAM_SERVICE_ID_LABEL.to_string(),
+                    adc::LabelValue::Single(parent_id.clone()),
+                );
                 wire.labels = Some(labels);
             }
             to_request_body(wire)
         }
-        ResourceType::InternalStreamService => {
-            Err(BackendError::Unsupported(format!("{:?} is not directly syncable by the apisix backend", event.resource_type)))
-        }
+        ResourceType::InternalStreamService => Err(BackendError::Unsupported(format!(
+            "{:?} is not directly syncable by the apisix backend",
+            event.resource_type
+        ))),
     }
 }
 
@@ -463,7 +566,13 @@ mod tests {
     }
 
     fn create(rt: ResourceType, id: &str) -> Event {
-        event(rt, EventKind::Create { new_value: json!({}) }, id)
+        event(
+            rt,
+            EventKind::Create {
+                new_value: json!({}),
+            },
+            id,
+        )
     }
 
     #[test]
@@ -471,7 +580,13 @@ mod tests {
         let route1 = create(ResourceType::Route, "r1");
         let consumer = create(ResourceType::Consumer, "c1");
         let route2 = create(ResourceType::Route, "r2");
-        let ssl_delete = event(ResourceType::Ssl, EventKind::Delete { old_value: json!({}) }, "s1");
+        let ssl_delete = event(
+            ResourceType::Ssl,
+            EventKind::Delete {
+                old_value: json!({}),
+            },
+            "s1",
+        );
 
         let groups = group_events(vec![route1, consumer, route2, ssl_delete]);
 
@@ -492,7 +607,13 @@ mod tests {
     #[test]
     fn same_resource_type_but_different_event_type_gets_its_own_group() {
         let create_route = create(ResourceType::Route, "r1");
-        let delete_route = event(ResourceType::Route, EventKind::Delete { old_value: json!({}) }, "r2");
+        let delete_route = event(
+            ResourceType::Route,
+            EventKind::Delete {
+                old_value: json!({}),
+            },
+            "r2",
+        );
 
         let groups = group_events(vec![create_route, delete_route]);
 
@@ -515,7 +636,9 @@ mod tests {
         // path (built from `event.resource_id`) and APISIX will reject it.
         let group_event = Event::new(
             ResourceType::ConsumerGroup,
-            EventKind::Create { new_value: json!({ "name": "renamed-group" }) },
+            EventKind::Create {
+                new_value: json!({ "name": "renamed-group" }),
+            },
             "stable-id",
             "renamed-group",
         );
@@ -530,12 +653,22 @@ mod tests {
     fn service_create_without_an_upstream_produces_only_the_main_request() {
         let service_event = event(
             ResourceType::Service,
-            EventKind::Create { new_value: json!({ "name": "svc-no-upstream" }) },
+            EventKind::Create {
+                new_value: json!({ "name": "svc-no-upstream" }),
+            },
             "svc-no-upstream",
         );
         let requests = build_requests(&service_event, &Version::new(3, 17, 0)).unwrap();
-        assert_eq!(requests.len(), 1, "no upstream request should be generated for a service with no upstream");
-        assert!(requests[0].1.ends_with("/services/svc-no-upstream"), "{}", requests[0].1);
+        assert_eq!(
+            requests.len(),
+            1,
+            "no upstream request should be generated for a service with no upstream"
+        );
+        assert!(
+            requests[0].1.ends_with("/services/svc-no-upstream"),
+            "{}",
+            requests[0].1
+        );
     }
 
     /// Regression: losing the upstream's *presence* (not just its content)
@@ -549,21 +682,38 @@ mod tests {
     fn service_update_removing_its_upstream_detaches_the_reference_before_deleting_it() {
         let old_value = json!({ "name": "svc1", "upstream": { "nodes": [] } });
         let new_value = json!({ "name": "svc1" });
-        let diff = vec![ValueDiff::Deleted { path: vec![PathSegment::Key("upstream".to_string())], lhs: old_value["upstream"].clone() }];
-        let service_event =
-            Event::new(ResourceType::Service, EventKind::Update { old_value, new_value, diff: Some(diff) }, "svc1", "svc1");
+        let diff = vec![ValueDiff::Deleted {
+            path: vec![PathSegment::Key("upstream".to_string())],
+            lhs: old_value["upstream"].clone(),
+        }];
+        let service_event = Event::new(
+            ResourceType::Service,
+            EventKind::Update {
+                old_value,
+                new_value,
+                diff: Some(diff),
+            },
+            "svc1",
+            "svc1",
+        );
 
         let requests = build_requests(&service_event, &Version::new(3, 17, 0)).unwrap();
         assert_eq!(requests.len(), 2);
 
         let (method, path, body, kind) = &requests[0];
-        assert!(matches!(kind, RequestKind::Main), "service request must come first");
+        assert!(
+            matches!(kind, RequestKind::Main),
+            "service request must come first"
+        );
         assert_eq!(*method, Method::PUT);
         assert_eq!(body.as_ref().unwrap()["upstream_id"], Value::Null);
         assert!(path.ends_with("/services/svc1"), "{path}");
 
         let (method, path, body, kind) = &requests[1];
-        assert!(matches!(kind, RequestKind::Upstream), "upstream DELETE must come after");
+        assert!(
+            matches!(kind, RequestKind::Upstream),
+            "upstream DELETE must come after"
+        );
         assert_eq!(*method, Method::DELETE);
         assert!(body.is_none());
         assert!(path.ends_with("/upstreams/svc1"), "{path}");
@@ -575,20 +725,43 @@ mod tests {
     /// `touches_non_upstream` was already true), but still ordered the
     /// upstream DELETE *before* the service request that detaches it.
     #[test]
-    fn service_update_changing_another_field_and_removing_its_upstream_still_detaches_before_deleting() {
-        let old_value = json!({ "name": "svc1", "description": "old", "upstream": { "nodes": [] } });
+    fn service_update_changing_another_field_and_removing_its_upstream_still_detaches_before_deleting()
+     {
+        let old_value =
+            json!({ "name": "svc1", "description": "old", "upstream": { "nodes": [] } });
         let new_value = json!({ "name": "svc1", "description": "new" });
         let diff = vec![
-            ValueDiff::Edit { path: vec![PathSegment::Key("description".to_string())], lhs: json!("old"), rhs: json!("new") },
-            ValueDiff::Deleted { path: vec![PathSegment::Key("upstream".to_string())], lhs: old_value["upstream"].clone() },
+            ValueDiff::Edit {
+                path: vec![PathSegment::Key("description".to_string())],
+                lhs: json!("old"),
+                rhs: json!("new"),
+            },
+            ValueDiff::Deleted {
+                path: vec![PathSegment::Key("upstream".to_string())],
+                lhs: old_value["upstream"].clone(),
+            },
         ];
-        let service_event =
-            Event::new(ResourceType::Service, EventKind::Update { old_value, new_value, diff: Some(diff) }, "svc1", "svc1");
+        let service_event = Event::new(
+            ResourceType::Service,
+            EventKind::Update {
+                old_value,
+                new_value,
+                diff: Some(diff),
+            },
+            "svc1",
+            "svc1",
+        );
 
         let requests = build_requests(&service_event, &Version::new(3, 17, 0)).unwrap();
         assert_eq!(requests.len(), 2);
-        assert!(matches!(requests[0].3, RequestKind::Main), "service request must come first");
-        assert!(matches!(requests[1].3, RequestKind::Upstream), "upstream DELETE must come after");
+        assert!(
+            matches!(requests[0].3, RequestKind::Main),
+            "service request must come first"
+        );
+        assert!(
+            matches!(requests[1].3, RequestKind::Upstream),
+            "upstream DELETE must come after"
+        );
         assert_eq!(requests[1].0, Method::DELETE);
     }
 
@@ -599,20 +772,37 @@ mod tests {
     fn service_update_gaining_an_upstream_creates_it_before_pointing_the_service_at_it() {
         let old_value = json!({ "name": "svc1" });
         let new_value = json!({ "name": "svc1", "upstream": { "nodes": [{"host":"1.1.1.1","port":80,"weight":1}] } });
-        let diff = vec![ValueDiff::New { path: vec![PathSegment::Key("upstream".to_string())], rhs: new_value["upstream"].clone() }];
-        let service_event =
-            Event::new(ResourceType::Service, EventKind::Update { old_value, new_value, diff: Some(diff) }, "svc1", "svc1");
+        let diff = vec![ValueDiff::New {
+            path: vec![PathSegment::Key("upstream".to_string())],
+            rhs: new_value["upstream"].clone(),
+        }];
+        let service_event = Event::new(
+            ResourceType::Service,
+            EventKind::Update {
+                old_value,
+                new_value,
+                diff: Some(diff),
+            },
+            "svc1",
+            "svc1",
+        );
 
         let requests = build_requests(&service_event, &Version::new(3, 17, 0)).unwrap();
         assert_eq!(requests.len(), 2);
 
         let (method, path, _, kind) = &requests[0];
-        assert!(matches!(kind, RequestKind::Upstream), "upstream PUT must come first");
+        assert!(
+            matches!(kind, RequestKind::Upstream),
+            "upstream PUT must come first"
+        );
         assert_eq!(*method, Method::PUT);
         assert!(path.ends_with("/upstreams/svc1"), "{path}");
 
         let (method, path, body, kind) = &requests[1];
-        assert!(matches!(kind, RequestKind::Main), "service request must come after");
+        assert!(
+            matches!(kind, RequestKind::Main),
+            "service request must come after"
+        );
         assert_eq!(*method, Method::PUT);
         assert_eq!(body.as_ref().unwrap()["upstream_id"], "svc1");
         assert!(path.ends_with("/services/svc1"), "{path}");
@@ -622,7 +812,11 @@ mod tests {
     fn service_update_with_no_diff_is_rejected_instead_of_silently_sending_nothing() {
         let service_event = Event::new(
             ResourceType::Service,
-            EventKind::Update { old_value: json!({}), new_value: json!({}), diff: None },
+            EventKind::Update {
+                old_value: json!({}),
+                new_value: json!({}),
+                diff: None,
+            },
             "svc1",
             "svc1",
         );
@@ -634,7 +828,9 @@ mod tests {
         let route_event = {
             let mut e = event(
                 ResourceType::Route,
-                EventKind::Create { new_value: json!({ "name": "r1", "uris": ["/x"] }) },
+                EventKind::Create {
+                    new_value: json!({ "name": "r1", "uris": ["/x"] }),
+                },
                 "a/../b",
             );
             e.parent_id = Some("svc1".to_string());
@@ -642,7 +838,11 @@ mod tests {
         };
         let requests = build_requests(&route_event, &Version::new(3, 17, 0)).unwrap();
         assert_eq!(requests.len(), 1);
-        assert!(requests[0].1.starts_with("/apisix/admin/routes/"), "{}", requests[0].1);
+        assert!(
+            requests[0].1.starts_with("/apisix/admin/routes/"),
+            "{}",
+            requests[0].1
+        );
         assert!(!requests[0].1.contains("/../"), "{}", requests[0].1);
     }
 }

--- a/rust/crates/adc-backend-apisix/src/transformer.rs
+++ b/rust/crates/adc-backend-apisix/src/transformer.rs
@@ -367,10 +367,14 @@ fn extract_name_label(labels: &Option<adc::Labels>, key: &str) -> Option<String>
 
 impl From<typing::StreamRoute> for adc::StreamRoute {
     fn from(route: typing::StreamRoute) -> Self {
-        // APISIX's stream routes have no `name` field at all; ADC smuggles
-        // one through a magic label when writing, and recovers it here when
-        // reading back, falling back to `id` if it was never set that way.
-        let name = extract_name_label(&route.labels, typing::ADC_NAME_LABEL)
+        // Native `name` wins when present (APISIX >= 3.13.0). Older servers,
+        // and routes never re-synced since upgrading past 3.13.0, only have
+        // the magic label ADC used to smuggle a name through; `id` is the
+        // last resort when neither was ever set.
+        let name = route
+            .name
+            .clone()
+            .or_else(|| extract_name_label(&route.labels, typing::ADC_NAME_LABEL))
             .unwrap_or_else(|| route.id.clone().unwrap_or_default());
         let labels = route
             .labels
@@ -618,25 +622,56 @@ impl From<adc::SSL> for typing::Ssl {
     }
 }
 
-/// Builds a stream route's wire body. `inject_name` gates whether ADC's name
-/// gets smuggled through the `__ADC_NAME` label (older APISIX versions
-/// don't support labels on stream routes at all, so the caller only sets
-/// this once it's confirmed the target version does — APISIX >= 3.8.0).
+/// How a stream route's ADC name gets persisted, decided by the caller from
+/// the target APISIX version and threaded through to
+/// [`transform_stream_route`]:
+/// - `Unsupported`: below 3.8.0, stream routes don't even support `labels`,
+///   so the name can't be persisted at all.
+/// - `Label`: `[3.8.0, 3.13.0)` — `labels` exist but there's no native
+///   `name` field yet, so ADC smuggles one through the `__ADC_NAME` label.
+/// - `Native`: `>= 3.13.0` — written straight to the (now native) `name`
+///   field; no label needed. A route last synced under `Label` mode still
+///   carries the old label until it's synced again under `Native`, at which
+///   point this stops re-adding it and it falls off on its own — see
+///   `impl From<typing::StreamRoute> for adc::StreamRoute`'s read side,
+///   which prefers the native field but still falls back to the label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamRouteNameMode {
+    Unsupported,
+    Label,
+    Native,
+}
+
+impl StreamRouteNameMode {
+    pub fn for_version(version: &semver::Version) -> Self {
+        if *version >= semver::Version::new(3, 13, 0) {
+            Self::Native
+        } else if *version >= semver::Version::new(3, 8, 0) {
+            Self::Label
+        } else {
+            Self::Unsupported
+        }
+    }
+}
+
+/// Builds a stream route's wire body. See [`StreamRouteNameMode`] for how
+/// `name_mode` decides where ADC's name ends up.
 pub fn transform_stream_route(
     route: adc::StreamRoute,
     parent_id: String,
-    inject_name: bool,
+    name_mode: StreamRouteNameMode,
 ) -> typing::StreamRoute {
     let mut labels = transform_labels_to_apisix(route.labels).unwrap_or_default();
-    if inject_name {
+    if name_mode == StreamRouteNameMode::Label {
         labels.insert(
             typing::ADC_NAME_LABEL.to_string(),
-            LabelValue::Single(route.name),
+            LabelValue::Single(route.name.clone()),
         );
     }
 
     typing::StreamRoute {
         id: None,
+        name: (name_mode == StreamRouteNameMode::Native).then_some(route.name),
         desc: route.description,
         labels: (!labels.is_empty()).then_some(labels),
 

--- a/rust/crates/adc-backend-apisix/src/typing.rs
+++ b/rust/crates/adc-backend-apisix/src/typing.rs
@@ -29,9 +29,11 @@ use serde_json::Value;
 
 pub const ADC_UPSTREAM_SERVICE_ID_LABEL: &str = "__ADC_UPSTREAM_SERVICE_ID";
 
-/// Label a stream route's ADC name is smuggled through, since APISIX
-/// stream routes have no native `name` field — see `transformer::
-/// transform_stream_route`'s doc comment.
+/// Label a stream route's ADC name was smuggled through on APISIX versions
+/// before 3.13.0, which had no native `name` field for stream routes — see
+/// `transformer::StreamRouteNameMode`'s doc comment. Still read as a
+/// fallback on newer servers, for routes never re-synced since the field
+/// became native.
 pub const ADC_NAME_LABEL: &str = "__ADC_NAME";
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -233,6 +235,11 @@ pub struct StreamRouteProtocol {
 pub struct StreamRoute {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Native as of APISIX 3.13.0 (absent, and unrecognized, on older
+    /// servers) — see `transformer::StreamRouteNameMode` for how ADC decides
+    /// which of this or the `ADC_NAME_LABEL` magic label to use.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub desc: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/rust/crates/adc-backend-apisix/src/validator.rs
+++ b/rust/crates/adc-backend-apisix/src/validator.rs
@@ -106,7 +106,10 @@ fn enrich(raw: RawValidationError, index: &ValidateIndex) -> BackendValidationEr
     }
 }
 
-fn build_request(events: &[Event], version: &Version) -> Result<(ValidateRequestBody, ValidateIndex), BackendError> {
+fn build_request(
+    events: &[Event],
+    version: &Version,
+) -> Result<(ValidateRequestBody, ValidateIndex), BackendError> {
     let mut body = ValidateRequestBody::default();
     let mut index: ValidateIndex = HashMap::new();
 
@@ -154,9 +157,10 @@ fn build_request(events: &[Event], version: &Version) -> Result<(ValidateRequest
                     .parent_id
                     .clone()
                     .ok_or_else(|| missing_parent(event))?;
-                let inject_name = *version >= Version::new(3, 8, 0);
-                body.stream_routes
-                    .push(transformer::transform_stream_route(route, parent_id, inject_name));
+                let name_mode = transformer::StreamRouteNameMode::for_version(version);
+                body.stream_routes.push(transformer::transform_stream_route(
+                    route, parent_id, name_mode,
+                ));
                 track(&mut index, "stream_routes");
             }
             ResourceType::Consumer => {
@@ -209,7 +213,9 @@ mod tests {
     fn stream_route_create(id: &str) -> Event {
         let mut event = Event::new(
             ResourceType::StreamRoute,
-            EventKind::Create { new_value: json!({ "name": id }) },
+            EventKind::Create {
+                new_value: json!({ "name": id }),
+            },
             id,
             id,
         );
@@ -219,15 +225,28 @@ mod tests {
 
     #[test]
     fn stream_route_omits_the_name_label_below_3_8_0() {
-        let (body, _) = build_request(&[stream_route_create("sr1")], &Version::new(3, 7, 0)).unwrap();
+        let (body, _) =
+            build_request(&[stream_route_create("sr1")], &Version::new(3, 7, 0)).unwrap();
         assert!(body.stream_routes[0].labels.is_none());
     }
 
     #[test]
     fn stream_route_injects_the_name_label_at_or_above_3_8_0() {
-        let (body, _) = build_request(&[stream_route_create("sr1")], &Version::new(3, 8, 0)).unwrap();
-        let labels = body.stream_routes[0].labels.as_ref().expect("name label injected");
+        let (body, _) =
+            build_request(&[stream_route_create("sr1")], &Version::new(3, 8, 0)).unwrap();
+        let labels = body.stream_routes[0]
+            .labels
+            .as_ref()
+            .expect("name label injected");
         assert!(labels.contains_key(typing::ADC_NAME_LABEL));
+    }
+
+    #[test]
+    fn stream_route_uses_the_native_name_field_at_or_above_3_13_0() {
+        let (body, _) =
+            build_request(&[stream_route_create("sr1")], &Version::new(3, 13, 0)).unwrap();
+        assert_eq!(body.stream_routes[0].name.as_deref(), Some("sr1"));
+        assert!(body.stream_routes[0].labels.is_none());
     }
 
     #[test]

--- a/rust/crates/adc-backend-apisix/tests/e2e_apisix.rs
+++ b/rust/crates/adc-backend-apisix/tests/e2e_apisix.rs
@@ -8,7 +8,7 @@
 //! Single-threaded because tests share one APISIX/etcd instance and each
 //! cleans up its own resources rather than sandboxing into a namespace.
 
-use adc_backend_apisix::tests::{Fetcher, Operator};
+use adc_backend_apisix::tests::{Fetcher, Operator, typing};
 use adc_sdk::{BackendSyncOptions, Event, EventKind, ResourceType};
 use semver::Version;
 use serde_json::json;
@@ -329,12 +329,17 @@ async fn syncs_a_stream_route_then_reads_it_back() {
         .expect("stream route was not written");
     assert_eq!(route.server_port, Some(33061));
     let adc_route: adc_sdk::resources::StreamRoute = route.clone().into();
-    if apisix_version() >= Version::new(3, 8, 0) {
-        // Recovered from the __ADC_NAME label injected on write (APISIX
-        // stream routes have no native `name` field, and that label is only
-        // written from 3.8.0 on) — proves the read/write round trip for
-        // that trick actually works against a real server, not just our
-        // own mock. Matches the TS suite's own `Dump (>=3.8.0)` case.
+    if apisix_version() >= Version::new(3, 13, 0) {
+        // Written straight to the native `name` field — no label needed.
+        assert_eq!(route.name.as_deref(), Some("e2e-stream-route"));
+        assert!(route.labels.as_ref().is_none_or(|labels| !labels.contains_key(typing::ADC_NAME_LABEL)));
+        assert_eq!(adc_route.name, "e2e-stream-route");
+    } else if apisix_version() >= Version::new(3, 8, 0) {
+        // Recovered from the __ADC_NAME label injected on write (no native
+        // `name` field below 3.13.0, and that label is only written from
+        // 3.8.0 on) — proves the read/write round trip for that trick
+        // actually works against a real server, not just our own mock.
+        // Matches the TS suite's own `Dump (>=3.8.0)` case.
         assert_eq!(adc_route.name, "e2e-stream-route");
     } else {
         // Below 3.8.0 no label is ever written, so recovery falls back to
@@ -354,6 +359,89 @@ async fn syncs_a_stream_route_then_reads_it_back() {
             .iter()
             .all(|r| r.id.as_deref() != Some(stream_route_id))
     );
+}
+
+/// A stream route written under the pre-3.13.0 `__ADC_NAME` label scheme
+/// (simulated here with a raw Admin API call, standing in for a route ADC
+/// itself wrote before either it or the server was upgraded) must still
+/// read its name correctly from a server that now supports the native
+/// field — and re-syncing it should migrate it to the native field,
+/// dropping the label.
+#[tokio::test]
+#[ignore]
+async fn a_legacy_label_named_stream_route_migrates_to_the_native_name_field() {
+    if apisix_version() < Version::new(3, 13, 0) {
+        eprintln!("skipping: the native stream route name field requires apisix >= 3.13.0");
+        return;
+    }
+
+    let mut cleanup = Cleanup::default();
+    let service_id = "e2e-svc-stream-migrate";
+    let stream_route_id = "e2e-stream-route-migrate";
+
+    sync_ok(vec![create(
+        ResourceType::Service,
+        service_id,
+        json!({ "name": "e2e stream migrate service", "upstream": { "nodes": [{ "host": "127.0.0.1", "port": 1980, "weight": 1 }] } }),
+    )])
+    .await;
+    cleanup.push(delete(ResourceType::StreamRoute, stream_route_id));
+    cleanup.push(delete(ResourceType::Service, service_id));
+
+    // Written directly, bypassing ADC entirely: only the legacy label
+    // carries a name, no native `name` field at all.
+    let http = client();
+    http.send(
+        http.request(
+            adc_backend_core::Method::PUT,
+            &format!("/apisix/admin/stream_routes/{stream_route_id}"),
+        )
+        .unwrap()
+        .json(&json!({
+            "server_port": 33062,
+            "service_id": service_id,
+            "labels": { "__ADC_NAME": "legacy-stream-route" },
+        })),
+    )
+    .await
+    .unwrap();
+
+    let stream_routes = fetcher().list_stream_routes().await.unwrap();
+    let route = stream_routes
+        .iter()
+        .find(|r| r.id.as_deref() == Some(stream_route_id))
+        .expect("stream route was not written");
+    assert!(route.name.is_none(), "no native name should exist yet");
+    let adc_route: adc_sdk::resources::StreamRoute = route.clone().into();
+    assert_eq!(adc_route.name, "legacy-stream-route");
+
+    // Re-syncing through ADC against a >= 3.13.0 server writes the native
+    // field instead of the label.
+    let mut migrate_event = create(
+        ResourceType::StreamRoute,
+        stream_route_id,
+        json!({ "name": "legacy-stream-route", "server_port": 33062 }),
+    );
+    migrate_event.parent_id = Some(service_id.to_string());
+    sync_ok(vec![migrate_event]).await;
+
+    let stream_routes = fetcher().list_stream_routes().await.unwrap();
+    let route = stream_routes
+        .iter()
+        .find(|r| r.id.as_deref() == Some(stream_route_id))
+        .expect("stream route disappeared after migrating sync");
+    assert_eq!(route.name.as_deref(), Some("legacy-stream-route"));
+    assert!(
+        route.labels.as_ref().is_none_or(|labels| !labels.contains_key(typing::ADC_NAME_LABEL)),
+        "the legacy label must be gone once the route has the native name"
+    );
+
+    sync_ok(vec![
+        delete(ResourceType::StreamRoute, stream_route_id),
+        delete(ResourceType::Service, service_id),
+    ])
+    .await;
+    cleanup.disarm();
 }
 
 #[tokio::test]

--- a/rust/crates/adc-backend-apisix/tests/transformer.rs
+++ b/rust/crates/adc-backend-apisix/tests/transformer.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use adc_backend_apisix::tests::transformer::{transform_consumer_group, transform_route, transform_service, transform_stream_route};
+use adc_backend_apisix::tests::transformer::{
+    StreamRouteNameMode, transform_consumer_group, transform_route, transform_service,
+    transform_stream_route,
+};
 use adc_backend_apisix::tests::typing;
 use adc_sdk::resources::{self as adc, LabelValue};
 use serde_json::json;
@@ -66,27 +69,65 @@ fn adc_upstream() -> adc::Upstream {
 }
 
 fn adc_ssl() -> adc::SSL {
-    adc::SSL { id: None, labels: None, r#type: adc::SslType::default(), snis: vec![], certificates: vec![], client: None, ssl_protocols: None }
+    adc::SSL {
+        id: None,
+        labels: None,
+        r#type: adc::SslType::default(),
+        snis: vec![],
+        certificates: vec![],
+        client: None,
+        ssl_protocols: None,
+    }
 }
 
 fn adc_credential(name: &str, ty: &str) -> adc::ConsumerCredential {
-    adc::ConsumerCredential { id: None, name: name.to_string(), description: None, labels: None, r#type: ty.to_string(), config: serde_json::Map::new() }
+    adc::ConsumerCredential {
+        id: None,
+        name: name.to_string(),
+        description: None,
+        labels: None,
+        r#type: ty.to_string(),
+        config: serde_json::Map::new(),
+    }
 }
 
 fn adc_stream_route(name: &str) -> adc::StreamRoute {
-    adc::StreamRoute { id: None, name: name.to_string(), description: None, labels: None, plugins: None, remote_addr: None, server_addr: None, server_port: None, sni: None }
+    adc::StreamRoute {
+        id: None,
+        name: name.to_string(),
+        description: None,
+        labels: None,
+        plugins: None,
+        remote_addr: None,
+        server_addr: None,
+        server_port: None,
+        sni: None,
+    }
 }
 
 fn adc_consumer_group(name: &str) -> adc::ConsumerGroup {
-    adc::ConsumerGroup { id: None, name: name.to_string(), description: None, labels: None, plugins: None, consumers: None }
+    adc::ConsumerGroup {
+        id: None,
+        name: name.to_string(),
+        description: None,
+        labels: None,
+        plugins: None,
+        consumers: None,
+    }
 }
 
 fn route(id: &str) -> typing::Route {
-    typing::Route { id: id.to_string(), ..Default::default() }
+    typing::Route {
+        id: id.to_string(),
+        ..Default::default()
+    }
 }
 
 fn service(id: &str) -> typing::Service {
-    typing::Service { id: id.to_string(), ..Default::default() }
+    typing::Service {
+        id: id.to_string(),
+        ..Default::default()
+    }
 }
 
 fn upstream() -> typing::Upstream {
@@ -129,14 +170,22 @@ fn route_parses_recognized_http_methods() {
     let mut route = route("r1");
     route.methods = Some(vec!["GET".into(), "POST".into()]);
     let adc_route: adc::Route = route.try_into().unwrap();
-    assert_eq!(adc_route.methods, Some(vec![adc::HttpMethod::Get, adc::HttpMethod::Post]));
+    assert_eq!(
+        adc_route.methods,
+        Some(vec![adc::HttpMethod::Get, adc::HttpMethod::Post])
+    );
 }
 
 #[test]
 fn upstream_list_nodes_pass_through_unchanged() {
     let mut upstream = upstream();
-    upstream.nodes =
-        Some(typing::UpstreamNodes::List(vec![adc::UpstreamNode { host: "10.0.0.1".into(), port: 8080, weight: 1, priority: 0, metadata: None }]));
+    upstream.nodes = Some(typing::UpstreamNodes::List(vec![adc::UpstreamNode {
+        host: "10.0.0.1".into(),
+        port: 8080,
+        weight: 1,
+        priority: 0,
+        metadata: None,
+    }]));
     let adc_upstream: adc::Upstream = upstream.try_into().unwrap();
     let nodes = adc_upstream.nodes.unwrap();
     assert_eq!(nodes.len(), 1);
@@ -147,7 +196,10 @@ fn upstream_list_nodes_pass_through_unchanged() {
 #[test]
 fn upstream_discovery_map_nodes_parse_host_and_port() {
     let mut upstream = upstream();
-    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([("10.0.0.1:9000".to_string(), 5)])));
+    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([(
+        "10.0.0.1:9000".to_string(),
+        5,
+    )])));
     let adc_upstream: adc::Upstream = upstream.try_into().unwrap();
     let nodes = adc_upstream.nodes.unwrap();
     assert_eq!(nodes.len(), 1);
@@ -159,7 +211,10 @@ fn upstream_discovery_map_nodes_parse_host_and_port() {
 #[test]
 fn upstream_discovery_map_nodes_without_a_port_is_rejected() {
     let mut upstream = upstream();
-    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([("10.0.0.1".to_string(), 1)])));
+    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([(
+        "10.0.0.1".to_string(),
+        1,
+    )])));
     let result: Result<adc::Upstream, String> = upstream.try_into();
     assert!(result.is_err());
 }
@@ -167,7 +222,10 @@ fn upstream_discovery_map_nodes_without_a_port_is_rejected() {
 #[test]
 fn upstream_discovery_map_nodes_parse_bracketed_ipv6_host_and_port() {
     let mut upstream = upstream();
-    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([("[::1]:9000".to_string(), 5)])));
+    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([(
+        "[::1]:9000".to_string(),
+        5,
+    )])));
     let adc_upstream: adc::Upstream = upstream.try_into().unwrap();
     let nodes = adc_upstream.nodes.unwrap();
     assert_eq!(nodes.len(), 1);
@@ -179,7 +237,10 @@ fn upstream_discovery_map_nodes_parse_bracketed_ipv6_host_and_port() {
 #[test]
 fn upstream_discovery_map_nodes_bracketed_ipv6_without_a_port_is_rejected() {
     let mut upstream = upstream();
-    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([("[::1]".to_string(), 1)])));
+    upstream.nodes = Some(typing::UpstreamNodes::Map(HashMap::from([(
+        "[::1]".to_string(),
+        1,
+    )])));
     let result: Result<adc::Upstream, String> = upstream.try_into();
     assert!(result.is_err());
 }
@@ -188,7 +249,10 @@ fn upstream_discovery_map_nodes_bracketed_ipv6_without_a_port_is_rejected() {
 fn upstream_strips_the_service_association_label_but_keeps_others() {
     let mut upstream = upstream();
     upstream.labels = Some(HashMap::from([
-        (typing::ADC_UPSTREAM_SERVICE_ID_LABEL.to_string(), LabelValue::Single("svc1".into())),
+        (
+            typing::ADC_UPSTREAM_SERVICE_ID_LABEL.to_string(),
+            LabelValue::Single("svc1".into()),
+        ),
         ("env".to_string(), LabelValue::Single("prod".into())),
     ]));
     let adc_upstream: adc::Upstream = upstream.try_into().unwrap();
@@ -242,8 +306,14 @@ fn ssl_pairs_the_primary_and_additional_certificates() {
     assert_eq!(
         adc_ssl.certificates,
         vec![
-            adc::SSLCertificate { certificate: "CERT_A".into(), key: "KEY_A".into() },
-            adc::SSLCertificate { certificate: "CERT_B".into(), key: "KEY_B".into() },
+            adc::SSLCertificate {
+                certificate: "CERT_A".into(),
+                key: "KEY_A".into()
+            },
+            adc::SSLCertificate {
+                certificate: "CERT_B".into(),
+                key: "KEY_B".into()
+            },
         ]
     );
 }
@@ -288,7 +358,13 @@ fn ssl_with_a_redacted_key_degrades_to_an_empty_placeholder_instead_of_failing()
         status: 1,
     };
     let adc_ssl: adc::SSL = ssl.try_into().unwrap();
-    assert_eq!(adc_ssl.certificates, vec![adc::SSLCertificate { certificate: "CERT_A".into(), key: String::new() }]);
+    assert_eq!(
+        adc_ssl.certificates,
+        vec![adc::SSLCertificate {
+            certificate: "CERT_A".into(),
+            key: String::new()
+        }]
+    );
 }
 
 #[test]
@@ -348,7 +424,14 @@ fn consumer_drops_credentials_that_fail_to_convert_but_keeps_the_rest() {
 
 #[test]
 fn consumer_with_credentials_never_fetched_stays_none_not_empty() {
-    let consumer = typing::Consumer { username: "alice".into(), desc: None, labels: None, group_id: None, plugins: None, credentials: None };
+    let consumer = typing::Consumer {
+        username: "alice".into(),
+        desc: None,
+        labels: None,
+        group_id: None,
+        plugins: None,
+        credentials: None,
+    };
     let adc_consumer: adc::Consumer = consumer.into();
     assert!(adc_consumer.credentials.is_none());
 }
@@ -357,9 +440,13 @@ fn consumer_with_credentials_never_fetched_stays_none_not_empty() {
 fn stream_route_recovers_its_name_from_the_magic_label_and_strips_it() {
     let route = typing::StreamRoute {
         id: Some("sr1".into()),
+        name: None,
         desc: None,
         labels: Some(HashMap::from([
-            ("__ADC_NAME".to_string(), LabelValue::Single("my-stream-route".into())),
+            (
+                "__ADC_NAME".to_string(),
+                LabelValue::Single("my-stream-route".into()),
+            ),
             ("env".to_string(), LabelValue::Single("prod".into())),
         ])),
         remote_addr: None,
@@ -384,6 +471,7 @@ fn stream_route_recovers_its_name_from_the_magic_label_and_strips_it() {
 fn stream_route_without_the_magic_label_falls_back_to_id() {
     let route = typing::StreamRoute {
         id: Some("sr1".into()),
+        name: None,
         desc: None,
         labels: None,
         remote_addr: None,
@@ -401,6 +489,34 @@ fn stream_route_without_the_magic_label_falls_back_to_id() {
 }
 
 #[test]
+fn stream_route_prefers_the_native_name_over_the_magic_label() {
+    let route = typing::StreamRoute {
+        id: Some("sr1".into()),
+        name: Some("native-name".into()),
+        desc: None,
+        labels: Some(HashMap::from([(
+            "__ADC_NAME".to_string(),
+            LabelValue::Single("stale-label-name".into()),
+        )])),
+        remote_addr: None,
+        server_addr: None,
+        server_port: None,
+        sni: None,
+        upstream: None,
+        upstream_id: None,
+        service_id: None,
+        plugins: None,
+        protocol: None,
+    };
+    let adc_route: adc::StreamRoute = route.into();
+    assert_eq!(adc_route.name, "native-name");
+    assert!(
+        adc_route.labels.is_none(),
+        "the stale magic label must still be stripped"
+    );
+}
+
+#[test]
 fn write_route_carries_parent_id_and_stringifies_methods() {
     let mut route = adc_route("r1");
     route.uris = vec!["/foo".into()];
@@ -409,7 +525,10 @@ fn write_route_carries_parent_id_and_stringifies_methods() {
     let wire = transform_route(route, "svc1".into());
     assert_eq!(wire.service_id.as_deref(), Some("svc1"));
     assert_eq!(wire.uris, Some(vec!["/foo".to_string()]));
-    assert_eq!(wire.methods, Some(vec!["GET".to_string(), "POST".to_string()]));
+    assert_eq!(
+        wire.methods,
+        Some(vec!["GET".to_string(), "POST".to_string()])
+    );
     assert_eq!(wire.status, Some(1));
 }
 
@@ -418,7 +537,10 @@ fn write_route_labels_are_plain_strings_arrays_get_json_stringified() {
     let mut route = adc_route("r1");
     route.labels = Some(HashMap::from([
         ("env".to_string(), LabelValue::Single("prod".into())),
-        ("team".to_string(), LabelValue::Multiple(vec!["a".into(), "b".into()])),
+        (
+            "team".to_string(),
+            LabelValue::Multiple(vec!["a".into(), "b".into()]),
+        ),
     ]));
 
     let wire = transform_route(route, "svc1".into());
@@ -434,7 +556,10 @@ fn write_service_splits_into_service_and_matching_upstream() {
     service.upstream = Some(adc_upstream());
 
     let (wire_service, wire_upstream) = transform_service(service);
-    assert!(wire_service.upstream.is_none(), "upstream must not be inlined into the service body");
+    assert!(
+        wire_service.upstream.is_none(),
+        "upstream must not be inlined into the service body"
+    );
     assert_eq!(wire_service.upstream_id.as_deref(), Some("svc1"));
 
     let wire_upstream = wire_upstream.expect("service had a default upstream");
@@ -464,8 +589,14 @@ fn write_upstream_never_carries_its_own_id() {
 fn write_ssl_splits_certificates_into_primary_and_additional() {
     let mut ssl = adc_ssl();
     ssl.certificates = vec![
-        adc::SSLCertificate { certificate: "CERT_A".into(), key: "KEY_A".into() },
-        adc::SSLCertificate { certificate: "CERT_B".into(), key: "KEY_B".into() },
+        adc::SSLCertificate {
+            certificate: "CERT_A".into(),
+            key: "KEY_A".into(),
+        },
+        adc::SSLCertificate {
+            certificate: "CERT_B".into(),
+            key: "KEY_B".into(),
+        },
     ];
 
     let wire: typing::Ssl = ssl.into();
@@ -479,7 +610,10 @@ fn write_ssl_splits_certificates_into_primary_and_additional() {
 #[test]
 fn write_ssl_with_a_single_certificate_omits_certs_and_keys() {
     let mut ssl = adc_ssl();
-    ssl.certificates = vec![adc::SSLCertificate { certificate: "CERT_A".into(), key: "KEY_A".into() }];
+    ssl.certificates = vec![adc::SSLCertificate {
+        certificate: "CERT_A".into(),
+        key: "KEY_A".into(),
+    }];
 
     let wire: typing::Ssl = ssl.into();
     assert!(wire.certs.is_none());
@@ -494,23 +628,62 @@ fn write_consumer_credential_wraps_type_and_config_into_a_plugins_map() {
     let wire: typing::ConsumerCredential = credential.into();
     let plugins = wire.plugins.unwrap();
     assert_eq!(plugins.len(), 1);
-    assert_eq!(plugins.get("key-auth").and_then(|v| v.get("key")), Some(&json!("secret")));
+    assert_eq!(
+        plugins.get("key-auth").and_then(|v| v.get("key")),
+        Some(&json!("secret"))
+    );
 }
 
 #[test]
-fn write_stream_route_injects_the_name_label_when_requested() {
+fn write_stream_route_injects_the_name_label_in_label_mode() {
     let route = adc_stream_route("my-stream-route");
-    let wire = transform_stream_route(route, "svc1".into(), true);
+    let wire = transform_stream_route(route, "svc1".into(), StreamRouteNameMode::Label);
     let labels = wire.labels.unwrap();
-    assert_eq!(labels.get("__ADC_NAME"), Some(&LabelValue::Single("my-stream-route".to_string())));
+    assert_eq!(
+        labels.get("__ADC_NAME"),
+        Some(&LabelValue::Single("my-stream-route".to_string()))
+    );
+    assert!(wire.name.is_none());
     assert_eq!(wire.service_id.as_deref(), Some("svc1"));
 }
 
 #[test]
-fn write_stream_route_omits_the_name_label_when_not_requested() {
+fn write_stream_route_omits_the_name_label_when_unsupported() {
     let route = adc_stream_route("my-stream-route");
-    let wire = transform_stream_route(route, "svc1".into(), false);
+    let wire = transform_stream_route(route, "svc1".into(), StreamRouteNameMode::Unsupported);
     assert!(wire.labels.is_none());
+    assert!(wire.name.is_none());
+}
+
+#[test]
+fn write_stream_route_uses_the_native_name_field_in_native_mode() {
+    let route = adc_stream_route("my-stream-route");
+    let wire = transform_stream_route(route, "svc1".into(), StreamRouteNameMode::Native);
+    assert_eq!(wire.name.as_deref(), Some("my-stream-route"));
+    assert!(
+        wire.labels.is_none(),
+        "native mode must not also inject the magic label"
+    );
+}
+
+#[test]
+fn stream_route_name_mode_picks_the_right_tier_by_version() {
+    assert_eq!(
+        StreamRouteNameMode::for_version(&semver::Version::new(3, 7, 0)),
+        StreamRouteNameMode::Unsupported
+    );
+    assert_eq!(
+        StreamRouteNameMode::for_version(&semver::Version::new(3, 8, 0)),
+        StreamRouteNameMode::Label
+    );
+    assert_eq!(
+        StreamRouteNameMode::for_version(&semver::Version::new(3, 12, 0)),
+        StreamRouteNameMode::Label
+    );
+    assert_eq!(
+        StreamRouteNameMode::for_version(&semver::Version::new(3, 13, 0)),
+        StreamRouteNameMode::Native
+    );
 }
 
 #[test]
@@ -518,13 +691,22 @@ fn write_consumer_group_derives_its_id_from_the_name_and_injects_adc_name() {
     let group = adc_consumer_group("my-group");
     let (wire, _consumers) = transform_consumer_group(group);
     assert_eq!(wire.id, adc_sdk::utils::generate_id("my-group"));
-    assert_eq!(wire.labels.unwrap().get("ADC_NAME"), Some(&LabelValue::Single("my-group".to_string())));
+    assert_eq!(
+        wire.labels.unwrap().get("ADC_NAME"),
+        Some(&LabelValue::Single("my-group".to_string()))
+    );
 }
 
 #[test]
 fn write_consumer_group_stamps_its_id_onto_member_consumers() {
     let mut group = adc_consumer_group("my-group");
-    group.consumers = Some(vec![adc::Consumer { username: "alice".into(), description: None, labels: None, plugins: None, credentials: None }]);
+    group.consumers = Some(vec![adc::Consumer {
+        username: "alice".into(),
+        description: None,
+        labels: None,
+        plugins: None,
+        credentials: None,
+    }]);
 
     let (wire_group, consumers) = transform_consumer_group(group);
     assert_eq!(consumers.len(), 1);


### PR DESCRIPTION
### Description

Support native name field in APISIX's stream route.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream routes now preserve their names using APISIX’s native naming support in version 3.13 and later.
  * APISIX 3.8–3.12 continue using the legacy naming mechanism.
  * Older unsupported versions fall back to route IDs when no name is available.
* **Bug Fixes**
  * Native route names now take precedence over outdated legacy labels.
  * Legacy-labeled routes can be migrated to the native name field during synchronization, with obsolete labels removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->