### PR TITLE
feat(server): rust standardize sync response status codes

### DIFF
--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use adc_sdk::resources::Configuration;
-use adc_sdk::{Backend, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
+use adc_sdk::{Backend, BackendError, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
 use axum::Json;
 use axum::body::Bytes;
 use axum::http::StatusCode;
@@ -176,15 +176,18 @@ fn output(results: &[BackendSyncResult]) -> Value {
 ///
 /// `events` is never split between `success`/`failed` — apisix-standalone
 /// writes one document in one request, so `events` as a whole landed or
-/// it didn't: every server failing is always `422` (the request itself was
-/// fine, the data plane rejected its content — `400` stays reserved for a
-/// malformed request, which never reaches this function at all), and puts
-/// every event in `failed`; anything else (including a partial failure —
-/// some server rejecting the exact same document some other server just
-/// accepted isn't about the document being bad) puts every event in
-/// `success`, with the status code telling those two apart: `200` once
-/// every server also confirmed the write, `202` for a partial failure or a
-/// write still only accepted.
+/// it didn't: every server failing puts every event in `failed`, answered
+/// `422` when at least one server actually evaluated the document and
+/// rejected it (the request itself was fine, the data plane rejected its
+/// content — `400` stays reserved for a malformed request, which never
+/// reaches this function at all) or `500` when every failure was transient
+/// (every server unreachable, or every server's own admin API erroring) —
+/// nobody looked at the content, so it isn't `422`'s to blame. Anything
+/// else (including a partial failure — some server rejecting the exact
+/// same document some other server just accepted isn't about the document
+/// being bad) puts every event in `success`, with the status code telling
+/// those two apart: `200` once every server also confirmed the write,
+/// `202` for a partial failure or a write still only accepted.
 ///
 /// On an all-failed `422`, re-validates `events` against the gateway (the
 /// same call `/validate` itself makes) for a `reason` more specific than
@@ -219,7 +222,8 @@ async fn output_for_apisix_standalone(gateway: &dyn Backend, events: &[Event], r
                     reason: reason_for(event, &reason_by_resource, &shared_reason),
                 })
                 .collect::<Vec<_>>();
-            (StatusCode::UNPROCESSABLE_ENTITY, Vec::new(), failed)
+            let status_code = if content_was_rejected(&failures) { StatusCode::UNPROCESSABLE_ENTITY } else { StatusCode::INTERNAL_SERVER_ERROR };
+            (status_code, Vec::new(), failed)
         }
         SyncStatus::Success => {
             let success = events
@@ -285,6 +289,17 @@ struct EndpointStatusEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
     requested_at: String,
+}
+
+/// Whether at least one server actually looked at the document and rejected
+/// it, as opposed to every failure being transient (unreachable, or the
+/// server's own admin API erroring on its end) — reuses `is_retriable`'s
+/// existing split, since a retriable failure is by definition one where the
+/// backend never gave a verdict on the content itself. All-transient means
+/// `422` would blame the document for something that was never evaluated;
+/// `500` says so instead.
+fn content_was_rejected(failures: &[&BackendSyncResult]) -> bool {
+    failures.iter().any(|r| !r.error.as_ref().is_some_and(BackendError::is_retriable))
 }
 
 /// Whether every server's write was confirmed picked up by the data plane —
@@ -401,6 +416,40 @@ mod tests {
     #[test]
     fn all_confirmed_of_an_empty_slice_is_vacuously_true() {
         assert!(all_confirmed(&[]));
+    }
+
+    fn failed_result(error: BackendError) -> BackendSyncResult {
+        BackendSyncResult { success: false, event: None, error: Some(error), server: Some("s1".to_string()), confirmed: None }
+    }
+
+    #[test]
+    fn content_was_rejected_is_false_when_every_server_was_unreachable() {
+        let failures = [failed_result(BackendError::Transport("connection refused".into())), failed_result(BackendError::Transport("timed out".into()))];
+        assert!(!content_was_rejected(&failures.iter().collect::<Vec<_>>()));
+    }
+
+    #[test]
+    fn content_was_rejected_is_false_when_every_server_erred_on_its_own_end() {
+        let failures = [failed_result(BackendError::Api { status: 502, message: "bad gateway".into() })];
+        assert!(!content_was_rejected(&failures.iter().collect::<Vec<_>>()));
+    }
+
+    #[test]
+    fn content_was_rejected_is_true_when_a_server_actually_rejected_it() {
+        let failures = [failed_result(BackendError::Api { status: 400, message: "unknown plugin".into() })];
+        assert!(content_was_rejected(&failures.iter().collect::<Vec<_>>()));
+    }
+
+    #[test]
+    fn content_was_rejected_is_true_if_even_one_of_several_servers_rejected_it() {
+        // Two servers unreachable, one genuinely rejected the document -- that one rejection
+        // is a real, actionable signal about the content and takes priority.
+        let failures = [
+            failed_result(BackendError::Transport("connection refused".into())),
+            failed_result(BackendError::Api { status: 400, message: "unknown plugin".into() }),
+            failed_result(BackendError::Transport("connection refused".into())),
+        ];
+        assert!(content_was_rejected(&failures.iter().collect::<Vec<_>>()));
     }
 
     #[test]

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -176,12 +176,17 @@ fn output(results: &[BackendSyncResult]) -> Value {
 ///
 /// `events` is never split between `success`/`failed` — apisix-standalone
 /// writes one document in one request, so `events` as a whole landed or
-/// it didn't: every server failing is always `400`, and puts every event
-/// in `failed`; anything else (including a partial failure — some server
-/// rejecting the exact same document some other server just accepted
-/// isn't about the document being bad) puts every event in `success`.
+/// it didn't: every server failing is always `422` (the request itself was
+/// fine, the data plane rejected its content — `400` stays reserved for a
+/// malformed request, which never reaches this function at all), and puts
+/// every event in `failed`; anything else (including a partial failure —
+/// some server rejecting the exact same document some other server just
+/// accepted isn't about the document being bad) puts every event in
+/// `success`, with the status code telling those two apart: `200` once
+/// every server also confirmed the write, `202` for a partial failure or a
+/// write still only accepted.
 ///
-/// On an all-failed `400`, re-validates `events` against the gateway (the
+/// On an all-failed `422`, re-validates `events` against the gateway (the
 /// same call `/validate` itself makes) for a `reason` more specific than
 /// the sync failure's own — a resource named in the re-validate's result
 /// gets its own error; everything else falls back to the first server's
@@ -214,13 +219,24 @@ async fn output_for_apisix_standalone(gateway: &dyn Backend, events: &[Event], r
                     reason: reason_for(event, &reason_by_resource, &shared_reason),
                 })
                 .collect::<Vec<_>>();
-            (StatusCode::BAD_REQUEST, Vec::new(), failed)
+            (StatusCode::UNPROCESSABLE_ENTITY, Vec::new(), failed)
         }
-        SyncStatus::Success | SyncStatus::PartialFailure => {
+        SyncStatus::Success => {
             let success = events
                 .iter()
                 .map(|event| SuccessEntry { server: None, event: Some(simplify_event(event)), synced_at: now.clone() })
                 .collect::<Vec<_>>();
+            let status_code = if all_confirmed(results) { StatusCode::OK } else { StatusCode::ACCEPTED };
+            (status_code, success, Vec::new())
+        }
+        SyncStatus::PartialFailure => {
+            let success = events
+                .iter()
+                .map(|event| SuccessEntry { server: None, event: Some(simplify_event(event)), synced_at: now.clone() })
+                .collect::<Vec<_>>();
+            // A server outright failing isn't "done" even if the rest confirmed -- the
+            // cluster is left inconsistent, `endpoint_status` names which one, and `202`
+            // says as much.
             (StatusCode::ACCEPTED, success, Vec::new())
         }
     };
@@ -269,6 +285,15 @@ struct EndpointStatusEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
     requested_at: String,
+}
+
+/// Whether every server's write was confirmed picked up by the data plane —
+/// the bar a `Success` sync clears to answer `200` rather than `202`.
+/// `confirmed: Some(false)` is the only thing that fails it; `Some(true)`
+/// and `None` (a cluster too old to report the distinction, collapsed to
+/// "confirmed" the same as `is_confirmed` collapses a single PUT) both pass.
+fn all_confirmed(results: &[BackendSyncResult]) -> bool {
+    results.iter().all(|r| r.confirmed != Some(false))
 }
 
 /// `null` for a failed write (nothing was confirmed *or* accepted) or a
