### PR TITLE
fix(server): rust server ensure same cache keys are sync serially

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "axum-server",
  "chrono",
  "clap",
+ "dashmap",
  "dotenvy",
  "glob",
  "http",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,6 +36,7 @@ rustls = "0.23"
 http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "query"] }
 serde_yaml_ng = "0.10"
+dashmap = "6"
 
 [profile.release]
 opt-level = 3

--- a/rust/crates/adc-backend-apisix-standalone/Cargo.toml
+++ b/rust/crates/adc-backend-apisix-standalone/Cargo.toml
@@ -22,7 +22,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 semver = { workspace = true }
 sha1 = { workspace = true }
-dashmap = "6"
+dashmap = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync"] }
 log = { workspace = true }
 tracing = { workspace = true }

--- a/rust/crates/adc-cli/Cargo.toml
+++ b/rust/crates/adc-cli/Cargo.toml
@@ -33,6 +33,7 @@ tracing = { workspace = true }
 indicatif = "0.18"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 http = { workspace = true }
+dashmap = { workspace = true }
 axum = { workspace = true }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 rustls = { workspace = true }

--- a/rust/crates/adc-cli/src/server/mod.rs
+++ b/rust/crates/adc-cli/src/server/mod.rs
@@ -7,6 +7,7 @@ mod backend;
 pub mod logging;
 mod schema;
 mod sync;
+mod sync_lock;
 mod validate;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -11,7 +11,7 @@ use axum::response::{IntoResponse, Response};
 use serde_json::{Value, json};
 
 use super::schema::{self, SyncInput};
-use super::{backend, bad_request, internal_error};
+use super::{backend, bad_request, internal_error, sync_lock};
 use crate::config;
 use crate::error::CliError;
 use crate::pipeline;
@@ -78,6 +78,20 @@ async fn run(
     exclude: &HashSet<ResourceType>,
     label_selector: &HashMap<String, String>,
 ) -> Result<Value, CliError> {
+    let is_apisix_standalone = backend_kind == "apisix-standalone";
+
+    // apisix-standalone folds every sync into one shared full document keyed
+    // by `cache_key` (see adc-backend-apisix-standalone::backend) — diffing
+    // against a dump and applying that diff has to happen as one unit, or a
+    // second concurrent sync for the same cache_key can diff against the
+    // same stale dump and silently overwrite what the first one just wrote.
+    // Held across dump+diff+sync below, released when `run` returns.
+    let _standalone_guard = if is_apisix_standalone {
+        Some(sync_lock::lock(&opts.cache_key).await)
+    } else {
+        None
+    };
+
     let gateway = backend::build_backend(opts)?;
     let remote = pipeline::load_remote(gateway.as_ref(), include, exclude, label_selector).await?;
     let events = pipeline::diff(gateway.as_ref(), &local, &remote).await?;
@@ -86,7 +100,6 @@ async fn run(
         exit_on_failure: Some(false),
     };
 
-    let is_apisix_standalone = backend_kind == "apisix-standalone";
     let events_for_output = is_apisix_standalone.then(|| events.clone());
     let results = gateway.sync(events, sync_opts).await?;
     Ok(match events_for_output {

--- a/rust/crates/adc-cli/src/server/sync_lock.rs
+++ b/rust/crates/adc-cli/src/server/sync_lock.rs
@@ -1,0 +1,75 @@
+//! Serializes the whole dump→diff→sync cycle per `cache_key`, for backends
+//! that fold every sync into one shared full document (apisix-standalone).
+//!
+//! That backend's own per-`cache_key` lock only guards the final read-modify-
+//! write of its cache — it doesn't cover the `diff` a caller computed
+//! *before* calling `sync`. Two concurrent `/sync` requests for the same
+//! `cache_key` can each `dump` the same base document, diff against it
+//! independently, and then apply their own diff one after the other; the
+//! second one's diff was computed against a document that's already stale
+//! by the time it writes, so it silently drops whatever the first one just
+//! added. Locking here — around `dump`+`diff`+`sync` together, before either
+//! request's `dump` runs — removes the window entirely: a `dump` can only
+//! ever be diffed against the document that's still current at apply time.
+use std::sync::{Arc, LazyLock};
+
+use dashmap::DashMap;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+// A sharded registry (same shape as `adc_backend_apisix_standalone::cache::Cache`)
+// of per-cache_key locks, each held by its caller across the `.await`s in
+// its dump -> diff -> sync cycle.
+static LOCKS: LazyLock<DashMap<String, Arc<AsyncMutex<()>>>> = LazyLock::new(DashMap::new);
+
+/// Holds the lock for `cache_key` until the returned guard is dropped.
+///
+/// The registry only ever grows (entries are never evicted) — harmless in
+/// practice, since `cache_key` tracks a small, effectively fixed set of real
+/// backend clusters for the life of an `ingress-server` process.
+pub async fn lock(cache_key: &str) -> OwnedMutexGuard<()> {
+    let entry = LOCKS
+        .entry(cache_key.to_string())
+        .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+        .clone();
+    entry.lock_owned().await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Two holders of the same key's lock must never be inside their
+    /// critical section at the same time — `busy` catches an overlap.
+    #[tokio::test]
+    async fn two_locks_on_the_same_key_never_overlap() {
+        let busy = Arc::new(AtomicBool::new(false));
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let busy = busy.clone();
+            tasks.push(tokio::spawn(async move {
+                let _guard = lock("shared").await;
+                assert!(
+                    !busy.swap(true, Ordering::SeqCst),
+                    "another holder was already in the critical section"
+                );
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                busy.store(false, Ordering::SeqCst);
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn locks_on_different_keys_do_not_block_each_other() {
+        let start = tokio::time::Instant::now();
+        let _guard = lock("one").await;
+        lock("two").await;
+        assert!(start.elapsed() < Duration::from_millis(100));
+    }
+}


### PR DESCRIPTION
### Description

`apisix-standalone` folds every sync into one shared in-memory document per `cache_key`, since its `PUT /apisix/admin/configs` endpoint always replaces the entire config in one shot rather than exposing per-resource writes. Each `/sync` request handles this by reading the current document, diffing it against the desired local configuration, and writing the merged result back.

Two concurrent `/sync` requests for the same `cache_key` are not serialized against each other end-to-end. A second request can read the shared document before the first request's write has committed, compute its own diff against that now-stale copy, and then write its own merged result — silently overwriting whatever the first request had just committed, since its diff never knew that resource existed. This was observed against a real cluster (apisix-ingress-controller's e2e suite, `provider_type: apisix-standalone`): an SSL resource synced concurrently with unrelated resources disappeared from APISIX's SNI routing table after being overwritten by a later, unrelated sync.

### Solution

Added `adc-cli`'s `server::sync_lock` module: a registry of per-`cache_key` async locks (sharded via `DashMap`, one lock per key). `sync::run()` acquires the lock for the request's `cache_key` before dumping the remote state, diffing, and syncing, and holds it for the entire dump→diff→sync cycle — released only once the whole operation completes.

This guarantees that, for a given `cache_key`, two sync cycles can never interleave: whichever request runs second always dumps the document the first one just committed, never a stale copy, so its diff is always computed against (and applied to) the same document it will write back to.

The lock is only taken for `apisix-standalone`; `apisix` and `api7ee` are unaffected — their per-resource admin API writes don't need this coordination.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent synchronization requests for the same configuration from overwriting one another with stale data.
  * Preserved parallel synchronization for different configurations.
  * Improved consistency across loading, comparison, and application of synchronization changes.
* **Tests**
  * Added coverage verifying serialization for matching configurations and independent processing for different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->