### PR TITLE
feat(apisix-standalone): fault-tolerant dump

### DIFF
--- a/rust/crates/adc-backend-apisix-standalone/src/backend.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/backend.rs
@@ -143,23 +143,44 @@ impl Backend {
         let version = self
             .version
             .get_or_try_init(|| async {
-                let primary = &self.servers[0];
-                // HEAD support on the config document endpoint is itself
-                // version-gated (see `Fetcher::find_latest`'s
-                // `version_supports_head`), so the version probe uses the
-                // admin root instead, which has none of that ambiguity.
-                let request = primary.client.request(Method::HEAD, "/apisix/admin")?;
-                let response = primary.client.send(request).await?;
-
-                let header = response
-                    .headers()
-                    .get("server")
-                    .and_then(|value| value.to_str().ok())
-                    .and_then(|value| value.strip_prefix("APISIX/"));
-                Ok::<_, BackendError>(match header.map(Version::parse) {
-                    Some(Ok(version)) => version,
-                    _ => UNKNOWN_VERSION,
-                })
+                // Tries every configured server in turn, not just the
+                // first — one unreachable instance (a rolling restart, a
+                // network blip) shouldn't block version resolution as
+                // long as some server in the cluster still answers.
+                let mut last_error = None;
+                for server in &self.servers {
+                    // HEAD support on the config document endpoint is
+                    // itself version-gated (see `Fetcher::probe_reachable`'s
+                    // `version_supports_head`), so the version probe uses
+                    // the admin root instead, which has none of that
+                    // ambiguity.
+                    let outcome = async {
+                        let request = server.client.request(Method::HEAD, "/apisix/admin")?;
+                        server.client.send(request).await
+                    }
+                    .await;
+                    let response = match outcome {
+                        Ok(response) => response,
+                        Err(error) => {
+                            tracing::warn!("apisix-standalone: server unreachable while probing for the cluster version: {error}");
+                            last_error = Some(error);
+                            continue;
+                        }
+                    };
+                    let header = response
+                        .headers()
+                        .get("server")
+                        .and_then(|value| value.to_str().ok())
+                        .and_then(|value| value.strip_prefix("APISIX/"));
+                    return Ok::<_, BackendError>(match header.map(Version::parse) {
+                        Some(Ok(version)) => version,
+                        _ => UNKNOWN_VERSION,
+                    });
+                }
+                // `self.servers` is never empty (enforced in `Backend::new`),
+                // so the loop above ran at least once — every iteration that
+                // doesn't early-return sets `last_error`.
+                Err(last_error.expect("self.servers is non-empty, so at least one iteration ran and failed"))
             })
             .await?;
         // Only cache a genuinely observed version, not the "couldn't tell"
@@ -342,7 +363,7 @@ impl adc_sdk::Backend for Backend {
                 // (same effect as `Cache::invalidate`, just through the
                 // guard instead of a second lookup) rather than leaving it
                 // pointing at data a live server may have moved past. The
-                // next dump() re-fetches and re-runs `find_latest` to
+                // next dump() re-fetches and re-runs the probe to
                 // discover the cluster's real state instead of trusting
                 // stale cache. This instance's own pinned snapshots are now
                 // equally untrustworthy, so they're cleared too — a retry

--- a/rust/crates/adc-backend-apisix-standalone/src/fetcher.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/fetcher.rs
@@ -39,14 +39,13 @@ impl Fetcher {
     pub async fn dump(&self) -> Result<(Configuration, ApisixStandalone), BackendError> {
         let reachable = self.probe_reachable().await?;
         // `reachable` is never empty here — `probe_reachable` already
-        // turned that case into the `Err` propagated above.
-        let target = pick_latest(reachable.clone()).unwrap_or_else(|| reachable[0].0.clone());
-        let client = &self
-            .servers
-            .iter()
-            .find(|s| s.server == target)
-            .expect("target came from probing self.servers, so it's one of them")
-            .client;
+        // turned that case into the `Err` propagated above. Indices into
+        // `self.servers`, not URLs — two entries can share the same
+        // `server` URL (paired with different tokens), so re-selecting by
+        // URL could silently pick a different `StandaloneServer` than the
+        // one that actually answered the probe.
+        let target = pick_latest(reachable.clone()).unwrap_or(reachable[0].0);
+        let client = &self.servers[target].client;
 
         let request = client.request(Method::GET, ENDPOINT_CONFIG)?;
         let raw_config: ApisixStandalone = client.send_json(request).await?;
@@ -65,10 +64,16 @@ impl Fetcher {
     /// of them could be reached (propagating whichever probe's error
     /// happened to be seen last — with every server down, which one's
     /// error surfaces isn't meaningful).
-    async fn probe_reachable(&self) -> Result<Vec<(String, i64)>, BackendError> {
+    async fn probe_reachable(&self) -> Result<Vec<(usize, i64)>, BackendError> {
         let method = if version_supports_head(&self.version) { Method::HEAD } else { Method::GET };
 
-        let probe = |server: StandaloneServer| {
+        // Carries each server's index in `self.servers` through the probe
+        // instead of its URL — `concurrent_map` completes in whatever
+        // order the responses actually arrive, not input order, so this is
+        // the only way `dump()` can later go straight back to the exact
+        // `StandaloneServer` that answered (see its own comment for why
+        // that matters).
+        let probe = |(index, server): (usize, StandaloneServer)| {
             let method = method.clone();
             async move {
                 let request = server.client.request(method, ENDPOINT_CONFIG)?;
@@ -79,10 +84,11 @@ impl Fetcher {
                     .and_then(|value| value.to_str().ok())
                     .and_then(|value| value.parse::<i64>().ok())
                     .unwrap_or(0);
-                Ok::<_, BackendError>((server.server, timestamp))
+                Ok::<_, BackendError>((index, timestamp))
             }
         };
-        let results = concurrent_map(self.servers.clone(), None, probe).await;
+        let indexed = self.servers.iter().cloned().enumerate().collect();
+        let results = concurrent_map(indexed, None, probe).await;
 
         let mut reachable = Vec::with_capacity(results.len());
         let mut last_error = None;
@@ -109,8 +115,11 @@ impl Fetcher {
 /// which *real* server wins a genuine tie is still not a documented,
 /// wall-clock-meaningful rule. `None` iff every entry is `0` (a fresh
 /// cluster no server has ever accepted a write on) or `results` is empty.
-fn pick_latest(results: Vec<(String, i64)>) -> Option<String> {
-    let mut latest: Option<(String, i64)> = None;
+/// Generic over what identifies a server (a URL in this file's own tests,
+/// an index into `self.servers` in `dump`'s real use) — the tie-break and
+/// zero-filtering logic doesn't care which.
+fn pick_latest<T>(results: Vec<(T, i64)>) -> Option<T> {
+    let mut latest: Option<(T, i64)> = None;
     for (server, timestamp) in results {
         if latest.as_ref().is_none_or(|(_, best)| timestamp >= *best) {
             latest = Some((server, timestamp));
@@ -156,7 +165,7 @@ mod tests {
 
     #[test]
     fn no_probes_at_all_has_no_latest() {
-        assert_eq!(pick_latest(vec![]), None);
+        assert_eq!(pick_latest::<String>(vec![]), None);
     }
 
     #[test]

--- a/rust/crates/adc-backend-apisix-standalone/src/fetcher.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/fetcher.rs
@@ -1,6 +1,6 @@
 //! Fetching a standalone cluster's current config: which server has the
-//! most recently accepted write (`find_latest`), then pulling that server's
-//! full config document (`dump`).
+//! most recently accepted write (`probe_reachable`), then pulling that
+//! server's full config document (`dump`).
 
 use adc_backend_core::{Method, concurrent_map};
 use adc_sdk::BackendError;
@@ -16,8 +16,8 @@ const HEADER_LAST_MODIFIED: &str = "x-last-modified";
 
 /// APISIX standalone versions above 3.13.0 accept `HEAD` on the config
 /// endpoint (a cheaper way to read just the `X-Last-Modified` header);
-/// older ones don't implement `HEAD` for it at all, so `find_latest` falls
-/// back to a full `GET` there.
+/// older ones don't implement `HEAD` for it at all, so `probe_reachable`
+/// falls back to a full `GET` there.
 const HEAD_SUPPORTED_SINCE: (u64, u64, u64) = (3, 13, 0);
 
 pub struct Fetcher {
@@ -30,25 +30,22 @@ impl Fetcher {
         Self { servers, version }
     }
 
-    /// Pulls the full config document from whichever server
-    /// [`Self::find_latest`] picks (or the first configured server, if none
-    /// of them has ever accepted a write yet), and converts it into ADC's
-    /// model.
+    /// Pulls the full config document from whichever server holds the
+    /// most recently accepted write, going by each one's `X-Last-Modified`
+    /// response header (a timestamp the server stamps on every config it
+    /// stores) — or an arbitrary reachable server, if every reachable one
+    /// reports timestamp `0` (a fresh cluster no server has ever accepted
+    /// a write on) — and converts it into ADC's model.
     pub async fn dump(&self) -> Result<(Configuration, ApisixStandalone), BackendError> {
-        let target = match self.find_latest().await? {
-            Some(server) => server,
-            None => self
-                .servers
-                .first()
-                .ok_or_else(no_servers_configured)?
-                .server
-                .clone(),
-        };
+        let reachable = self.probe_reachable().await?;
+        // `reachable` is never empty here — `probe_reachable` already
+        // turned that case into the `Err` propagated above.
+        let target = pick_latest(reachable.clone()).unwrap_or_else(|| reachable[0].0.clone());
         let client = &self
             .servers
             .iter()
             .find(|s| s.server == target)
-            .expect("find_latest only ever returns a server from self.servers")
+            .expect("target came from probing self.servers, so it's one of them")
             .client;
 
         let request = client.request(Method::GET, ENDPOINT_CONFIG)?;
@@ -57,13 +54,18 @@ impl Fetcher {
         Ok((config, raw_config))
     }
 
-    /// Finds which server holds the most recently accepted write, going by
-    /// each one's `X-Last-Modified` response header (a timestamp the server
-    /// stamps on every config it stores). `None` means no server has ever
-    /// accepted a write (every one reports timestamp `0` — a fresh
-    /// cluster), not that a request failed — a request failure is still
-    /// propagated as `Err`.
-    async fn find_latest(&self) -> Result<Option<String>, BackendError> {
+    /// Probes every configured server for its `X-Last-Modified` header,
+    /// tolerating some being unreachable: a real cluster can have a subset
+    /// of instances down (a rolling restart, a network blip) without that
+    /// blocking `dump()` entirely, as long as at least one instance
+    /// answers. An unreachable server is logged and simply excluded from
+    /// the returned set — not retried here, nor recorded anywhere past
+    /// this one call; the next `dump()` probes every server again from
+    /// scratch, including ones excluded this time. Fails only when *none*
+    /// of them could be reached (propagating whichever probe's error
+    /// happened to be seen last — with every server down, which one's
+    /// error surfaces isn't meaningful).
+    async fn probe_reachable(&self) -> Result<Vec<(String, i64)>, BackendError> {
         let method = if version_supports_head(&self.version) { Method::HEAD } else { Method::GET };
 
         let probe = |server: StandaloneServer| {
@@ -81,14 +83,22 @@ impl Fetcher {
             }
         };
         let results = concurrent_map(self.servers.clone(), None, probe).await;
-        let mut resolved = Vec::with_capacity(results.len());
-        for result in results {
-            // Any single probe failure fails the whole lookup, even if every
-            // other server is healthy — not attempted-and-recovered-from.
-            resolved.push(result?);
-        }
 
-        Ok(pick_latest(resolved))
+        let mut reachable = Vec::with_capacity(results.len());
+        let mut last_error = None;
+        for result in results {
+            match result {
+                Ok(pair) => reachable.push(pair),
+                Err(error) => {
+                    tracing::warn!("apisix-standalone: server unreachable while probing for the latest config: {error}");
+                    last_error = Some(error);
+                }
+            }
+        }
+        if reachable.is_empty() {
+            return Err(last_error.unwrap_or_else(no_servers_configured));
+        }
+        Ok(reachable)
     }
 }
 
@@ -168,11 +178,13 @@ mod tests {
         StandaloneServer { server: "http://127.0.0.1:1".to_string(), client }
     }
 
-    /// Documents current behavior rather than asserting it's the only
-    /// sensible one: a single unreachable server fails the whole `dump()`,
-    /// even with zero other servers configured to fall back on. If this
-    /// crate ever grows tolerance for a subset of unreachable servers, this
-    /// test is the one that should change alongside it.
+    /// The tolerant case (some servers unreachable, at least one isn't) is
+    /// `e2e_cache.rs`'s `a_dump_tolerates_one_unreachable_server_among_
+    /// several`, which needs a real cluster to have something to succeed
+    /// against; this one needs no live cluster at all, since with only one
+    /// server configured and it unreachable, zero servers are reachable —
+    /// still a hard failure, by design (see `probe_reachable`'s doc
+    /// comment).
     #[tokio::test]
     async fn a_single_unreachable_server_fails_the_whole_dump() {
         let fetcher = Fetcher::new(vec![unreachable_server()], Version::new(999, 999, 999));

--- a/rust/crates/adc-backend-apisix-standalone/src/operator.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/operator.rs
@@ -188,7 +188,7 @@ impl Operator {
                     // the caller resets its held entry rather than leaving
                     // it pointing at data a live server may have already
                     // moved past. The next dump() re-fetches and re-runs
-                    // `find_latest` to discover the cluster's real state
+                    // the probe to discover the cluster's real state
                     // instead of trusting stale cache.
                     return Err(error);
                 }

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_cache.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_cache.rs
@@ -274,6 +274,12 @@ async fn bypass_cache_discards_stale_state_and_refetches() {
 /// single dead instance (the pure-logic half of this — an all-unreachable
 /// probe still fails outright — is covered without a live cluster, in
 /// `fetcher.rs`'s own `a_single_unreachable_server_fails_the_whole_dump`).
+/// The dead server is listed *first*: `Backend::resolved_version` tries
+/// `self.servers` in that order and returns on the first success, so
+/// listing the live one first would let this test pass without ever
+/// exercising `resolved_version`'s own skip-and-continue fallback — only
+/// `probe_reachable`'s (which probes every server concurrently regardless
+/// of list order).
 #[tokio::test]
 #[ignore]
 async fn a_dump_tolerates_one_unreachable_server_among_several() {
@@ -285,7 +291,7 @@ async fn a_dump_tolerates_one_unreachable_server_among_several() {
     sync_ok(&backend_for(common::SERVER1, cache_key), diff(&synced, &empty_configuration())).await;
     common::cache().invalidate(cache_key).await;
 
-    let opts = common::backend_options(vec![common::SERVER1.to_string(), "http://127.0.0.1:1".to_string()], cache_key);
+    let opts = common::backend_options(vec!["http://127.0.0.1:1".to_string(), common::SERVER1.to_string()], cache_key);
     let backend = Backend::new(opts).unwrap();
 
     let config = dump(&backend).await;

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_cache.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_cache.rs
@@ -198,12 +198,12 @@ async fn a_multi_server_dump_picks_up_whichever_server_was_updated_most_recently
 
     // ... then a moment later, independently to server2 (newer). A real
     // sleep, not a mocked clock: server2's write must land at a genuinely
-    // later wall-clock timestamp than server1's for `find_latest` to be
+    // later wall-clock timestamp than server1's for the freshness probe to be
     // able to tell them apart by `X-Last-Modified` — which is APISIX's own
     // second-granularity header, not our millisecond `stable_timestamp`, so
     // the gap has to clear a full second (matches the TS reference's own
     // `wait(1000)` in this same scenario) or the two can tie and
-    // `find_latest`'s tie-break (whichever probe's response completes
+    // the tie-break (whichever probe's response completes
     // last, not whichever was actually written last) picks arbitrarily.
     tokio::time::sleep(Duration::from_millis(1100)).await;
 
@@ -267,4 +267,28 @@ async fn bypass_cache_discards_stale_state_and_refetches() {
     // ... and a subsequent non-bypassing dump serves that repopulated cache.
     let result = dump(&backend).await;
     assert_eq!(result.services.unwrap()[0].name, "service1");
+}
+
+/// One real, live server plus one that will never answer — `dump()` must
+/// still succeed off the reachable one, not fail the whole cluster over a
+/// single dead instance (the pure-logic half of this — an all-unreachable
+/// probe still fails outright — is covered without a live cluster, in
+/// `fetcher.rs`'s own `a_single_unreachable_server_fails_the_whole_dump`).
+#[tokio::test]
+#[ignore]
+async fn a_dump_tolerates_one_unreachable_server_among_several() {
+    common::restart_apisix().await;
+    let cache_key = "cache-e2e-fault-tolerant";
+    common::cache().invalidate(cache_key).await;
+
+    let synced = fixture_config(9180);
+    sync_ok(&backend_for(common::SERVER1, cache_key), diff(&synced, &empty_configuration())).await;
+    common::cache().invalidate(cache_key).await;
+
+    let opts = common::backend_options(vec![common::SERVER1.to_string(), "http://127.0.0.1:1".to_string()], cache_key);
+    let backend = Backend::new(opts).unwrap();
+
+    let config = dump(&backend).await;
+    let services = config.services.expect("the reachable server's data, despite the other server being dead");
+    assert_eq!(services[0].name, "service1");
 }


### PR DESCRIPTION
### Description

Makes the apisix-standalone backend's dump path tolerate a partially-unreachable cluster:

- Finding which server holds the most recently accepted write, and resolving the cluster's APISIX version, both now try every configured server and only give up if *none* of them answer.
- Previously, either one failed outright the moment a single configured server was unreachable, even with other healthy servers to fall back on.
- An unreachable server is logged and simply excluded from that call's result — nothing is retried or remembered past it; the next dump probes every server again from scratch.
- Sync (pushing the new document to every server) is unaffected — it already attempts every server regardless of what dump's probe saw.

Covered by both an existing test (every server unreachable — still a hard failure, by design, since there's nothing left to fall back on) and a new one (one server down, one reachable, against a live 3-server cluster).

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standalone APISIX now checks all configured servers when resolving versions and retrieving configuration.
  * Unreachable servers are skipped, allowing operations to continue using an available server.
  * Configuration is selected from the most recent reachable server, with a fallback when timestamps are unavailable.
  * Operations now fail only when no configured server can be reached.
  * Server-specific connection settings are preserved when selecting a reachable server, including when multiple servers share the same address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->