### PR TITLE
fix(server): rust standardize failed semantic

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pemfile",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/rust/crates/adc-backend-apisix-standalone/src/backend.rs
+++ b/rust/crates/adc-backend-apisix-standalone/src/backend.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use adc_backend_core::{HttpClient, HttpClientConfig, Method, TlsConfig};
+use adc_backend_core::{HttpClient, HttpClientConfig, Method, TlsConfig, concurrent_map_until_ok};
 use adc_sdk::resources::Configuration;
 use adc_sdk::{
     BackendError, BackendMetadata, BackendSyncOptions, BackendSyncResult, BackendValidateResult,
@@ -383,8 +383,20 @@ impl adc_sdk::Backend for Backend {
 
     async fn validate(&self, events: &[Event]) -> Result<BackendValidateResult, BackendError> {
         let version = self.resolved_version().await?;
-        adc_backend_apisix::Validator::new(self.servers[0].client.clone(), version)
-            .validate(events)
-            .await
+        // Tries every configured server concurrently -- one unreachable instance (or one
+        // too old to support `/validate` at all) shouldn't blank out attribution as long as
+        // some other server in the cluster can answer. Whichever answers first (with a real
+        // result, not just whichever settles first) wins; the rest are dropped mid-flight.
+        concurrent_map_until_ok(self.servers.clone(), None, |server| {
+            let version = version.clone();
+            async move {
+                let result = adc_backend_apisix::Validator::new(server.client, version).validate(events).await;
+                if let Err(error) = &result {
+                    tracing::warn!("apisix-standalone: {} failed to validate: {error}", server.server);
+                }
+                result
+            }
+        })
+        .await
     }
 }

--- a/rust/crates/adc-backend-core/src/concurrency.rs
+++ b/rust/crates/adc-backend-core/src/concurrency.rs
@@ -58,3 +58,34 @@ where
         None => Ok(results),
     }
 }
+
+/// The mirror of `concurrent_map_until_err`: stops as soon as one item's future resolves to
+/// `Ok`, dropping every other future still in flight (and anything not yet dispatched)
+/// without waiting for them — dropping is the only way Rust has to cancel a future that's
+/// already running. Only fails once every item has: `Err` from whichever one settles last.
+///
+/// `items` must be non-empty — there's no `E` to report on zero attempts.
+pub async fn concurrent_map_until_ok<T, U, E, F, Fut>(items: Vec<T>, concurrency: Option<usize>, mut f: F) -> Result<U, E>
+where
+    F: FnMut(T) -> Fut,
+    Fut: Future<Output = Result<U, E>>,
+{
+    let concurrency = concurrency.unwrap_or(items.len()).max(1);
+    let mut items = items.into_iter();
+    let mut in_flight = FuturesUnordered::new();
+    for item in items.by_ref().take(concurrency) {
+        in_flight.push(f(item));
+    }
+
+    let mut last_error = None;
+    while let Some(outcome) = in_flight.next().await {
+        match outcome {
+            Ok(value) => return Ok(value),
+            Err(error) => last_error = Some(error),
+        }
+        if let Some(item) = items.next() {
+            in_flight.push(f(item));
+        }
+    }
+    Err(last_error.expect("items must be non-empty"))
+}

--- a/rust/crates/adc-backend-core/src/lib.rs
+++ b/rust/crates/adc-backend-core/src/lib.rs
@@ -14,7 +14,7 @@ mod retry;
 mod tls;
 
 pub use client::{HTTP_REQUEST_SPAN_NAME, HttpClient, HttpClientConfig, encode_path_segment};
-pub use concurrency::{concurrent_map, concurrent_map_until_err};
+pub use concurrency::{concurrent_map, concurrent_map_until_err, concurrent_map_until_ok};
 pub use event::{deserialize_event_value, missing_parent, to_request_body};
 pub use resource_filter::{ResourceFilter, filter_configuration_by_labels};
 pub use resource_path::resource_type_collection_name;

