### PR TITLE
feat(apisix-standalone): add write confirmation and improve sync failure reporting

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -150,6 +150,7 @@ jobs:
           rustup update stable
           rustup default stable
           cargo test -p adc-backend-apisix-standalone -- --ignored --test-threads=1
+          cargo test -p adc-cli --test e2e_server_sync_apisix_standalone -- --ignored --test-threads=1
       # Only useful when the step above fails: a bare 404 from an admin API
       # request gives no clue why on its own — the container's own error
       # log does.

--- a/rust/crates/adc-backend-api7/src/operator.rs
+++ b/rust/crates/adc-backend-api7/src/operator.rs
@@ -81,6 +81,7 @@ impl Operator {
                             event: Some(event),
                             error: Some(error),
                             server: None,
+                            confirmed: None,
                         }),
                     }
                 }
@@ -127,6 +128,7 @@ impl Operator {
                 event: Some(event),
                 error: None,
                 server: None,
+                confirmed: None,
             }),
             Err(error) => Err((event, error)),
         }

--- a/rust/crates/adc-backend-apisix-standalone/src/backend.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/backend.rs
@@ -307,6 +307,12 @@ impl adc_sdk::Backend for Backend {
         events: Vec<Event>,
         opts: BackendSyncOptions,
     ) -> Result<Vec<BackendSyncResult>, BackendError> {
+        // Resolved before the lock below, same reason as `dump`'s own
+        // pre-lock resolve: may itself read or write this cache_key's
+        // cached `version` field, which would deadlock against a lock this
+        // call is about to hold.
+        let version = self.resolved_version().await?;
+
         // Held for the whole read-modify-write span, not just the read
         // below — see `Cache::lock`'s doc comment for why two concurrent
         // syncs on the same key can't just read-then-write independently.
@@ -324,7 +330,7 @@ impl adc_sdk::Backend for Backend {
         };
         let latest_known_version = entry.latest_version;
 
-        match Operator::new(self.servers.clone(), prior_desired, old_versions, latest_known_version)
+        match Operator::new(self.servers.clone(), prior_desired, old_versions, latest_known_version, version)
             .sync(events, opts)
             .await
         {

--- a/rust/crates/adc-backend-apisix-standalone/src/operator.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/operator.rs
@@ -31,6 +31,7 @@ use adc_sdk::{
     BackendError, BackendSyncOptions, BackendSyncResult, DEFAULT_EXIT_ON_FAILURE, Event, EventType, PathSegment,
     ResourceType, ValueDiff,
 };
+use semver::Version;
 use serde_json::Value;
 use sha1::{Digest, Sha1};
 
@@ -118,6 +119,7 @@ pub struct Operator {
     prior_desired: Configuration,
     old_versions: WireVersions,
     latest_known_version: Option<i64>,
+    version: Version,
 }
 
 impl Operator {
@@ -133,8 +135,9 @@ impl Operator {
         prior_desired: Configuration,
         old_versions: WireVersions,
         latest_known_version: Option<i64>,
+        version: Version,
     ) -> Self {
-        Self { servers, prior_desired, old_versions, latest_known_version }
+        Self { servers, prior_desired, old_versions, latest_known_version, version }
     }
 
     pub async fn sync(&self, events: Vec<Event>, opts: BackendSyncOptions) -> Result<SyncOutcome, BackendError> {
@@ -165,12 +168,18 @@ impl Operator {
             .map_err(|e| BackendError::Serialization(format!("encoding sync config: {e}")))?;
         let digest = sha1_hex(body.as_bytes());
 
+        let wait_ms = env_sync_wait_ms();
+        let version = self.version.clone();
         let put = |server: StandaloneServer| {
             let body = body.clone();
             let digest = digest.clone();
+            let version = version.clone();
             async move {
-                match put_one(&server.client, body, digest).await {
-                    Ok(()) => Ok(BackendSyncResult { success: true, event: None, error: None, server: Some(server.server) }),
+                match put_one(&server.client, body, digest, wait_ms).await {
+                    Ok(status) => {
+                        let confirmed = is_confirmed(&version, status);
+                        Ok(BackendSyncResult { success: true, event: None, error: None, server: Some(server.server), confirmed: Some(confirmed) })
+                    }
                     Err(error) => {
                         if let Some(message) = conf_version_rejection_message(&error) {
                             tracing::error!(
@@ -185,7 +194,7 @@ impl Operator {
         };
 
         let exit_on_failure = opts.exit_on_failure.unwrap_or(DEFAULT_EXIT_ON_FAILURE);
-        let results = if exit_on_failure {
+        let results: Vec<BackendSyncResult> = if exit_on_failure {
             match concurrent_map_until_err(self.servers.clone(), None, put).await {
                 Ok(results) => results,
                 Err((_, error)) => {
@@ -207,25 +216,75 @@ impl Operator {
                 .into_iter()
                 .map(|outcome| match outcome {
                     Ok(result) => result,
-                    Err((server, error)) => BackendSyncResult { success: false, event: None, error: Some(error), server: Some(server) },
+                    Err((server, error)) => {
+                        BackendSyncResult { success: false, event: None, error: Some(error), server: Some(server), confirmed: None }
+                    }
                 })
                 .collect()
         };
 
-        // Keyed on "at least one server accepted the write", not on
-        // per-server completion order — with concurrent writers, "cache
+        // Keyed on "at least one server *confirmed* the write" — not on
+        // per-server completion order (with concurrent writers, "cache
         // whatever the most recently completed request happened to see"
-        // has no coherent meaning.
-        let new_state = results.iter().any(|result| result.success).then(|| SyncedState { timestamp, desired, wire });
+        // has no coherent meaning), and not on plain `success` either: a
+        // `202` means APISIX only accepted the document, without waiting
+        // to confirm the data plane actually picked it up — trusting that
+        // as much as a confirmed `200` would let this crate's cache get
+        // ahead of what's really live. `is_confirmed` already collapses to
+        // "any success counts" on a cluster too old to ever tell the
+        // difference, so this never regresses to "cache never refreshes"
+        // there.
+        let new_state = results.iter().any(|r| r.confirmed == Some(true)).then(|| SyncedState { timestamp, desired, wire });
 
         Ok(SyncOutcome { results, new_state })
     }
 }
 
-async fn put_one(client: &HttpClient, body: String, digest: String) -> Result<(), BackendError> {
-    let request = client.request(Method::PUT, CONFIG_ENDPOINT)?.header(HEADER_DIGEST, digest).body(body);
-    client.send(request).await?;
-    Ok(())
+/// Whether a PUT that got `status` back is confirmed applied, not just
+/// accepted — on a cluster that can actually tell the difference (see
+/// `is_confirmed`'s own version gate), only `200` means APISIX waited and
+/// saw its own data plane pick the document up; `202` means it gave up
+/// waiting (or never started — see `env_sync_wait_ms`) without that
+/// confirmation. A cluster below that version has no such distinction to
+/// make in the first place — every one of its 2xx responses collapses to
+/// "confirmed" here, the same as this crate treated any successful PUT
+/// before this gate existed, since otherwise its cache would never be
+/// trusted enough to refresh at all.
+const WAIT_CONFIRMATION_SUPPORTED_SINCE: (u64, u64, u64) = (3, 19, 0);
+fn is_confirmed(version: &Version, status: u16) -> bool {
+    let (major, minor, patch) = WAIT_CONFIRMATION_SUPPORTED_SINCE;
+    if *version < Version::new(major, minor, patch) {
+        return true;
+    }
+    status == 200
+}
+
+/// How long a PUT's `?wait=` asks APISIX to hold the response open for,
+/// polling its own data plane for confirmation before giving up and
+/// answering `202` instead of `200` — milliseconds, matching the query
+/// parameter's own unit. `u32` rather than `u64`: comfortably enough range
+/// (up to ~49 days) that nothing reasonable ever gets clamped, while an
+/// absurd config value fails to parse outright instead of being silently
+/// accepted; also keeps this nowhere near the point (2^53) where a Lua
+/// number — a double, same as everywhere else this crate's values cross
+/// into APISIX's own Lua-side handling — would start losing precision.
+/// Configurable because how long "the data plane hasn't picked this up
+/// yet" stays worth waiting on is a deployment-size question, not
+/// something this crate can pick a universally right answer for.
+const DEFAULT_SYNC_WAIT_MS: u32 = 3_000;
+fn env_sync_wait_ms() -> u32 {
+    std::env::var("ADC_APISIX_STANDALONE_SYNC_WAIT_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|v: &u32| *v >= 1)
+        .unwrap_or(DEFAULT_SYNC_WAIT_MS)
+}
+
+async fn put_one(client: &HttpClient, body: String, digest: String, wait_ms: u32) -> Result<u16, BackendError> {
+    let endpoint = format!("{CONFIG_ENDPOINT}?wait={wait_ms}");
+    let request = client.request(Method::PUT, &endpoint)?.header(HEADER_DIGEST, digest).body(body);
+    let response = client.send(request).await?;
+    Ok(response.status().as_u16())
 }
 
 /// Whether `error` is APISIX rejecting a PUT for carrying a stale
@@ -461,6 +520,25 @@ mod tests {
 
     use super::*;
     use crate::typing::{self, ConsumerOrCredential};
+
+    #[test]
+    fn an_old_cluster_treats_any_status_as_confirmed() {
+        assert!(is_confirmed(&Version::new(3, 18, 0), 202));
+        assert!(is_confirmed(&Version::new(3, 18, 0), 200));
+    }
+
+    #[test]
+    fn a_cluster_new_enough_to_wait_only_confirms_on_200() {
+        assert!(is_confirmed(&Version::new(3, 19, 0), 200));
+        assert!(!is_confirmed(&Version::new(3, 19, 0), 202));
+    }
+
+    #[test]
+    fn the_cutoff_itself_already_counts_as_new_enough() {
+        // `>= 3.19.0`, not `> 3.19.0` — 3.19.0 exactly must already gate on
+        // the status, not fall back to the pre-gate "any status confirms".
+        assert!(!is_confirmed(&Version::new(3, 19, 0), 202));
+    }
 
     #[test]
     fn a_400_naming_a_conf_version_field_is_recognized() {

--- a/rust/crates/adc-backend-apisix-standalone/src/operator.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/operator.rs
@@ -171,7 +171,15 @@ impl Operator {
             async move {
                 match put_one(&server.client, body, digest).await {
                     Ok(()) => Ok(BackendSyncResult { success: true, event: None, error: None, server: Some(server.server) }),
-                    Err(error) => Err((server.server, error)),
+                    Err(error) => {
+                        if let Some(message) = conf_version_rejection_message(&error) {
+                            tracing::error!(
+                                "conf_version rejected by {}: (\"{message}\") — another writer is likely active on this cluster.",
+                                server.server
+                            );
+                        }
+                        Err((server.server, error))
+                    }
                 }
             }
         };
@@ -218,6 +226,23 @@ async fn put_one(client: &HttpClient, body: String, digest: String) -> Result<()
     let request = client.request(Method::PUT, CONFIG_ENDPOINT)?.header(HEADER_DIGEST, digest).body(body);
     client.send(request).await?;
     Ok(())
+}
+
+/// Whether `error` is APISIX rejecting a PUT for carrying a stale
+/// `*_conf_version` — observed verbatim from a real 3.17.0 instance:
+/// `{"error_msg":"services_conf_version must be greater than or equal to
+/// (<N>)"}`, i.e. a `400` whose message names one of the eight
+/// `*_conf_version` fields. Means someone else's write landed on this
+/// cluster after the baseline this sync computed its own versions from —
+/// this crate's own cache regressing (a bug) would look identical from
+/// here, since the two aren't distinguishable from the response alone.
+/// Returns the message, for the caller to log — not a bool, so the ERROR
+/// log below doesn't need its own second, separate extraction.
+fn conf_version_rejection_message(error: &BackendError) -> Option<&str> {
+    match error {
+        BackendError::Api { status: 400, message } if message.contains("conf_version") => Some(message),
+        _ => None,
+    }
 }
 
 fn sha1_hex(bytes: &[u8]) -> String {
@@ -436,6 +461,37 @@ mod tests {
 
     use super::*;
     use crate::typing::{self, ConsumerOrCredential};
+
+    #[test]
+    fn a_400_naming_a_conf_version_field_is_recognized() {
+        // Verbatim from a real 3.17.0 instance (seeded with an inflated
+        // `services_conf_version` via raw PUT, then PUT a normal one back).
+        let error = BackendError::Api {
+            status: 400,
+            message: "services_conf_version must be greater than or equal to (99999999999999)".to_string(),
+        };
+        assert_eq!(
+            conf_version_rejection_message(&error),
+            Some("services_conf_version must be greater than or equal to (99999999999999)")
+        );
+    }
+
+    #[test]
+    fn a_400_not_naming_a_conf_version_field_is_not_a_conf_version_rejection() {
+        let error = BackendError::Api { status: 400, message: "missing digest header".to_string() };
+        assert_eq!(conf_version_rejection_message(&error), None);
+    }
+
+    #[test]
+    fn a_non_400_status_is_never_a_conf_version_rejection_even_if_it_mentions_one() {
+        let error = BackendError::Api { status: 500, message: "services_conf_version must be greater than or equal to (1)".to_string() };
+        assert_eq!(conf_version_rejection_message(&error), None);
+    }
+
+    #[test]
+    fn a_non_api_error_is_never_a_conf_version_rejection() {
+        assert_eq!(conf_version_rejection_message(&BackendError::Transport("connection refused".to_string())), None);
+    }
 
     #[test]
     fn no_known_latest_version_uses_the_wall_clock_time_as_is() {

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_concurrency.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_concurrency.rs
@@ -1,4 +1,3 @@
-//! No TS reference spec to port from — this is a from-scratch addition.
 //! `Cache`'s own unit tests (in `src/cache.rs`) prove the raw per-key mutex
 //! is race-safe in isolation; this proves the *composed* guarantee actually
 //! holds when real, independent `Backend` instances (mirroring independent

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_conf_version_conflict.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_conf_version_conflict.rs
@@ -1,0 +1,100 @@
+//! Reproduces the actual multi-writer conflict (see `impl/standalone/
+//! p01-multi-writer.md`): another writer already advanced a collection's
+//! `*_conf_version` past what this crate's next `sync()` computes, and
+//! APISIX rejects the PUT with `400`. The exact message this asserts on
+//! was captured verbatim from a real 3.17.0 instance (seed an inflated
+//! `services_conf_version` via raw PUT, then PUT a normal one back) —
+//! `operator.rs`'s own unit tests cover `conf_version_rejection_message`'s
+//! classification logic in isolation; this only needs to prove a real
+//! rejection still propagates to the caller unchanged, the one thing that
+//! can't be checked without an actual gateway. Real network calls against
+//! a live 3-instance standalone APISIX cluster — see `common`'s module doc
+//! for how to bring one up and run this file.
+
+use adc_backend_apisix_standalone::tests::typing::ApisixStandalone;
+use adc_backend_apisix_standalone::Backend;
+use adc_backend_core::{HttpClient, HttpClientConfig, Method, TlsConfig};
+use adc_sdk::resources::{self as adc, Configuration};
+use adc_sdk::Backend as _;
+use adc_sdk::BackendSyncOptions;
+use sha1::{Digest, Sha1};
+
+mod common;
+use common::{backend, base_service, base_upstream, diff, empty_configuration};
+
+const HEADER_DIGEST: &str = "x-digest";
+
+async fn dump(backend: &Backend) -> Configuration {
+    backend.dump().await.unwrap()
+}
+
+fn sha1_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha1::new();
+    hasher.update(bytes);
+    hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// PUTs `raw` back with its `services_conf_version` inflated far past
+/// anything a real sync would ever compute — bypasses `Backend`/`Operator`
+/// entirely, the same way `e2e_digest_short_circuit.rs`'s `put_raw` does,
+/// since this crate's own `Operator::sync` only ever PUTs a document whose
+/// versions it just computed correctly, never a stale one.
+async fn seed_inflated_services_conf_version(mut raw: ApisixStandalone) {
+    // Comfortably below 2^53 (~9.007e15) — APISIX's Lua/cjson round-trips
+    // numbers as doubles, so anything past that precision loses digits and
+    // comes back as scientific notation (`4.6116860184274e+18` for
+    // `i64::MAX / 2`, observed firsthand), which our `i64` field then
+    // fails to deserialize.
+    raw.services_conf_version = 99_999_999_999_999;
+    let body = serde_json::to_string(&raw).unwrap();
+    let digest = sha1_hex(body.as_bytes());
+    let client = HttpClient::new(HttpClientConfig {
+        server: common::SERVER1.to_string(),
+        token: common::TOKEN.to_string(),
+        timeout: None,
+        tls: TlsConfig::default(),
+    })
+    .unwrap();
+    let request = client.request(Method::PUT, "/apisix/admin/configs").unwrap().header(HEADER_DIGEST, digest).body(body);
+    let status = client.send(request).await.unwrap().status();
+    assert!(status.is_success(), "seeding the inflated conf_version must itself succeed: got {status}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_stale_conf_version_rejection_propagates_to_the_caller_unchanged() {
+    common::restart_apisix().await;
+    let cache_key = "conf-version-conflict-e2e";
+    let backend = backend(cache_key);
+
+    let before = dump(&backend).await;
+    let raw = common::raw_config().await;
+    seed_inflated_services_conf_version(raw).await;
+
+    // This crate's own cache still thinks `services_conf_version` is
+    // whatever `before` saw — a normal sync computes a normal (small)
+    // timestamp for it, which the server now rejects: someone else (this
+    // test, standing in for another writer) already moved it far ahead.
+    let local = Configuration {
+        services: Some(vec![adc::Service {
+            name: "svc1".to_string(),
+            upstream: Some(adc::Upstream { nodes: Some(vec![adc::UpstreamNode { host: "127.0.0.1".to_string(), port: 9180, weight: 100, priority: 0, metadata: None }]), ..base_upstream() }),
+            ..base_service()
+        }]),
+        ..empty_configuration()
+    };
+    let events = diff(&local, &before);
+    assert!(!events.is_empty());
+
+    let error = backend
+        .sync(events, BackendSyncOptions::default())
+        .await
+        .expect_err("a stale conf_version must still surface as an error to the caller, unchanged");
+    let message = error.to_string();
+    assert!(message.contains("conf_version"), "the real APISIX rejection message must reach the caller verbatim, got: {message}");
+
+    // The failed attempt must not have perturbed the server's actual state.
+    let after = common::raw_config().await;
+    assert_eq!(after.services_conf_version, 99_999_999_999_999);
+    assert_eq!(after.services.len(), 0, "the rejected write must not have landed");
+}

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_digest_short_circuit.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_digest_short_circuit.rs
@@ -1,4 +1,3 @@
-//! No TS reference spec to port from — this is a from-scratch addition.
 //! Every other test touching `X-Digest` (the header `operator.rs::sha1_hex`
 //! computes to let APISIX skip reprocessing an unchanged document) only
 //! checks its *effect*: that resyncing unchanged state doesn't move any

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_error_paths.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_error_paths.rs
@@ -1,4 +1,3 @@
-//! No TS reference spec to port from — this is a from-scratch addition.
 //! `operator.rs`'s own unit tests already prove `ChangeSet::from_events`
 //! surfaces a clear error for a malformed *input* (a missing `parent_id`);
 //! this instead provokes a real rejection from a live server (wrong admin

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_partial_failure.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_partial_failure.rs
@@ -1,4 +1,3 @@
-//! No TS reference spec to port from — this is a from-scratch addition.
 //! `backend.rs`'s `sync` has explicit, commented recovery logic for a
 //! multi-server write where only some servers accept the PUT ("a server
 //! earlier in the batch may have already accepted the new document before a

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_resource_plugin_metadata.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_resource_plugin_metadata.rs
@@ -1,6 +1,4 @@
-//! No TS reference spec to port from (`libs/backend-apisix-standalone/e2e/
-//! resources/` has no `plugin-metadata.e2e-spec.ts`) — this is a
-//! from-scratch addition, structured like `e2e_resource_global_rule.rs`
+//! Structured like `e2e_resource_global_rule.rs`
 //! (same `Record`-kind wire shape) but going through the real differ
 //! (`common::diff`) instead of hand-built events, and adding the
 //! per-entry isolation checks that file doesn't make. Also the e2e

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_resource_ssl.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_resource_ssl.rs
@@ -1,6 +1,4 @@
-//! No TS reference spec to port from (`libs/backend-apisix-standalone/e2e/
-//! resources/` has no `ssl.e2e-spec.ts`) — this is a from-scratch addition,
-//! covering SSL the same way the ported suites cover every other resource
+//! Covers SSL the same way the ported suites cover every other resource
 //! type: basic correctness (create/dump round-trips), extension correctness
 //! (modifiedIndex/conf_version bump on a real change), and that a create
 //! then an update each produce exactly one event through the real differ.

--- a/rust/crates/adc-backend-apisix-standalone/tests/e2e_resource_stream_route.rs
+++ b/rust/crates/adc-backend-apisix-standalone/tests/e2e_resource_stream_route.rs
@@ -1,6 +1,4 @@
-//! No TS reference spec to port from (`libs/backend-apisix-standalone/e2e/
-//! resources/` has no `stream-route.e2e-spec.ts`) — this is a from-scratch
-//! addition. Mirrors `e2e_resource_service.rs`'s HTTP-route coverage for the
+//! Mirrors `e2e_resource_service.rs`'s HTTP-route coverage for the
 //! stream (TCP/UDP) side, plus the isolation checks that file doesn't make:
 //! adding a stream route must bump only `stream_routes`, never `services` —
 //! `DifferV4::handle_update` doesn't even emit a `Service` event when the

--- a/rust/crates/adc-backend-apisix/src/operator.rs
+++ b/rust/crates/adc-backend-apisix/src/operator.rs
@@ -90,6 +90,7 @@ impl Operator {
                             event: Some(event),
                             error: Some(error),
                             server: None,
+                            confirmed: None,
                         }),
                     }
                 }
@@ -158,6 +159,7 @@ impl Operator {
                 event: Some(event),
                 error: Some(error),
                 server: None,
+                confirmed: None,
             });
         }
 
@@ -167,6 +169,7 @@ impl Operator {
                 event: Some(event),
                 error: None,
                 server: None,
+                confirmed: None,
             }),
             Err(error) => Err((event, error)),
         }

--- a/rust/crates/adc-cli/src/cli.rs
+++ b/rust/crates/adc-cli/src/cli.rs
@@ -82,8 +82,6 @@ pub enum BackendKind {
     Apisix,
     #[value(name = "api7ee")]
     Api7Ee,
-    #[value(name = "apisix-standalone")]
-    ApisixStandalone,
 }
 
 impl BackendKind {
@@ -91,7 +89,6 @@ impl BackendKind {
         match self {
             BackendKind::Apisix => "apisix",
             BackendKind::Api7Ee => "api7ee",
-            BackendKind::ApisixStandalone => "apisix-standalone",
         }
     }
 }

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -227,9 +227,9 @@ async fn output_for_apisix_standalone(gateway: &dyn Backend, events: &[Event], r
 
     let body = json!({
         "status": status,
-        "total_resources": 0,
-        "success_count": successes.len(),
-        "failed_count": failures.len(),
+        "total_resources": success.len() + failed.len(),
+        "success_count": success.len(),
+        "failed_count": failed.len(),
         "success": success,
         "failed": failed,
         "endpoint_status": results.iter().map(|r| EndpointStatusEntry {

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use adc_sdk::resources::Configuration;
-use adc_sdk::{BackendSyncOptions, BackendSyncResult, Event, ResourceType};
+use adc_sdk::{Backend, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
 use axum::Json;
 use axum::body::Bytes;
 use axum::http::StatusCode;
@@ -66,7 +66,7 @@ pub async fn sync_handler(body: Bytes) -> Response {
     )
     .await
     {
-        Ok(output) => (StatusCode::ACCEPTED, Json(output)).into_response(),
+        Ok((status, output)) => (status, Json(output)).into_response(),
         Err(error) => internal_error(json!({"message": error.to_string()})),
     }
 }
@@ -78,7 +78,7 @@ async fn run(
     include: &HashSet<ResourceType>,
     exclude: &HashSet<ResourceType>,
     label_selector: &HashMap<String, String>,
-) -> Result<Value, CliError> {
+) -> Result<(StatusCode, Value), CliError> {
     let is_apisix_standalone = backend_kind == "apisix-standalone";
 
     let _standalone_guard = if is_apisix_standalone {
@@ -97,10 +97,10 @@ async fn run(
 
     let events_for_output = is_apisix_standalone.then(|| events.clone());
     let results = gateway.sync(events, sync_opts).await?;
-    Ok(match events_for_output {
-        Some(events) => output_for_apisix_standalone(&events, &results),
-        None => output(&results),
-    })
+    match events_for_output {
+        Some(events) => Ok(output_for_apisix_standalone(gateway.as_ref(), &events, &results).await),
+        None => Ok((StatusCode::ACCEPTED, output(&results))),
+    }
 }
 
 #[derive(Serialize)]
@@ -121,6 +121,30 @@ fn status_of(total: usize, successes: usize, failures: usize) -> SyncStatus {
     }
 }
 
+/// `server` is only ever `Some` for the per-server backends (apisix-
+/// standalone) — apisix/api7ee never set it (they have exactly one
+/// target, not a cluster to distinguish between), and skip it entirely
+/// rather than serializing an always-`null` field: matches the TS
+/// implementation, where the equivalent property is simply never assigned
+/// (`server?: string`) and so never appears in the JSON either — an
+/// absent key there, not a `null` one.
+#[derive(Serialize)]
+struct SuccessEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+    event: Option<Value>,
+    synced_at: String,
+}
+
+#[derive(Serialize)]
+struct FailedEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<String>,
+    event: Option<Value>,
+    failed_at: String,
+    reason: String,
+}
+
 fn output(results: &[BackendSyncResult]) -> Value {
     let now = chrono::Utc::now().to_rfc3339();
     let (successes, failures): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.success);
@@ -130,45 +154,103 @@ fn output(results: &[BackendSyncResult]) -> Value {
         "total_resources": results.len(),
         "success_count": successes.len(),
         "failed_count": failures.len(),
-        "success": successes.iter().map(|r| json!({
-            "server": r.server,
-            "event": r.event.as_ref().map(simplify_event),
-            "synced_at": now,
-        })).collect::<Vec<_>>(),
-        "failed": failures.iter().map(|r| json!({
-            "server": r.server,
-            "event": r.event.as_ref().map(simplify_event),
-            "failed_at": now,
-            "reason": r.error.as_ref().map(|e| e.to_string()).unwrap_or_default(),
-        })).collect::<Vec<_>>(),
+        "success": successes.iter().map(|r| SuccessEntry {
+            server: r.server.clone(),
+            event: r.event.as_ref().map(simplify_event),
+            synced_at: now.clone(),
+        }).collect::<Vec<_>>(),
+        "failed": failures.iter().map(|r| FailedEntry {
+            server: r.server.clone(),
+            event: r.event.as_ref().map(simplify_event),
+            failed_at: now.clone(),
+            reason: r.error.as_ref().map(|e| e.to_string()).unwrap_or_default(),
+        }).collect::<Vec<_>>(),
     })
 }
 
 /// One `BackendSyncResult` per *server* here, not per event — `success`/
-/// `failed` describe `events` directly, `endpoint_status` carries the
-/// per-server detail.
-fn output_for_apisix_standalone(events: &[Event], results: &[BackendSyncResult]) -> Value {
+/// `failed` describe `events` directly (same shape as `output`'s, so the
+/// caller doesn't need a standalone-specific parser for them), and
+/// `endpoint_status` carries the per-server detail `output` has no
+/// equivalent for.
+///
+/// `events` is never split between `success`/`failed` — apisix-standalone
+/// writes one document in one request, so `events` as a whole landed or
+/// it didn't: every server failing is always `400`, and puts every event
+/// in `failed`; anything else (including a partial failure — some server
+/// rejecting the exact same document some other server just accepted
+/// isn't about the document being bad) puts every event in `success`.
+///
+/// On an all-failed `400`, re-validates `events` against the gateway (the
+/// same call `/validate` itself makes) for a `reason` more specific than
+/// the sync failure's own — a resource named in the re-validate's result
+/// gets its own error; everything else falls back to the first server's
+/// rejection reason (still useful — a conf_version conflict, say, rejects
+/// the whole document for a reason that has nothing to do with any one
+/// resource, and re-validating finds nothing to report there). Best-effort
+/// — a re-validate that itself errors just means every event falls back
+/// to that same shared reason.
+async fn output_for_apisix_standalone(gateway: &dyn Backend, events: &[Event], results: &[BackendSyncResult]) -> (StatusCode, Value) {
     let now = chrono::Utc::now().to_rfc3339();
     let (successes, failures): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.success);
+    let status = status_of(results.len(), successes.len(), failures.len());
 
-    json!({
-        "status": status_of(results.len(), successes.len(), failures.len()),
+    let (http_status, success, failed) = match status {
+        SyncStatus::AllFailed => {
+            let errors = match gateway.validate(events).await {
+                Ok(BackendValidateResult { errors, .. }) => errors,
+                Err(_) => vec![],
+            };
+            let reason_by_resource: HashMap<&str, &str> =
+                errors.iter().filter_map(|e| e.resource_id.as_deref().map(|id| (id, e.error.as_str()))).collect();
+            let shared_reason = failures.first().and_then(|r| r.error.as_ref()).map(|e| e.to_string()).unwrap_or_default();
+
+            let failed = events
+                .iter()
+                .map(|event| FailedEntry {
+                    server: None,
+                    event: Some(simplify_event(event)),
+                    failed_at: now.clone(),
+                    reason: reason_for(event, &reason_by_resource, &shared_reason),
+                })
+                .collect::<Vec<_>>();
+            (StatusCode::BAD_REQUEST, Vec::new(), failed)
+        }
+        SyncStatus::Success | SyncStatus::PartialFailure => {
+            let success = events
+                .iter()
+                .map(|event| SuccessEntry { server: None, event: Some(simplify_event(event)), synced_at: now.clone() })
+                .collect::<Vec<_>>();
+            (StatusCode::ACCEPTED, success, Vec::new())
+        }
+    };
+
+    let body = json!({
+        "status": status,
         "total_resources": 0,
         "success_count": successes.len(),
         "failed_count": failures.len(),
-        "success": events.iter().map(|event| json!({
-            "event": simplify_event(event),
-            "synced_at": now,
-        })).collect::<Vec<_>>(),
-        "failed": Vec::<Value>::new(),
-        "endpoint_status": results.iter().map(|r| json!({
-            "server": r.server,
-            "success": r.success,
-            "confirmation": confirmation_of(r),
-            "reason": r.error.as_ref().map(|e| e.to_string()),
-            "requested_at": now,
-        })).collect::<Vec<_>>(),
-    })
+        "success": success,
+        "failed": failed,
+        "endpoint_status": results.iter().map(|r| EndpointStatusEntry {
+            server: r.server.clone(),
+            success: r.success,
+            confirmation: confirmation_of(r),
+            reason: r.error.as_ref().map(|e| e.to_string()),
+            requested_at: now.clone(),
+        }).collect::<Vec<_>>(),
+    });
+    (http_status, body)
+}
+
+/// The specific reason a re-validate found for `event` (matched by
+/// `resource_id`), or `shared_reason` when it didn't — either because the
+/// re-validate ran but didn't report anything for this particular event
+/// (a resource swept up in the same failed batch without being
+/// individually invalid), or because it found nothing at all (the whole
+/// document was rejected for a reason that isn't about any one resource).
+fn reason_for(event: &Event, reason_by_resource: &HashMap<&str, &str>, shared_reason: &str) -> String {
+    reason_by_resource.get(event.resource_id.as_str()).map(|r| r.to_string()).unwrap_or_else(|| shared_reason.to_string())
 }
 
 #[derive(Serialize)]
@@ -176,6 +258,17 @@ fn output_for_apisix_standalone(events: &[Event], results: &[BackendSyncResult])
 enum Confirmation {
     Applied,
     Accepted,
+}
+
+#[derive(Serialize)]
+struct EndpointStatusEntry {
+    server: Option<String>,
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    confirmation: Option<Confirmation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    requested_at: String,
 }
 
 /// `null` for a failed write (nothing was confirmed *or* accepted) or a
@@ -225,6 +318,33 @@ mod tests {
     }
 
     #[test]
+    fn a_none_server_is_an_absent_key_not_a_null_value() {
+        let entry = SuccessEntry { server: None, event: None, synced_at: "t".to_string() };
+        let value = serde_json::to_value(entry).unwrap();
+        assert!(!value.as_object().unwrap().contains_key("server"), "{value}");
+
+        let entry = FailedEntry { server: None, event: None, failed_at: "t".to_string(), reason: "x".to_string() };
+        let value = serde_json::to_value(entry).unwrap();
+        assert!(!value.as_object().unwrap().contains_key("server"), "{value}");
+    }
+
+    #[test]
+    fn a_some_server_still_serializes_normally() {
+        let entry = SuccessEntry { server: Some("s1".to_string()), event: None, synced_at: "t".to_string() };
+        let value = serde_json::to_value(entry).unwrap();
+        assert_eq!(value["server"], json!("s1"));
+    }
+
+    #[test]
+    fn endpoint_status_omits_confirmation_and_reason_when_absent_rather_than_nulling_them() {
+        let entry = EndpointStatusEntry { server: Some("s1".to_string()), success: true, confirmation: None, reason: None, requested_at: "t".to_string() };
+        let value = serde_json::to_value(entry).unwrap();
+        let object = value.as_object().unwrap();
+        assert!(!object.contains_key("confirmation"), "{value}");
+        assert!(!object.contains_key("reason"), "{value}");
+    }
+
+    #[test]
     fn a_failed_write_has_no_confirmation_regardless_of_what_confirmed_says() {
         assert!(confirmation_of(&result(false, Some(true))).is_none());
         assert!(confirmation_of(&result(false, None)).is_none());
@@ -252,5 +372,29 @@ mod tests {
         assert_eq!(serde_json::to_value(status_of(2, 2, 0)).unwrap(), json!("success"));
         assert_eq!(serde_json::to_value(status_of(2, 0, 2)).unwrap(), json!("all_failed"));
         assert_eq!(serde_json::to_value(status_of(2, 1, 1)).unwrap(), json!("partial_failure"));
+    }
+
+    fn event_with_id(resource_id: &str) -> Event {
+        Event::new(ResourceType::Service, adc_sdk::EventKind::Create { new_value: json!({"name": "svc"}) }, resource_id, "svc")
+    }
+
+    #[test]
+    fn reason_for_prefers_the_re_validate_error_matched_by_resource_id() {
+        let event = event_with_id("bad-one");
+        let reason_by_resource = HashMap::from([("bad-one", "unknown plugin")]);
+        assert_eq!(reason_for(&event, &reason_by_resource, "shared reason"), "unknown plugin");
+    }
+
+    #[test]
+    fn reason_for_falls_back_to_the_shared_reason_when_this_event_has_no_specific_match() {
+        let event = event_with_id("innocent-bystander");
+        let reason_by_resource = HashMap::from([("bad-one", "unknown plugin")]);
+        assert_eq!(reason_for(&event, &reason_by_resource, "shared reason"), "shared reason");
+    }
+
+    #[test]
+    fn reason_for_falls_back_to_the_shared_reason_when_nothing_matched_at_all() {
+        let event = event_with_id("any-id");
+        assert_eq!(reason_for(&event, &HashMap::new(), "shared reason"), "shared reason");
     }
 }

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -8,6 +8,7 @@ use axum::Json;
 use axum::body::Bytes;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Serialize;
 use serde_json::{Value, json};
 
 use super::schema::{self, SyncInput};
@@ -102,13 +103,21 @@ async fn run(
     })
 }
 
-fn status_of(total: usize, successes: usize, failures: usize) -> &'static str {
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SyncStatus {
+    Success,
+    AllFailed,
+    PartialFailure,
+}
+
+fn status_of(total: usize, successes: usize, failures: usize) -> SyncStatus {
     if total == successes {
-        "success"
+        SyncStatus::Success
     } else if total == failures {
-        "all_failed"
+        SyncStatus::AllFailed
     } else {
-        "partial_failure"
+        SyncStatus::PartialFailure
     }
 }
 
@@ -155,10 +164,33 @@ fn output_for_apisix_standalone(events: &[Event], results: &[BackendSyncResult])
         "endpoint_status": results.iter().map(|r| json!({
             "server": r.server,
             "success": r.success,
+            "confirmation": confirmation_of(r),
             "reason": r.error.as_ref().map(|e| e.to_string()),
             "requested_at": now,
         })).collect::<Vec<_>>(),
     })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Confirmation {
+    Applied,
+    Accepted,
+}
+
+/// `null` for a failed write (nothing was confirmed *or* accepted) or a
+/// backend/cluster that never reports the distinction (`confirmed: None`)
+/// — `Applied` when the write was confirmed picked up by the data plane,
+/// `Accepted` when it was only accepted for later processing.
+fn confirmation_of(result: &BackendSyncResult) -> Option<Confirmation> {
+    if !result.success {
+        return None;
+    }
+    match result.confirmed {
+        Some(true) => Some(Confirmation::Applied),
+        Some(false) => Some(Confirmation::Accepted),
+        None => None,
+    }
 }
 
 fn simplify_event(event: &Event) -> Value {
@@ -182,4 +214,43 @@ fn lint_issue_json(issue: &adc_sdk::lint::LintIssue) -> Value {
         "path": issue.path.iter().map(ToString::to_string).collect::<Vec<_>>(),
         "message": issue.message,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(success: bool, confirmed: Option<bool>) -> BackendSyncResult {
+        BackendSyncResult { success, event: None, error: None, server: Some("s1".to_string()), confirmed }
+    }
+
+    #[test]
+    fn a_failed_write_has_no_confirmation_regardless_of_what_confirmed_says() {
+        assert!(confirmation_of(&result(false, Some(true))).is_none());
+        assert!(confirmation_of(&result(false, None)).is_none());
+    }
+
+    #[test]
+    fn a_backend_that_never_reports_the_distinction_has_no_confirmation() {
+        assert!(confirmation_of(&result(true, None)).is_none());
+    }
+
+    #[test]
+    fn a_confirmed_write_serializes_to_applied() {
+        let confirmation = confirmation_of(&result(true, Some(true))).unwrap();
+        assert_eq!(serde_json::to_value(confirmation).unwrap(), json!("applied"));
+    }
+
+    #[test]
+    fn a_merely_accepted_write_serializes_to_accepted() {
+        let confirmation = confirmation_of(&result(true, Some(false))).unwrap();
+        assert_eq!(serde_json::to_value(confirmation).unwrap(), json!("accepted"));
+    }
+
+    #[test]
+    fn status_of_serializes_to_the_three_snake_case_values() {
+        assert_eq!(serde_json::to_value(status_of(2, 2, 0)).unwrap(), json!("success"));
+        assert_eq!(serde_json::to_value(status_of(2, 0, 2)).unwrap(), json!("all_failed"));
+        assert_eq!(serde_json::to_value(status_of(2, 1, 1)).unwrap(), json!("partial_failure"));
+    }
 }

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -136,15 +136,23 @@ async fn put_sync(server: &Server, body: &Value) -> (u16, Value) {
     (status, json)
 }
 
-/// `SERVER1`'s raw config document, bypassing this whole crate — used to
+/// `server`'s raw config document, bypassing this whole crate — used to
 /// prove a rejected write actually left the real server untouched, not
-/// just that the response said so.
-async fn raw_consumers() -> Vec<Value> {
+/// just that the response said so. `error_for_status` first, so a failed
+/// request surfaces as a panic instead of silently reading as "no
+/// consumers". A genuinely successful response with no `consumers` field
+/// at all is a real, different case — a fresh instance that has never had
+/// anything written to it omits the key entirely rather than returning
+/// `[]` (see `typing.rs`'s own tolerant deserialization for this) — and is
+/// correctly treated as "no consumers".
+async fn raw_consumers(server: &str) -> Vec<Value> {
     let response = reqwest::Client::new()
-        .get(format!("{SERVER1}/apisix/admin/configs"))
+        .get(format!("{server}/apisix/admin/configs"))
         .header("X-API-KEY", TOKEN)
         .send()
         .await
+        .unwrap()
+        .error_for_status()
         .unwrap();
     let body: Value = response.json().await.unwrap();
     body["consumers"].as_array().cloned().unwrap_or_default()
@@ -227,8 +235,10 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     }
 
     // Rejected outright by every server — neither consumer, not even the
-    // innocent one, actually landed anywhere.
-    assert!(raw_consumers().await.is_empty(), "an all-failed write must leave the real servers untouched");
+    // innocent one, actually landed anywhere on any of the three.
+    for target in [SERVER1, SERVER2, SERVER3] {
+        assert!(raw_consumers(target).await.is_empty(), "an all-failed write must leave {target} untouched");
+    }
 
     // The cluster isn't left poisoned by the rejected write — a follow-up
     // sync with just the valid resource still succeeds normally.
@@ -236,7 +246,7 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     let (status, json) = put_sync(&server, &recovery_body).await;
     assert_eq!(status, 202, "{json}");
     assert_eq!(json["status"], "success", "{json}");
-    assert_eq!(raw_consumers().await.len(), 1, "{json}");
+    assert_eq!(raw_consumers(SERVER1).await.len(), 1, "{json}");
 }
 
 #[tokio::test]

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -1,0 +1,267 @@
+//! Black-box `/sync` coverage for the apisix-standalone backend through the
+//! real ingress-server HTTP layer, against a live 3-instance standalone
+//! APISIX cluster — same cluster `adc-backend-apisix-standalone`'s own e2e
+//! suite uses (see that crate's `tests/common/mod.rs` for how to bring it
+//! up). That suite already covers `Backend` itself thoroughly; this file
+//! only proves the pieces it can't see: `output_for_apisix_standalone`'s
+//! JSON shape, HTTP status mapping, and `endpoint_status`, exercised end to
+//! end through a real HTTP request to a real spawned `adc` process — the
+//! same black-box pattern `ingress_server_sigint.rs` uses.
+//!
+//! The real cluster here reports APISIX/3.17.0, below the 3.19.0
+//! `?wait`-confirmation gate — every successful write is therefore always
+//! `confirmed` regardless of the raw status APISIX itself returns for that
+//! request. The `>= 3.19 and 202 → accepted, not applied` branch has no
+//! real gateway to test against yet; `operator.rs`'s own unit tests are the
+//! only coverage for it (see D10 in `impl/standalone/changes-by-project.md`).
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::process::{Child, Command};
+use tokio::time::timeout;
+
+const SERVER1: &str = "http://localhost:19180";
+const SERVER2: &str = "http://localhost:29180";
+const SERVER3: &str = "http://localhost:39180";
+const TOKEN: &str = "edd1c9f034335f136f87ad84b625c8f1";
+const UNREACHABLE: &str = "http://127.0.0.1:1";
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+}
+
+/// Same cluster, same wipe-and-recheck strategy as
+/// `adc-backend-apisix-standalone`'s own `common::restart_apisix` — every
+/// test here needs a clean document on all three real servers, since
+/// standalone has no per-test namespacing of its own.
+async fn restart_apisix() {
+    let compose_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../libs/backend-apisix-standalone/e2e/assets");
+    let status = Command::new("docker")
+        .args(["compose", "restart"])
+        .current_dir(&compose_dir)
+        .status()
+        .await
+        .unwrap_or_else(|e| panic!("failed to run `docker compose restart` in {compose_dir:?}: {e}"));
+    assert!(status.success(), "`docker compose restart` in {compose_dir:?} failed");
+
+    for server in [SERVER1, SERVER2, SERVER3] {
+        wait_until_ready(server).await;
+    }
+}
+
+async fn wait_until_ready(server: &str) {
+    let client = reqwest::Client::new();
+    const MAX_ATTEMPTS: u32 = 60;
+    const REQUIRED_CONSECUTIVE_SUCCESSES: u32 = 2;
+    let mut consecutive_successes = 0;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let got_200 = client
+            .get(format!("{server}/apisix/admin/configs"))
+            .header("X-API-KEY", TOKEN)
+            .send()
+            .await
+            .map(|r| r.status().as_u16() == 200)
+            .unwrap_or(false);
+        consecutive_successes = if got_200 { consecutive_successes + 1 } else { 0 };
+        if consecutive_successes >= REQUIRED_CONSECUTIVE_SUCCESSES {
+            return;
+        }
+        if attempt == MAX_ATTEMPTS {
+            panic!("{server} never became ready after `docker compose restart` ({MAX_ATTEMPTS} attempts)");
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Spawns the real `adc` binary in `ingress-server` mode and waits for its
+/// status listener to report ready.
+struct Server {
+    child: Child,
+    base_url: String,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+    }
+}
+
+async fn spawn_server() -> Server {
+    let listen_port = free_port();
+    let status_port = free_port();
+    let child = Command::new(env!("CARGO_BIN_EXE_adc"))
+        .args(["ingress-server", "--listen", &format!("http://127.0.0.1:{listen_port}"), "--listen-status", &format!("{status_port}")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to spawn the adc binary");
+
+    let ready = timeout(Duration::from_secs(10), async {
+        loop {
+            if let Ok(response) = reqwest::get(format!("http://127.0.0.1:{status_port}/healthz/ready")).await
+                && response.status().is_success()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(ready.is_ok(), "ingress-server never became ready");
+
+    Server { child, base_url: format!("http://127.0.0.1:{listen_port}") }
+}
+
+fn sync_body(servers: &[&str], cache_key: &str, config: Value) -> Value {
+    json!({
+        "task": {
+            "opts": {
+                "backend": "apisix-standalone",
+                "server": servers,
+                "token": TOKEN,
+                "cacheKey": cache_key,
+            },
+            "config": config,
+        }
+    })
+}
+
+async fn put_sync(server: &Server, body: &Value) -> (u16, Value) {
+    let response = reqwest::Client::new().put(format!("{}/sync", server.base_url)).json(body).send().await.unwrap();
+    let status = response.status().as_u16();
+    let json = response.json().await.unwrap();
+    (status, json)
+}
+
+/// `SERVER1`'s raw config document, bypassing this whole crate — used to
+/// prove a rejected write actually left the real server untouched, not
+/// just that the response said so.
+async fn raw_consumers() -> Vec<Value> {
+    let response = reqwest::Client::new()
+        .get(format!("{SERVER1}/apisix/admin/configs"))
+        .header("X-API-KEY", TOKEN)
+        .send()
+        .await
+        .unwrap();
+    let body: Value = response.json().await.unwrap();
+    body["consumers"].as_array().cloned().unwrap_or_default()
+}
+
+fn consumer(username: &str) -> Value {
+    json!({"username": username, "plugins": {"limit-count": {"count": 10, "time_window": 60}}})
+}
+
+/// `limit-count` requires `count`/`time_window`; both are missing — the
+/// same shape `e2e_validate.rs` uses, confirmed against a real standalone
+/// admin API to 400 the whole config write, not just `/validate`.
+fn consumer_with_bad_plugin(username: &str) -> Value {
+    json!({"username": username, "plugins": {"limit-count": {}}})
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_successful_sync_confirms_every_server() {
+    restart_apisix().await;
+    let server = spawn_server().await;
+    let body = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-success", json!({"consumers": [consumer("sync-ok")]}));
+
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 202, "{json}");
+    assert_eq!(json["status"], "success", "{json}");
+    assert_eq!(json["total_resources"], 1, "{json}");
+    assert_eq!(json["success_count"], 1, "{json}");
+    assert_eq!(json["failed_count"], 0, "{json}");
+    assert_eq!(json["success"].as_array().unwrap().len(), 1, "{json}");
+    assert_eq!(json["failed"].as_array().unwrap().len(), 0, "{json}");
+
+    let endpoint_status = json["endpoint_status"].as_array().unwrap();
+    assert_eq!(endpoint_status.len(), 3, "{json}");
+    for entry in endpoint_status {
+        assert_eq!(entry["success"], true, "{json}");
+        // The real cluster reports APISIX/3.17.0, below the 3.19.0 wait
+        // gate — every successful write is confirmed regardless of the raw
+        // status APISIX itself returned for this request.
+        assert_eq!(entry["confirmation"], "applied", "{json}");
+        assert!(entry["reason"].is_null(), "{json}");
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn an_all_server_rejection_reports_structured_per_resource_failures() {
+    restart_apisix().await;
+    let server = spawn_server().await;
+    let config = json!({"consumers": [consumer("innocent-bystander"), consumer_with_bad_plugin("the-bad-one")]});
+    let body = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-all-failed", config);
+
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 400, "{json}");
+    assert_eq!(json["status"], "all_failed", "{json}");
+    assert_eq!(json["total_resources"], 2, "{json}");
+    assert_eq!(json["success_count"], 0, "{json}");
+    assert_eq!(json["failed_count"], 2, "{json}");
+    assert_eq!(json["success"].as_array().unwrap().len(), 0, "{json}");
+
+    let failed = json["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 2, "{json}");
+    let bad = failed.iter().find(|e| e["event"]["resource_name"] == "the-bad-one").expect("the bad resource must be in `failed`");
+    let good = failed
+        .iter()
+        .find(|e| e["event"]["resource_name"] == "innocent-bystander")
+        .expect("the whole document was rejected — the innocent resource must be in `failed` too");
+
+    let bad_reason = bad["reason"].as_str().unwrap();
+    assert!(bad_reason.to_lowercase().contains("limit-count"), "{bad_reason}");
+    let good_reason = good["reason"].as_str().unwrap();
+    assert!(!good_reason.is_empty(), "{json}");
+
+    let endpoint_status = json["endpoint_status"].as_array().unwrap();
+    assert_eq!(endpoint_status.len(), 3, "{json}");
+    for entry in endpoint_status {
+        assert_eq!(entry["success"], false, "{json}");
+        assert!(entry["confirmation"].is_null(), "{json}");
+        assert!(entry["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
+    }
+
+    // Rejected outright by every server — neither consumer, not even the
+    // innocent one, actually landed anywhere.
+    assert!(raw_consumers().await.is_empty(), "an all-failed write must leave the real servers untouched");
+
+    // The cluster isn't left poisoned by the rejected write — a follow-up
+    // sync with just the valid resource still succeeds normally.
+    let recovery_body = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-all-failed", json!({"consumers": [consumer("innocent-bystander")]}));
+    let (status, json) = put_sync(&server, &recovery_body).await;
+    assert_eq!(status, 202, "{json}");
+    assert_eq!(json["status"], "success", "{json}");
+    assert_eq!(raw_consumers().await.len(), 1, "{json}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn a_partial_server_failure_still_reports_the_event_as_synced() {
+    restart_apisix().await;
+    let server = spawn_server().await;
+    let body = sync_body(&[SERVER1, SERVER2, UNREACHABLE], "sync-e2e-partial-failure", json!({"consumers": [consumer("sync-partial")]}));
+
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 202, "{json}");
+    assert_eq!(json["status"], "partial_failure", "{json}");
+    assert_eq!(json["total_resources"], 1, "{json}");
+    assert_eq!(json["success_count"], 1, "{json}");
+    assert_eq!(json["failed_count"], 0, "{json}");
+    assert_eq!(json["success"].as_array().unwrap().len(), 1, "{json}");
+    assert_eq!(json["failed"].as_array().unwrap().len(), 0, "{json}");
+
+    let endpoint_status = json["endpoint_status"].as_array().unwrap();
+    assert_eq!(endpoint_status.len(), 3, "{json}");
+    let successes = endpoint_status.iter().filter(|e| e["success"] == true).count();
+    let failures = endpoint_status.iter().filter(|e| e["success"] == false).count();
+    assert_eq!(successes, 2, "{json}");
+    assert_eq!(failures, 1, "{json}");
+    let failed_entry = endpoint_status.iter().find(|e| e["success"] == false).unwrap();
+    assert!(failed_entry["confirmation"].is_null(), "{json}");
+    assert!(failed_entry["reason"].as_str().is_some_and(|r| !r.is_empty()), "{json}");
+}

--- a/rust/crates/adc-sdk/src/backend/mod.rs
+++ b/rust/crates/adc-sdk/src/backend/mod.rs
@@ -52,6 +52,13 @@ pub struct BackendSyncResult {
     pub event: Option<Event>,
     pub error: Option<BackendError>,
     pub server: Option<String>,
+    /// Whether this backend can, and did, confirm the write was actually
+    /// picked up by the data plane rather than merely accepted for later
+    /// processing — `None` for every backend that makes no such
+    /// distinction (everything but apisix-standalone, today, and even
+    /// there only when talking to a cluster new enough to wait for that
+    /// confirmation). Never meaningful when `success` is `false`.
+    pub confirmed: Option<bool>,
 }
 
 /// `resource_type` stays a raw string, not `ResourceType`: it's whatever the


### PR DESCRIPTION
### Description

Four related changes to the apisix-standalone backend and the ingress-server's `/sync` endpoint, building on #588/#589:

- **Drop `apisix-standalone` from the plain CLI's `--backend`** (`apisix`/`api7ee` only). This backend exists to be driven by the ingress server on AIC's behalf, not to be picked directly from a shell. Server mode (`Opts::backend: String`) is untouched. As a side effect, this also closes off the only remaining path to `Operator::sync`'s first-error-abort mode for standalone — server mode already ran with `exit_on_failure: false`, so no behavior change was needed there.
- **Detect and log conf_version conflicts** (a 400 whose message names a `conf_version` field): logged once as an `ERROR`, the response itself is unchanged and still propagates to the caller as-is. Verified against a real APISIX 3.17.0 rejection message, and against a live cluster where one sync's stale `conf_version` collides with another's.
- **Distinguish "applied" from "accepted"**: PUTs now carry `?wait=<ms>` (`ADC_APISIX_STANDALONE_SYNC_WAIT_MS`, default 3000). On a cluster new enough to honor it (`>= 3.19.0`), a `200` means the write was confirmed picked up by the data plane and a `202` means only accepted for later processing; ADC's own cache only refreshes on a confirmed write. Older clusters (which never return anything but their usual status regardless of `?wait`) are treated as always-confirmed, so their cache refresh isn't broken by this gate.
- **Structured `/sync` failures for apisix-standalone**: the response now returns `success`/`failed` arrays shaped exactly like the other backends' (not a bespoke format), plus a standalone-only `endpoint_status[]` with each server's `applied`/`accepted` confirmation. When every server rejects the same document (`all_failed`, HTTP 400), the events are re-validated against the gateway and each one gets either its own validate error (matched by `resource_id`) or a shared fallback reason; a partial failure (some servers unreachable, not a bad document) still reports every event as synced. Optional fields (`server`, `confirmation`, `reason`) are omitted from the JSON when absent, matching the TS implementation, rather than serialized as `null`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync responses now include HTTP status codes and structured success or failure details.
  * Successful standalone syncs report whether changes were confirmed by the data plane.
  * Partial results distinguish accepted, unconfirmed, and failed updates.

* **Bug Fixes**
  * Improved handling of version conflicts, invalid credentials, unreachable servers, and partial failures.
  * Failed operations no longer leave stale cached state.

* **Tests**
  * Added coverage for concurrency, confirmation behavior, error handling, and multi-server failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->