### PR TITLE
fix(apisix): rust allow disabled stream route

### DIFF
--- a/libs/backend-apisix/e2e/assets/apisix_conf/no_stream.yaml
+++ b/libs/backend-apisix/e2e/assets/apisix_conf/no_stream.yaml
@@ -1,0 +1,22 @@
+apisix:
+  node_listen: 9080
+  enable_ipv6: false
+  enable_control: true
+  control:
+    ip: "0.0.0.0"
+    port: 9092
+deployment:
+  admin:
+    allow_admin:
+      - 0.0.0.0/0
+    admin_key:
+      - name: "admin"
+        key: edd1c9f034335f136f87ad84b625c8f1
+        role: admin
+  etcd:
+    host:
+      - "http://etcd:2379"
+    prefix: "/apisix"
+    timeout: 30
+nginx_config:
+  worker_processes: 1

--- a/libs/backend-apisix/e2e/assets/docker-compose.yaml
+++ b/libs/backend-apisix/e2e/assets/docker-compose.yaml
@@ -26,6 +26,19 @@ services:
     networks:
       apisix:
 
+  apisix_no_stream:
+    image: apache/apisix:${BACKEND_APISIX_IMAGE:-3.9.0-debian}
+    restart: always
+    volumes:
+      - ./apisix_conf/no_stream.yaml:/usr/local/apisix/conf/config.yaml:ro
+    depends_on:
+      - etcd
+    ports:
+      - "39180:9180/tcp"
+      - "39080:9080/tcp"
+    networks:
+      apisix:
+
   etcd:
     image: bitnamilegacy/etcd:3.6
     restart: always

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "axum",
  "indexmap",
  "log",
+ "rstest",
  "semver",
  "serde",
  "serde_json",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,7 @@ http = "1"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "query"] }
 serde_yaml_ng = "0.10"
 dashmap = "6"
+rstest = "0.26.1"
 
 [profile.release]
 opt-level = 3