@@ -353,6 +378,29 @@ mod tests {
     #[test]
     fn a_backend_that_never_reports_the_distinction_has_no_confirmation() {
         assert!(confirmation_of(&result(true, None)).is_none());
+    }
+
+    #[test]
+    fn all_confirmed_requires_every_result_to_have_confirmed() {
+        assert!(all_confirmed(&[result(true, Some(true)), result(true, Some(true))]));
+    }
+
+    #[test]
+    fn all_confirmed_fails_on_a_single_merely_accepted_result() {
+        assert!(!all_confirmed(&[result(true, Some(true)), result(true, Some(false))]));
+    }
+
+    #[test]
+    fn all_confirmed_treats_an_unreported_distinction_as_confirmed() {
+        // A cluster too old to tell 200 from 202 apart never sets `confirmed` at all --
+        // collapsing that to "confirmed" is what keeps such a cluster's successful syncs at
+        // 200, not permanently stuck at 202.
+        assert!(all_confirmed(&[result(true, None)]));
+    }
+
+    #[test]
+    fn all_confirmed_of_an_empty_slice_is_vacuously_true() {
+        assert!(all_confirmed(&[]));
     }
 
     #[test]

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -164,7 +164,7 @@ fn consumer(username: &str) -> Value {
 
 /// `limit-count` requires `count`/`time_window`; both are missing — the
 /// same shape `e2e_validate.rs` uses, confirmed against a real standalone
-/// admin API to 400 the whole config write, not just `/validate`.
+/// admin API to 422 the whole config write, not just `/validate`.
 fn consumer_with_bad_plugin(username: &str) -> Value {
     json!({"username": username, "plugins": {"limit-count": {}}})
 }
@@ -177,7 +177,8 @@ async fn a_successful_sync_confirms_every_server() {
     let body = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-success", json!({"consumers": [consumer("sync-ok")]}));
 
     let (status, json) = put_sync(&server, &body).await;
-    assert_eq!(status, 202, "{json}");
+    // Every server confirmed the write (see the loop below) -- 200, not 202.
+    assert_eq!(status, 200, "{json}");
     assert_eq!(json["status"], "success", "{json}");
     assert_eq!(json["total_resources"], 1, "{json}");
     assert_eq!(json["success_count"], 1, "{json}");
@@ -206,7 +207,7 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     let body = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-all-failed", config);
 
     let (status, json) = put_sync(&server, &body).await;
-    assert_eq!(status, 400, "{json}");
+    assert_eq!(status, 422, "{json}");
     assert_eq!(json["status"], "all_failed", "{json}");
     assert_eq!(json["total_resources"], 2, "{json}");
     assert_eq!(json["success_count"], 0, "{json}");
@@ -244,7 +245,7 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     // sync with just the valid resource still succeeds normally.
     let recovery_body = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-all-failed", json!({"consumers": [consumer("innocent-bystander")]}));
     let (status, json) = put_sync(&server, &recovery_body).await;
-    assert_eq!(status, 202, "{json}");
+    assert_eq!(status, 200, "{json}");
     assert_eq!(json["status"], "success", "{json}");
     assert_eq!(raw_consumers(SERVER1).await.len(), 1, "{json}");
 }

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -276,3 +276,17 @@ async fn a_partial_server_failure_still_reports_the_event_as_synced() {
     assert!(failed_entry["confirmation"].is_null(), "{json}");
     assert!(failed_entry["reason"].as_str().is_some_and(|r| !r.is_empty()), "{json}");
 }
+
+/// Every configured server unreachable fails before a document is ever
+/// evaluated -- 500, not the 422 a genuine content rejection gets. No real
+/// APISIX cluster is involved at all, so this doesn't call `restart_apisix`.
+#[tokio::test]
+#[ignore]
+async fn every_server_unreachable_returns_500_not_422() {
+    let server = spawn_server().await;
+    let body = sync_body(&[UNREACHABLE, UNREACHABLE, UNREACHABLE], "sync-e2e-unreachable", json!({"consumers": [consumer("sync-unreachable")]}));
+
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 500, "{json}");
+    assert!(json["message"].as_str().is_some_and(|m| !m.is_empty()), "{json}");
+}


### PR DESCRIPTION
### Description

`PUT /sync`'s status codes used to conflate two unrelated things under `400` (a malformed request vs. apisix-standalone rejecting the document outright), and always answered `202` even when apisix-standalone had already confirmed the write was live on the data plane. This PR gives `/sync` a precise, backend-aware status-code contract instead, so a caller can tell what happened from the status code alone, without needing to inspect the body.

No change to `/validate`, `/healthz`/`/healthz/ready`, or any endpoint other than `/sync`.

#### Status codes `/sync` can answer with

**System-level — the same for every backend (`apisix`, `api7ee`, `apisix-standalone`)**

| Code | Meaning | Body |
|---|---|---|
| `413 Payload Too Large` | The request body exceeds the fixed 100 MiB limit, enforced by request-logging middleware before the request reaches the sync handler at all. Room enough for tens to hundreds of thousands of resources — this shouldn't happen outside a bug or a misbehaving caller. | none |
| `400 Bad Request` | The request itself is invalid, for reasons unrelated to any backend: unparsable JSON, an invalid `opts.server`/`opts.tlsClientCert`+`opts.tlsClientKey` pairing, a `config` payload that doesn't deserialize into the resource schema, or (when `opts.lint` — on by default — isn't disabled) a configuration that fails lint. Never carries per-resource `success`/`failed` detail. | `{"message": string, "errors": [...]}` |
| `500 Internal Server Error` | An ADC Server-side problem — e.g. failing to fetch or diff against the current remote state — prevented the sync from being attempted or completed. Distinct from any individual server/resource rejecting the write, which never reaches this code (see below). | `{"message": string}` |

