### PR TITLE
fix(server): rust server command alias

### DIFF
--- a/rust/crates/adc-cli/src/cli.rs
+++ b/rust/crates/adc-cli/src/cli.rs
@@ -38,7 +38,7 @@ pub enum Command {
     #[command(hide = true)]
     IngressSync,
     /// run the local ingress server
-    #[command(hide = true)]
+    #[command(hide = true, alias = "server")]
     IngressServer(IngressServerArgs),
 }
 
@@ -296,4 +296,24 @@ fn existing_file(raw: &str) -> Result<PathBuf, String> {
 /// only ever deals with bytes already in memory, never a path.
 fn read_file_bytes(raw: &str) -> Result<Vec<u8>, String> {
     std::fs::read(raw).map_err(|e| format!("{raw}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Older deployment manifests (e.g. apisix-ingress-controller's) invoke
+    // this subcommand as `server`, from before it was renamed.
+    #[test]
+    fn server_is_still_accepted_as_an_alias_for_ingress_server() {
+        let cli = Cli::try_parse_from(["adc", "server"]).unwrap();
+        assert!(matches!(cli.command, Command::IngressServer(_)));
+    }
+
+    // The alias must not shadow the real name it stands in for.
+    #[test]
+    fn ingress_server_still_works_under_its_own_name() {
+        let cli = Cli::try_parse_from(["adc", "ingress-server"]).unwrap();
+        assert!(matches!(cli.command, Command::IngressServer(_)));
+    }
 }


### PR DESCRIPTION
### Description

Add `server` as the alias of ingress-server mode, to keep compatibility with the old implementation.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `server` as an alias for the hidden ingress server command.
  * The existing `ingress-server` command remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->