--- a/rust/crates/adc-backend-core/tests/concurrency.rs
+++ b/rust/crates/adc-backend-core/tests/concurrency.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use adc_backend_core::{concurrent_map, concurrent_map_until_err};
+use adc_backend_core::{concurrent_map, concurrent_map_until_err, concurrent_map_until_ok};
 
 #[tokio::test]
 async fn respects_the_concurrency_bound() {
@@ -87,4 +87,39 @@ async fn until_err_returns_all_results_when_nothing_fails() {
     let mut results = result.unwrap();
     results.sort();
     assert_eq!(results, items);
+}
+
+#[tokio::test]
+async fn until_ok_stops_pulling_new_work_after_the_first_success_but_finishes_in_flight_items() {
+    let started = AtomicUsize::new(0);
+    let items: Vec<u32> = (0..20).collect();
+
+    // Nothing resolves synchronously, so the whole initial batch gets polled at least once
+    // before any of them can win -- item 0's shorter sleep is what makes it win.
+    let result = concurrent_map_until_ok(items, Some(4), |item| {
+        let started = &started;
+        async move {
+            started.fetch_add(1, Ordering::SeqCst);
+            if item == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                return Ok::<u32, &str>(item);
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Err("boom")
+        }
+    })
+    .await;
+
+    assert_eq!(result, Ok(0));
+    // Only the initial batch (bounded by concurrency) was ever started -- nothing queued
+    // behind the limit was pulled once a success was observed.
+    assert_eq!(started.load(Ordering::SeqCst), 4, "no new work should start once a success is observed");
+}
+
+#[tokio::test]
+async fn until_ok_fails_only_once_everything_has() {
+    let items: Vec<u32> = (0..10).collect();
+    let result = concurrent_map_until_ok(items, Some(3), |_| async move { Err::<u32, &str>("boom") }).await;
+
+    assert_eq!(result, Err("boom"));
 }

--- a/rust/crates/adc-cli/Cargo.toml
+++ b/rust/crates/adc-cli/Cargo.toml
@@ -47,3 +47,4 @@ http-body-util = "0.1"
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 libc = "0.2"
+semver = { workspace = true }

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use adc_sdk::resources::Configuration;
-use adc_sdk::{Backend, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
+use adc_sdk::{Backend, BackendError, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
 use axum::Json;
 use axum::body::Bytes;
 use axum::http::StatusCode;
@@ -199,6 +199,16 @@ async fn output_for_apisix_standalone(
 
             let errors = match gateway.validate(&all_events).await {
                 Ok(BackendValidateResult { errors, .. }) => errors,
+                // This gateway version has no `/validate` endpoint at all -- `failed` comes
+                // back empty not because nothing was found, but because nothing could be
+                // looked for. Worth its own log line, not silently identical to any other
+                // validate failure.
+                Err(BackendError::Unsupported(_)) => {
+                    tracing::warn!(
+                        "apisix-standalone: gateway doesn't support /validate, all-failed rejection can't be attributed to a resource"
+                    );
+                    vec![]
+                }
                 Err(_) => vec![],
             };
             let reason_by_resource: HashMap<&str, &str> =

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use adc_sdk::resources::Configuration;
-use adc_sdk::{Backend, BackendError, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
+use adc_sdk::{Backend, BackendSyncOptions, BackendSyncResult, BackendValidateResult, Event, ResourceType};
 use axum::Json;
 use axum::body::Bytes;
 use axum::http::StatusCode;
@@ -98,7 +98,7 @@ async fn run(
     let events_for_output = is_apisix_standalone.then(|| events.clone());
     let results = gateway.sync(events, sync_opts).await?;
     match events_for_output {
-        Some(events) => Ok(output_for_apisix_standalone(gateway.as_ref(), &events, &results).await),
+        Some(events) => Ok(output_for_apisix_standalone(gateway.as_ref(), &local, &events, &results).await),
         None => Ok((StatusCode::ACCEPTED, output(&results))),
     }
 }
@@ -168,62 +168,59 @@ fn output(results: &[BackendSyncResult]) -> Value {
     })
 }
 
-/// One `BackendSyncResult` per *server* here, not per event — `success`/
-/// `failed` describe `events` directly (same shape as `output`'s, so the
-/// caller doesn't need a standalone-specific parser for them), and
-/// `endpoint_status` carries the per-server detail `output` has no
-/// equivalent for.
+/// One `BackendSyncResult` per *server*, not per event — it's whether the whole document
+/// landed on that server, not whether any one resource in it was valid. Status codes:
+/// `422` when every server failed (content rejected, unreachable, or a mix — `400` is only
+/// for a malformed request, handled before this function); `200`/`202` when every server
+/// took the write, split on whether every one also confirmed it; `202` for a partial
+/// failure (some server rejecting what others accepted isn't about the document).
 ///
-/// `events` is never split between `success`/`failed` — apisix-standalone
-/// writes one document in one request, so `events` as a whole landed or
-/// it didn't: every server failing puts every event in `failed`, answered
-/// `422` when at least one server actually evaluated the document and
-/// rejected it (the request itself was fine, the data plane rejected its
-/// content — `400` stays reserved for a malformed request, which never
-/// reaches this function at all) or `500` when every failure was transient
-/// (every server unreachable, or every server's own admin API erroring) —
-/// nobody looked at the content, so it isn't `422`'s to blame. Anything
-/// else (including a partial failure — some server rejecting the exact
-/// same document some other server just accepted isn't about the document
-/// being bad) puts every event in `success`, with the status code telling
-/// those two apart: `200` once every server also confirmed the write,
-/// `202` for a partial failure or a write still only accepted.
-///
-/// On an all-failed `422`, re-validates `events` against the gateway (the
-/// same call `/validate` itself makes) for a `reason` more specific than
-/// the sync failure's own — a resource named in the re-validate's result
-/// gets its own error; everything else falls back to the first server's
-/// rejection reason (still useful — a conf_version conflict, say, rejects
-/// the whole document for a reason that has nothing to do with any one
-/// resource, and re-validating finds nothing to report there). Best-effort
-/// — a re-validate that itself errors just means every event falls back
-/// to that same shared reason.
-async fn output_for_apisix_standalone(gateway: &dyn Backend, events: &[Event], results: &[BackendSyncResult]) -> (StatusCode, Value) {
+/// On `422`, re-validates *every resource this cacheKey holds* — not just this sync's own
+/// diff — since a resource the diff never touched can still be the one rejected. `failed[]`
+/// only ever holds what the re-validate actually named: an innocent resource swept up in the
+/// same rejection is left out entirely, never guessed at, so bad-resource exclusion can't
+/// blacklist it for something it never did.
+async fn output_for_apisix_standalone(
+    gateway: &dyn Backend,
+    local: &Configuration,
+    events: &[Event],
+    results: &[BackendSyncResult],
+) -> (StatusCode, Value) {
     let now = chrono::Utc::now().to_rfc3339();
     let (successes, failures): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.success);
     let status = status_of(results.len(), successes.len(), failures.len());
 
     let (http_status, success, failed) = match status {
         SyncStatus::AllFailed => {
-            let errors = match gateway.validate(events).await {
+            // Every resource as a fresh Create event, same as `/validate`'s empty-remote
+            // diff. Falls back to this sync's own `events` on error, though standalone's
+            // `default_value` makes no network call and shouldn't ever fail here.
+            let all_events = pipeline::diff(gateway, local, &Configuration::default()).await.unwrap_or_else(|_| events.to_vec());
+
+            let errors = match gateway.validate(&all_events).await {
                 Ok(BackendValidateResult { errors, .. }) => errors,
                 Err(_) => vec![],
             };
             let reason_by_resource: HashMap<&str, &str> =
                 errors.iter().filter_map(|e| e.resource_id.as_deref().map(|id| (id, e.error.as_str()))).collect();
-            let shared_reason = failures.first().and_then(|r| r.error.as_ref()).map(|e| e.to_string()).unwrap_or_default();
 
-            let failed = events
+            // Only resources the re-validate actually named -- an innocent one swept up in
+            // the same rejected document must never land here, or bad-resource exclusion
+            // would blacklist it for something it never did. A rejection with no per-resource
+            // cause at all (a conf_version race, say) leaves `failed` empty on purpose;
+            // `endpoint_status` already carries that document-level reason.
+            let failed = all_events
                 .iter()
-                .map(|event| FailedEntry {
-                    server: None,
-                    event: Some(simplify_event(event)),
-                    failed_at: now.clone(),
-                    reason: reason_for(event, &reason_by_resource, &shared_reason),
+                .filter_map(|event| {
+                    reason_by_resource.get(event.resource_id.as_str()).map(|reason| FailedEntry {
+                        server: None,
+                        event: Some(simplify_event(event)),
+                        failed_at: now.clone(),
+                        reason: reason.to_string(),
+                    })
                 })
                 .collect::<Vec<_>>();
-            let status_code = if content_was_rejected(&failures) { StatusCode::UNPROCESSABLE_ENTITY } else { StatusCode::INTERNAL_SERVER_ERROR };
-            (status_code, Vec::new(), failed)
+            (StatusCode::UNPROCESSABLE_ENTITY, Vec::new(), failed)
         }
         SyncStatus::Success => {
             let success = events
@@ -263,16 +260,6 @@ async fn output_for_apisix_standalone(gateway: &dyn Backend, events: &[Event], r
     (http_status, body)
 }
 
-/// The specific reason a re-validate found for `event` (matched by
-/// `resource_id`), or `shared_reason` when it didn't — either because the
-/// re-validate ran but didn't report anything for this particular event
-/// (a resource swept up in the same failed batch without being
-/// individually invalid), or because it found nothing at all (the whole
-/// document was rejected for a reason that isn't about any one resource).
-fn reason_for(event: &Event, reason_by_resource: &HashMap<&str, &str>, shared_reason: &str) -> String {
-    reason_by_resource.get(event.resource_id.as_str()).map(|r| r.to_string()).unwrap_or_else(|| shared_reason.to_string())
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 enum Confirmation {
@@ -289,17 +276,6 @@ struct EndpointStatusEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<String>,
     requested_at: String,
-}
-
-/// Whether at least one server actually looked at the document and rejected
-/// it, as opposed to every failure being transient (unreachable, or the
-/// server's own admin API erroring on its end) — reuses `is_retriable`'s
-/// existing split, since a retriable failure is by definition one where the
-/// backend never gave a verdict on the content itself. All-transient means
-/// `422` would blame the document for something that was never evaluated;
-/// `500` says so instead.
-fn content_was_rejected(failures: &[&BackendSyncResult]) -> bool {
-    failures.iter().any(|r| !r.error.as_ref().is_some_and(BackendError::is_retriable))
 }
 
 /// Whether every server's write was confirmed picked up by the data plane —
@@ -418,40 +394,6 @@ mod tests {
         assert!(all_confirmed(&[]));
     }
 
-    fn failed_result(error: BackendError) -> BackendSyncResult {
-        BackendSyncResult { success: false, event: None, error: Some(error), server: Some("s1".to_string()), confirmed: None }
-    }
-
-    #[test]
-    fn content_was_rejected_is_false_when_every_server_was_unreachable() {
-        let failures = [failed_result(BackendError::Transport("connection refused".into())), failed_result(BackendError::Transport("timed out".into()))];
-        assert!(!content_was_rejected(&failures.iter().collect::<Vec<_>>()));
-    }
-
-    #[test]
-    fn content_was_rejected_is_false_when_every_server_erred_on_its_own_end() {
-        let failures = [failed_result(BackendError::Api { status: 502, message: "bad gateway".into() })];
-        assert!(!content_was_rejected(&failures.iter().collect::<Vec<_>>()));
-    }
-
-    #[test]
-    fn content_was_rejected_is_true_when_a_server_actually_rejected_it() {
-        let failures = [failed_result(BackendError::Api { status: 400, message: "unknown plugin".into() })];
-        assert!(content_was_rejected(&failures.iter().collect::<Vec<_>>()));
-    }
-
-    #[test]
-    fn content_was_rejected_is_true_if_even_one_of_several_servers_rejected_it() {
-        // Two servers unreachable, one genuinely rejected the document -- that one rejection
-        // is a real, actionable signal about the content and takes priority.
-        let failures = [
-            failed_result(BackendError::Transport("connection refused".into())),
-            failed_result(BackendError::Api { status: 400, message: "unknown plugin".into() }),
-            failed_result(BackendError::Transport("connection refused".into())),
-        ];
-        assert!(content_was_rejected(&failures.iter().collect::<Vec<_>>()));
-    }
-
     #[test]
     fn a_confirmed_write_serializes_to_applied() {
         let confirmation = confirmation_of(&result(true, Some(true))).unwrap();
@@ -471,27 +413,4 @@ mod tests {
         assert_eq!(serde_json::to_value(status_of(2, 1, 1)).unwrap(), json!("partial_failure"));
     }
 
-    fn event_with_id(resource_id: &str) -> Event {
-        Event::new(ResourceType::Service, adc_sdk::EventKind::Create { new_value: json!({"name": "svc"}) }, resource_id, "svc")
-    }
-
-    #[test]
-    fn reason_for_prefers_the_re_validate_error_matched_by_resource_id() {
-        let event = event_with_id("bad-one");
-        let reason_by_resource = HashMap::from([("bad-one", "unknown plugin")]);
-        assert_eq!(reason_for(&event, &reason_by_resource, "shared reason"), "unknown plugin");
-    }
-
-    #[test]
-    fn reason_for_falls_back_to_the_shared_reason_when_this_event_has_no_specific_match() {
-        let event = event_with_id("innocent-bystander");
-        let reason_by_resource = HashMap::from([("bad-one", "unknown plugin")]);
-        assert_eq!(reason_for(&event, &reason_by_resource, "shared reason"), "shared reason");
-    }
-
-    #[test]
-    fn reason_for_falls_back_to_the_shared_reason_when_nothing_matched_at_all() {
-        let event = event_with_id("any-id");
-        assert_eq!(reason_for(&event, &HashMap::new(), "shared reason"), "shared reason");
-    }
 }

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -8,12 +8,14 @@
 //! end through a real HTTP request to a real spawned `adc` process — the
 //! same black-box pattern `ingress_server_sigint.rs` uses.
 //!
-//! The real cluster here reports APISIX/3.17.0, below the 3.19.0
-//! `?wait`-confirmation gate — every successful write is therefore always
-//! `confirmed` regardless of the raw status APISIX itself returns for that
-//! request. The `>= 3.19 and 202 → accepted, not applied` branch has no
-//! real gateway to test against yet; `operator.rs`'s own unit tests are the
-//! only coverage for it (see D10 in `impl/standalone/changes-by-project.md`).
+//! CI runs this against a version matrix (`BACKEND_APISIX_VERSION`, same env var the TS
+//! suite reads), all still below the 3.19.0 `?wait`-confirmation gate — every successful
+//! write is therefore always `confirmed` regardless of the raw status APISIX itself returns.
+//! The `>= 3.19 and 202 → accepted, not applied` branch has no real gateway to test against
+//! yet; `operator.rs`'s own unit tests are the only coverage for it (see D10 in
+//! `impl/standalone/changes-by-project.md`). Below 3.17.0, APISIX has no `/validate` endpoint
+//! at all (`apisix_version_supports_validate`) — `failed[]` attribution needs it, so an
+//! all-failed rejection there reports `failed: []` even for an obviously bad resource.
 
 use std::process::Stdio;
 use std::time::Duration;
@@ -30,6 +32,22 @@ const UNREACHABLE: &str = "http://127.0.0.1:1";
 
 fn free_port() -> u16 {
     std::net::TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+}
+
+/// Same pattern as `adc-backend-apisix-standalone`'s own `common::apisix_version` --
+/// falls back to a version high enough to exercise every version-gated path when unset.
+fn apisix_version() -> semver::Version {
+    match std::env::var("BACKEND_APISIX_VERSION") {
+        Ok(v) => semver::Version::parse(&v).unwrap_or_else(|e| panic!("BACKEND_APISIX_VERSION={v:?} is not a valid semver: {e}")),
+        Err(_) => semver::Version::new(999, 999, 999),
+    }
+}
+
+/// APISIX added `/apisix/admin/configs/validate` in 3.17.0 -- below that, `Validator::validate`
+/// gets a 404 (`BackendError::Unsupported`), so an all-failed rejection's `failed[]` can never
+/// be attributed there, no matter how obviously bad the resource actually is.
+fn apisix_version_supports_validate() -> bool {
+    apisix_version() >= semver::Version::new(3, 17, 0)
 }
 
 /// Same cluster, same wipe-and-recheck strategy as
@@ -209,24 +227,29 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     let (status, json) = put_sync(&server, &body).await;
     assert_eq!(status, 422, "{json}");
     assert_eq!(json["status"], "all_failed", "{json}");
-    assert_eq!(json["total_resources"], 1, "{json}");
-    assert_eq!(json["success_count"], 0, "{json}");
-    assert_eq!(json["failed_count"], 1, "{json}");
     assert_eq!(json["success"].as_array().unwrap().len(), 0, "{json}");
 
     // Only the resource the re-validate actually named -- the innocent one swept up in the
     // same rejected document must not appear, or bad-resource exclusion would blacklist it
-    // for something it never did.
+    // for something it never did. Below 3.17.0 there's no `/validate` endpoint to name
+    // anything with at all, so `failed[]` is empty even though the rejection is just as real
+    // (see `endpoint_status` below).
     let failed = json["failed"].as_array().unwrap();
-    assert_eq!(failed.len(), 1, "{json}");
-    let bad = failed.iter().find(|e| e["event"]["resource_name"] == "the-bad-one").expect("the bad resource must be in `failed`");
+    if apisix_version_supports_validate() {
+        assert_eq!(json["total_resources"], 1, "{json}");
+        assert_eq!(json["failed_count"], 1, "{json}");
+        assert_eq!(failed.len(), 1, "{json}");
+        let bad = failed.iter().find(|e| e["event"]["resource_name"] == "the-bad-one").expect("the bad resource must be in `failed`");
+        assert!(bad["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
+    } else {
+        assert_eq!(json["total_resources"], 0, "{json}");
+        assert_eq!(json["failed_count"], 0, "{json}");
+        assert_eq!(failed.len(), 0, "{json}");
+    }
     assert!(
         failed.iter().all(|e| e["event"]["resource_name"] != "innocent-bystander"),
         "an unattributed resource must never appear in failed[]: {json}"
     );
-
-    let bad_reason = bad["reason"].as_str().unwrap();
-    assert!(bad_reason.to_lowercase().contains("limit-count"), "{bad_reason}");
 
     let endpoint_status = json["endpoint_status"].as_array().unwrap();
     assert_eq!(endpoint_status.len(), 3, "{json}");
@@ -265,9 +288,14 @@ async fn an_all_failed_rejection_mixed_with_an_unreachable_server_is_still_422()
     assert_eq!(status, 422, "{json}");
     assert_eq!(json["status"], "all_failed", "{json}");
 
+    // Below 3.17.0 there's no `/validate` endpoint to attribute anything with at all.
     let failed = json["failed"].as_array().unwrap();
-    assert_eq!(failed.len(), 1, "{json}");
-    assert!(failed[0]["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
+    if apisix_version_supports_validate() {
+        assert_eq!(failed.len(), 1, "{json}");
+        assert!(failed[0]["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
+    } else {
+        assert_eq!(failed.len(), 0, "{json}");
+    }
 
     let endpoint_status = json["endpoint_status"].as_array().unwrap();
     assert_eq!(endpoint_status.len(), 3, "{json}");

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -310,6 +310,30 @@ async fn an_all_failed_rejection_mixed_with_an_unreachable_server_is_still_422()
     }
 }
 
+/// Same as above with the unreachable server listed *first* -- `Backend::validate` must not
+/// depend on the first configured server specifically; it should move on and re-validate
+/// against another one instead of losing attribution just because of server order.
+#[tokio::test]
+#[ignore]
+async fn an_all_failed_rejection_is_still_attributed_when_the_first_server_is_unreachable() {
+    restart_apisix().await;
+    let server = spawn_server().await;
+    let config = json!({"consumers": [consumer_with_bad_plugin("the-bad-one")]});
+    let body = sync_body(&[UNREACHABLE, SERVER1, SERVER2], "sync-e2e-mixed-all-failed-reversed", config);
+
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 422, "{json}");
+    assert_eq!(json["status"], "all_failed", "{json}");
+
+    let failed = json["failed"].as_array().unwrap();
+    if apisix_version_supports_validate() {
+        assert_eq!(failed.len(), 1, "{json}");
+        assert!(failed[0]["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
+    } else {
+        assert_eq!(failed.len(), 0, "{json}");
+    }
+}
+
 /// A first sync against real servers caches this cacheKey's baseline; a second sync
 /// against unreachable ones reuses that cache instead of re-probing, so it reaches the
 /// write itself -- which then fails on every server. No content was ever evaluated (the

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -209,23 +209,24 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     let (status, json) = put_sync(&server, &body).await;
     assert_eq!(status, 422, "{json}");
     assert_eq!(json["status"], "all_failed", "{json}");
-    assert_eq!(json["total_resources"], 2, "{json}");
+    assert_eq!(json["total_resources"], 1, "{json}");
     assert_eq!(json["success_count"], 0, "{json}");
-    assert_eq!(json["failed_count"], 2, "{json}");
+    assert_eq!(json["failed_count"], 1, "{json}");
     assert_eq!(json["success"].as_array().unwrap().len(), 0, "{json}");
 
+    // Only the resource the re-validate actually named -- the innocent one swept up in the
+    // same rejected document must not appear, or bad-resource exclusion would blacklist it
+    // for something it never did.
     let failed = json["failed"].as_array().unwrap();
-    assert_eq!(failed.len(), 2, "{json}");
+    assert_eq!(failed.len(), 1, "{json}");
     let bad = failed.iter().find(|e| e["event"]["resource_name"] == "the-bad-one").expect("the bad resource must be in `failed`");
-    let good = failed
-        .iter()
-        .find(|e| e["event"]["resource_name"] == "innocent-bystander")
-        .expect("the whole document was rejected — the innocent resource must be in `failed` too");
+    assert!(
+        failed.iter().all(|e| e["event"]["resource_name"] != "innocent-bystander"),
+        "an unattributed resource must never appear in failed[]: {json}"
+    );
 
     let bad_reason = bad["reason"].as_str().unwrap();
     assert!(bad_reason.to_lowercase().contains("limit-count"), "{bad_reason}");
-    let good_reason = good["reason"].as_str().unwrap();
-    assert!(!good_reason.is_empty(), "{json}");
 
     let endpoint_status = json["endpoint_status"].as_array().unwrap();
     assert_eq!(endpoint_status.len(), 3, "{json}");
@@ -248,6 +249,62 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
     assert_eq!(status, 200, "{json}");
     assert_eq!(json["status"], "success", "{json}");
     assert_eq!(raw_consumers(SERVER1).await.len(), 1, "{json}");
+}
+
+/// A rejecting server and an unreachable one can land in the same response -- all three end
+/// up success:false either way, and it's still all_failed, still 422.
+#[tokio::test]
+#[ignore]
+async fn an_all_failed_rejection_mixed_with_an_unreachable_server_is_still_422() {
+    restart_apisix().await;
+    let server = spawn_server().await;
+    let config = json!({"consumers": [consumer_with_bad_plugin("the-bad-one")]});
+    let body = sync_body(&[SERVER1, SERVER2, UNREACHABLE], "sync-e2e-mixed-all-failed", config);
+
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 422, "{json}");
+    assert_eq!(json["status"], "all_failed", "{json}");
+
+    let failed = json["failed"].as_array().unwrap();
+    assert_eq!(failed.len(), 1, "{json}");
+    assert!(failed[0]["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
+
+    let endpoint_status = json["endpoint_status"].as_array().unwrap();
+    assert_eq!(endpoint_status.len(), 3, "{json}");
+    assert!(endpoint_status.iter().all(|e| e["success"] == false), "{json}");
+    assert!(
+        endpoint_status.iter().any(|e| e["server"] == UNREACHABLE),
+        "the unreachable server must still be reported, not silently dropped: {json}"
+    );
+
+    for target in [SERVER1, SERVER2] {
+        assert!(raw_consumers(target).await.is_empty(), "an all-failed write must leave {target} untouched");
+    }
+}
+
+/// A first sync against real servers caches this cacheKey's baseline; a second sync
+/// against unreachable ones reuses that cache instead of re-probing, so it reaches the
+/// write itself -- which then fails on every server. No content was ever evaluated (the
+/// re-validate can't reach anyone either), so `failed[]` stays empty; still 422, not 500.
+#[tokio::test]
+#[ignore]
+async fn an_all_failed_write_with_nothing_reachable_reports_no_attribution() {
+    restart_apisix().await;
+    let server = spawn_server().await;
+
+    let baseline = sync_body(&[SERVER1, SERVER2, SERVER3], "sync-e2e-unreachable-write", json!({"consumers": [consumer("stable-one")]}));
+    let (status, json) = put_sync(&server, &baseline).await;
+    assert_eq!(status, 200, "{json}");
+
+    let body = sync_body(&[UNREACHABLE, UNREACHABLE, UNREACHABLE], "sync-e2e-unreachable-write", json!({"consumers": [consumer("stable-two")]}));
+    let (status, json) = put_sync(&server, &body).await;
+    assert_eq!(status, 422, "{json}");
+    assert_eq!(json["status"], "all_failed", "{json}");
+    assert_eq!(json["failed"].as_array().unwrap().len(), 0, "{json}");
+
+    let endpoint_status = json["endpoint_status"].as_array().unwrap();
+    assert_eq!(endpoint_status.len(), 3, "{json}");
+    assert!(endpoint_status.iter().all(|e| e["success"] == false), "{json}");
 }
 
 #[tokio::test]
@@ -277,12 +334,12 @@ async fn a_partial_server_failure_still_reports_the_event_as_synced() {
     assert!(failed_entry["reason"].as_str().is_some_and(|r| !r.is_empty()), "{json}");
 }
 
-/// Every configured server unreachable fails before a document is ever
-/// evaluated -- 500, not the 422 a genuine content rejection gets. No real
-/// APISIX cluster is involved at all, so this doesn't call `restart_apisix`.
+/// Fails during the pre-write dump (needs at least one reachable server), not during the
+/// write itself -- a system-level 500, unrelated to the 422 an all-server write failure
+/// gets. No real cluster involved, so no `restart_apisix`.
 #[tokio::test]
 #[ignore]
-async fn every_server_unreachable_returns_500_not_422() {
+async fn every_server_unreachable_before_the_write_is_attempted_returns_500() {
     let server = spawn_server().await;
     let body = sync_body(&[UNREACHABLE, UNREACHABLE, UNREACHABLE], "sync-e2e-unreachable", json!({"consumers": [consumer("sync-unreachable")]}));
 


### PR DESCRIPTION
### Description

`output_for_apisix_standalone`'s `AllFailed` handling had two bugs from the last round: it split 422 vs 500 based on whether a failure was "content rejection" vs "transient", using a wrong mental model (`BackendSyncResult` is per-*server* for standalone, not per-event — a `Transport`/`Api` error on one server says nothing about whether the document's content is actually bad); and `failed[]` fell back to a `shared_reason` pulled from an arbitrary server's raw error text when a resource couldn't be individually attributed, leaking endpoint-level detail into what's supposed to be resource-level, validated attribution.

This PR:
- Makes `AllFailed` always answer `422` (never `500` — that stays reserved for a failure before the write is even attempted, e.g. no server reachable during dump).
- Re-validates *every resource this cacheKey holds*, not just this sync's own diff, so a resource untouched by the diff can still be attributed if it's the one actually rejected.
- `failed[]` now only ever contains resources the re-validate specifically named. An innocent resource swept into the same all-server rejection — whether or not it was in this sync's own diff — is left out entirely, never given a guessed-at reason. Bad-resource exclusion (a future consumer of `failed[]`) depends on this: an unattributed entry there would get a resource wrongly blacklisted for something it never did. `endpoint_status[]` already carries each server's own raw error, so no information is lost.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APISIX standalone synchronization error reporting for multi-resource writes.
  * Failed responses now identify only resources confirmed as invalid.
  * Validation can succeed through any available configured server.
  * All-server write failures consistently return `422 Unprocessable Entity`.
  * Unsupported APISIX versions now produce a warning with an empty `failed` list.
  * Requests blocked because all endpoints are unreachable continue to return an appropriate server error.
  * Mixed endpoint failures provide clearer validation results and resource attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->