**`apisix` / `api7ee`** — one admin-API call per resource, no atomicity or data-plane-confirmation concept above that call:

| Code | When | Body |
|---|---|---|
| `202 Accepted` | Always, whatever the outcome — `status` in the body is `"success"`, `"partial_failure"`, or `"all_failed"`, each event landing in `success[]` or `failed[]` on its own merits. This backend's admin API has no "wait for the data plane to pick it up" mechanism at all, so `202` is the only honest answer regardless of how many resources succeeded. | `SyncResult` |

**`apisix-standalone`** — one document, written atomically to every server in the cluster, with each server optionally confirming the data plane picked it up (via `?wait=`, gated on the cluster's own APISIX version):

| Code | When | Body |
|---|---|---|
| `200 OK` | Every event landed on every server, **and** every server confirmed the data plane applied it (`confirmed: Some(true)`, or `None` on a cluster too old to report the distinction — collapsed to "confirmed" the same way `is_confirmed` collapses a single PUT). | `SyncResult` |
| `202 Accepted` | Either a) every event landed everywhere but at least one server only *accepted* the write without confirming it (`confirmed: Some(false)`), or b) at least one server rejected the write outright while others accepted it (`partial_failure`) — the cluster is left inconsistent, and `endpoint_status[]` names which server. | `SyncResult` |
| `422 Unprocessable Entity` | Every server rejected the write — the request itself was well-formed, the document just wasn't accepted anywhere (a genuine content problem, e.g. an invalid plugin config, or a `conf_version` conflict with a concurrent writer). Every event lands in `failed[]`, each with the most specific reason a re-validate against the gateway could attach. | `SyncResult` |

`SyncResult`'s shape (`status`, `total_resources`, `success_count`, `failed_count`, `success[]`, `failed[]`, and — apisix-standalone only — `endpoint_status[]` with each server's `success`/`confirmation`/`reason`) is otherwise unchanged and identical across both backend families, so a caller that already parses it for `apisix`/`api7ee` needs no separate parser for `apisix-standalone`.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - APISIX standalone synchronization now returns `200 OK` for successful and recovery scenarios.
  - Returns `422 Unprocessable Entity` when servers reject document content.
  - Returns `500 Internal Server Error` when all configured servers are unreachable or encounter backend-internal failures.
  - Mixed server outcomes are classified consistently, with coverage for successful, rejected, unreachable, and backend-error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->