--- a/rust/crates/adc-backend-apisix/Cargo.toml
+++ b/rust/crates/adc-backend-apisix/Cargo.toml
@@ -30,3 +30,4 @@ url = { workspace = true }
 adc-backend-apisix = { path = ".", features = ["test-utils"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net"] }
 axum = { workspace = true }
+rstest = { workspace = true }

--- a/rust/crates/adc-backend-apisix/src/fetcher.rs
+++ b/rust/crates/adc-backend-apisix/src/fetcher.rs
@@ -143,15 +143,11 @@ impl Fetcher {
         Ok(merged)
     }
 
-    /// Stream routes are an optional APISIX feature, and a `GET` on the
-    /// collection has no inputs that could be malformed, so any 4xx here
-    /// means "this instance has no stream routes to fetch" rather than a
-    /// bad request: a 404 when the endpoint doesn't exist on this
-    /// build, a 400 (`stream mode is disabled, can not add stream routes`)
-    /// when the build supports stream routes but the instance has stream
-    /// mode turned off. An auth failure still surfaces as
-    /// [`BackendError::Auth`], and a 5xx is still a real error, same as
-    /// [`Fetcher::list`].
+    /// Stream routes are an optional APISIX feature. Only a 404 (endpoint
+    /// absent on this build) or a 400 (`stream mode is disabled, can not
+    /// add stream routes` — stream mode turned off) yield an empty list.
+    /// Everything else propagates: 401/403 as [`BackendError::Auth`], any
+    /// other 4xx/5xx as [`BackendError::Api`], same as [`Fetcher::list`].
     pub async fn list_stream_routes(&self) -> Result<Vec<typing::StreamRoute>, BackendError> {
         if self.filter.is_skip(ResourceType::StreamRoute) {
             return Ok(Vec::new());

--- a/rust/crates/adc-backend-apisix/src/fetcher.rs
+++ b/rust/crates/adc-backend-apisix/src/fetcher.rs
@@ -143,21 +143,27 @@ impl Fetcher {
         Ok(merged)
     }
 
-    /// Stream routes are an optional APISIX feature: on a version/build
-    /// that doesn't support them, the endpoint itself may not exist. Only a
-    /// 404 here is treated as "no stream routes" — anything else
-    /// (authentication/authorization failure, a 5xx) is a real error, same
-    /// as [`Fetcher::list`].
+    /// Stream routes are an optional APISIX feature, and a `GET` on the
+    /// collection has no inputs that could be malformed, so any 4xx here
+    /// means "this instance has no stream routes to fetch" rather than a
+    /// bad request: a 404 when the endpoint doesn't exist on this
+    /// build, a 400 (`stream mode is disabled, can not add stream routes`)
+    /// when the build supports stream routes but the instance has stream
+    /// mode turned off. An auth failure still surfaces as
+    /// [`BackendError::Auth`], and a 5xx is still a real error, same as
+    /// [`Fetcher::list`].
     pub async fn list_stream_routes(&self) -> Result<Vec<typing::StreamRoute>, BackendError> {
         if self.filter.is_skip(ResourceType::StreamRoute) {
             return Ok(Vec::new());
         }
         let builder = self.collection_request("/apisix/admin/stream_routes")?;
         let response = self.client.execute(builder).await?;
-        if response.status().as_u16() == 404 {
-            return Ok(Vec::new());
-        }
-        let response = HttpClient::require_success(response).await?;
+        let response = match HttpClient::require_success(response).await {
+            Ok(response) => response,
+            Err(BackendError::NotFound(_)) => return Ok(Vec::new()),
+            Err(BackendError::Api { status: 400, .. }) => return Ok(Vec::new()),
+            Err(e) => return Err(e),
+        };
         let body: typing::ListResponse<typing::StreamRoute> =
             response.json().await.map_err(|e| {
                 BackendError::Serialization(format!(
@@ -423,6 +429,7 @@ mod tests {
     use std::collections::HashSet;
 
     use adc_backend_core::{HttpClientConfig, TlsConfig};
+    use rstest::rstest;
 
     use super::*;
 
@@ -608,5 +615,65 @@ mod tests {
 
         let names: Vec<String> = configuration.services.unwrap().into_iter().map(|s| s.name).collect();
         assert_eq!(names, vec!["matches"]);
+    }
+
+    /// A server whose `/apisix/admin/stream_routes` always answers with a
+    /// fixed status (and an APISIX-shaped error body), and which answers
+    /// everything else generically.
+    async fn spawn_server_with_stream_routes_status(status: u16) -> String {
+        let status = axum::http::StatusCode::from_u16(status).unwrap();
+        let router = axum::Router::new()
+            .route(
+                "/apisix/admin/stream_routes",
+                axum::routing::get(move || async move {
+                    (status, axum::Json(serde_json::json!({ "error_msg": "stream routes error" })))
+                }),
+            )
+            .fallback(axum::routing::any(|| async { axum::Json(serde_json::json!({ "list": [] })) }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    /// A 404 (endpoint absent on this build) or a 400 (`stream mode is
+    /// disabled`) both mean "no stream routes" and must leave the dump
+    /// intact; an auth failure or a 5xx is still a real error.
+    #[rstest]
+    #[case(404, true)]
+    #[case(400, true)]
+    #[case(401, false)]
+    #[case(500, false)]
+    #[tokio::test]
+    async fn list_stream_routes_swallows_only_the_absent_statuses(
+        #[case] status: u16,
+        #[case] treated_as_absent: bool,
+    ) {
+        let server = spawn_server_with_stream_routes_status(status).await;
+        let client = HttpClient::new(HttpClientConfig {
+            server,
+            token: "test-token".to_string(),
+            timeout: None,
+            tls: TlsConfig::default(),
+        })
+        .unwrap();
+        let filter = ResourceFilter {
+            include: HashSet::new(),
+            exclude: HashSet::new(),
+            label_selector: HashMap::new(),
+        };
+        let fetcher = Fetcher::new(client, Version::new(999, 999, 999), filter, 10);
+
+        let list_result = fetcher.list_stream_routes().await;
+        let dump_result = fetcher.dump().await;
+        if treated_as_absent {
+            assert!(list_result.unwrap().is_empty());
+            assert_eq!(dump_result.unwrap().services, None);
+        } else {
+            assert!(list_result.is_err(), "{list_result:?}");
+            assert!(dump_result.is_err(), "{dump_result:?}");
+        }
     }
 }

--- a/rust/crates/adc-backend-apisix/tests/common/mod.rs
+++ b/rust/crates/adc-backend-apisix/tests/common/mod.rs
@@ -9,11 +9,22 @@ use adc_backend_apisix::Backend as ApisixBackend;
 use adc_backend_core::{HttpClient, HttpClientConfig, TlsConfig};
 
 pub const SERVER: &str = "http://localhost:19180";
+/// The `apisix_no_stream` compose instance — same admin key, started
+/// without stream proxy enabled.
+pub const SERVER_NO_STREAM: &str = "http://localhost:39180";
 pub const TOKEN: &str = "edd1c9f034335f136f87ad84b625c8f1";
 
 pub fn client() -> HttpClient {
+    client_for(SERVER)
+}
+
+pub fn client_no_stream() -> HttpClient {
+    client_for(SERVER_NO_STREAM)
+}
+
+fn client_for(server: &str) -> HttpClient {
     HttpClient::new(HttpClientConfig {
-        server: SERVER.to_string(),
+        server: server.to_string(),
         token: TOKEN.to_string(),
         timeout: None,
         tls: TlsConfig::default(),

--- a/rust/crates/adc-backend-apisix/tests/e2e_resource_stream_route.rs
+++ b/rust/crates/adc-backend-apisix/tests/e2e_resource_stream_route.rs
@@ -1,0 +1,23 @@
+use adc_backend_apisix::tests::Fetcher;
+use adc_backend_core::ResourceFilter;
+
+mod common;
+use common::{apisix_version, client_no_stream};
+
+/// `client_no_stream` points at an APISIX started without stream proxy,
+/// where `GET /apisix/admin/stream_routes` answers 400.
+fn fetcher() -> Fetcher {
+    Fetcher::new(client_no_stream(), apisix_version(), ResourceFilter::default(), 10)
+}
+
+#[tokio::test]
+#[ignore]
+async fn list_stream_routes_reports_none_when_stream_mode_is_disabled() {
+    assert!(fetcher().list_stream_routes().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn dump_succeeds_when_stream_mode_is_disabled() {
+    fetcher().dump().await.unwrap();
+}

--- a/rust/crates/adc-converter-openapi/Cargo.toml
+++ b/rust/crates/adc-converter-openapi/Cargo.toml
@@ -17,4 +17,4 @@ thiserror = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.26.1"
+rstest = { workspace = true }


### PR DESCRIPTION
### Description

Fixes #585 

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with APISIX instances that do not support stream routes.
  - Treats expected 400 and 404 responses as having no stream routes, while preserving errors for authentication and server failures.
  - Ensures resource route exports continue successfully when stream proxy support is unavailable.

- **Tests**
  - Added coverage for supported and unsupported stream-route responses.
  - Added end-to-end validation for APISIX configurations without stream support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->