### PR TITLE
fix(core): rust use correct validate baseline

### DIFF
--- a/rust/crates/adc-cli/src/main.rs
+++ b/rust/crates/adc-cli/src/main.rs
@@ -8,6 +8,7 @@ mod server;
 
 use std::collections::{HashMap, HashSet};
 
+use adc_sdk::resources::Configuration;
 use adc_sdk::{BackendSyncOptions, Event, EventType, ResourceType};
 use clap::Parser;
 
@@ -280,14 +281,9 @@ async fn cmd_validate(args: ValidateArgs) -> Result<(), CliError> {
         ),
     )
     .await?;
-    let remote = progress::stage(
-        "Fetching remote configuration...",
-        pipeline::load_remote(backend.as_ref(), &include, &exclude, &label_selector),
-    )
-    .await?;
     let events = progress::stage(
         "Computing diff...",
-        pipeline::diff(backend.as_ref(), &local, &remote),
+        pipeline::diff(backend.as_ref(), &local, &Configuration::default()),
     )
     .await?;
 

--- a/rust/crates/adc-cli/src/server/validate.rs
+++ b/rust/crates/adc-cli/src/server/validate.rs
@@ -14,17 +14,6 @@ use super::{backend, bad_request, internal_error};
 use crate::config;
 use crate::pipeline;
 
-fn empty_configuration() -> Configuration {
-    Configuration {
-        services: None,
-        ssls: None,
-        consumers: None,
-        consumer_groups: None,
-        global_rules: None,
-        plugin_metadata: None,
-    }
-}
-
 pub async fn validate_handler(body: Bytes) -> Response {
     let input: ValidateInput = match serde_json::from_slice(&body) {
         Ok(input) => input,
@@ -79,7 +68,7 @@ pub async fn validate_handler(body: Bytes) -> Response {
         Err(error) => return internal_error(json!({"success": false, "message": error.to_string(), "errors": []})),
     };
 
-    let events = match pipeline::diff(gateway.as_ref(), &configuration, &empty_configuration()).await {
+    let events = match pipeline::diff(gateway.as_ref(), &configuration, &Configuration::default()).await {
         Ok(events) => events,
         Err(error) => return internal_error(json!({"success": false, "message": error.to_string(), "errors": []})),
     };


### PR DESCRIPTION
### Description

Currently, the `validate` command uses the actual remote configuration as a baseline, which isn't ideal. This is because resources already present in the remote configuration may become invalid due to version updates. This PR changes this behavior to use an empty remote configuration as the baseline, exactly as in the TypeScript implementation.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [ ] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
