### PR TITLE
fix(apisix): rust lost upstream update after upgrade gateway

### DIFF
--- a/rust/crates/adc-backend-apisix/src/operator.rs
+++ b/rust/crates/adc-backend-apisix/src/operator.rs
@@ -711,8 +711,8 @@ mod tests {
     }
 
     /// A service update that both changes another field *and* removes its
-    /// upstream still orders the upstream DELETE *before* the service
-    /// request that detaches it.
+    /// upstream still puts the service request that detaches `upstream_id`
+    /// *before* the upstream DELETE.
     #[test]
     fn service_update_changing_another_field_and_removing_its_upstream_still_detaches_before_deleting()
      {

--- a/rust/crates/adc-backend-apisix/src/operator.rs
+++ b/rust/crates/adc-backend-apisix/src/operator.rs
@@ -10,9 +10,14 @@
 //!   own request references it by `upstream_id`, which APISIX validates
 //!   exists), losing/deleting one removes the service (or the service's own
 //!   update, which clears `upstream_id`) first — nothing should reference
-//!   the upstream by the time it's removed. An update where only the
-//!   upstream's *content* changed (not whether it exists at all) skips the
-//!   service request entirely, since `upstream_id` doesn't change either.
+//!   the upstream by the time it's removed. An update whose new value still
+//!   has an upstream always (re)writes the upstream sub-resource, even when
+//!   the diff shows no change to it: remote data written before adc split
+//!   upstreams out of services can still have the upstream inlined rather
+//!   than stored as this separate resource, and the diff alone can't tell
+//!   inline apart from already-split, so only an unconditional write
+//!   reliably converts it. The service's own request is likewise never
+//!   skipped on an update.
 //! - Requests within one event are applied *sequentially* (a service's
 //!   upstream write must complete before its own write starts); events are
 //!   grouped by `(resource_type, event_type)` and applied *sequentially
@@ -393,42 +398,27 @@ fn build_requests(event: &Event, version: &Version) -> Result<Vec<BuiltRequest>,
                         .into(),
                     )
                 })?;
-                let touches_non_upstream = diff.iter().any(|d| !diff_path_is_upstream(d));
                 let touches_upstream = diff.iter().any(diff_path_is_upstream);
-                // A diff entry at exactly `["upstream"]` (not deeper) is a
-                // New/Deleted for the field itself — the upstream's
-                // *presence* changed, which changes the service's own wire
-                // body too (`transform_service` sets `upstream_id` iff
-                // `service.upstream.is_some()`). Skipping the service
-                // request is only safe when presence is unchanged and only
-                // the upstream's content differs further down the tree.
-                let upstream_presence_changed = diff.iter().any(|d| {
-                    matches!(d, ValueDiff::New { path, .. } | ValueDiff::Deleted { path, .. }
-                        if path.as_slice() == [PathSegment::Key("upstream".to_string())])
-                });
-                if !touches_non_upstream && !upstream_presence_changed {
-                    paths.pop();
-                }
-                if touches_upstream {
-                    if service_has_upstream(event) {
-                        // Still has an upstream: create/update it before the
-                        // service request (re)points `upstream_id` at it —
-                        // APISIX rejects a service pointing at a
-                        // nonexistent upstream.
-                        paths.insert(0, (upstream_path, RequestKind::Upstream, Method::PUT));
-                    } else {
-                        // Lost it entirely: the service request above (kept
-                        // in `paths` since presence changed) must detach the
-                        // `upstream_id` reference *before* the upstream is
-                        // deleted, or APISIX rejects the DELETE with "still
-                        // using it" — `operate` already tolerates a 404 here
-                        // for the "never had one" case, but a rejected
-                        // DELETE would just retry against the same
-                        // still-referencing service and exhaust its
-                        // retries, since nothing else in this event would
-                        // ever run that service request afterward.
-                        paths.push((upstream_path, RequestKind::Upstream, Method::DELETE));
-                    }
+                if service_has_upstream(event) {
+                    // Always create/update it before the service request
+                    // (re)points `upstream_id` at it, regardless of whether
+                    // the diff shows its content changed — APISIX rejects a
+                    // service pointing at a nonexistent upstream, and remote
+                    // data can have the upstream inlined into the service
+                    // rather than already split into this resource, which
+                    // the diff has no way to distinguish from "unchanged".
+                    paths.insert(0, (upstream_path, RequestKind::Upstream, Method::PUT));
+                } else if touches_upstream {
+                    // Lost it entirely: the service request must detach the
+                    // `upstream_id` reference *before* the upstream is
+                    // deleted, or APISIX rejects the DELETE with "still
+                    // using it" — `operate` already tolerates a 404 here
+                    // for the "never had one" case, but a rejected
+                    // DELETE would just retry against the same
+                    // still-referencing service and exhaust its
+                    // retries, since nothing else in this event would
+                    // ever run that service request afterward.
+                    paths.push((upstream_path, RequestKind::Upstream, Method::DELETE));
                 }
             }
         }
@@ -674,13 +664,11 @@ mod tests {
         );
     }
 
-    /// Regression: losing the upstream's *presence* (not just its content)
-    /// changes the service's own wire body too (`upstream_id` gets
-    /// cleared), so — unlike a pure content-only upstream update — the
-    /// service request can't be skipped here. It must also come *before*
-    /// the upstream DELETE: APISIX rejects deleting an upstream a service
-    /// still references, and nothing later in this same event would ever
-    /// run the service request to fix that up.
+    /// Losing the upstream clears `upstream_id` in the service's own wire
+    /// body, and that request must come *before* the upstream DELETE:
+    /// APISIX rejects deleting an upstream a service still references, and
+    /// nothing later in this same event would ever run the service request
+    /// to fix that up.
     #[test]
     fn service_update_removing_its_upstream_detaches_the_reference_before_deleting_it() {
         let old_value = json!({ "name": "svc1", "upstream": { "nodes": [] } });
@@ -723,10 +711,8 @@ mod tests {
     }
 
     /// A service update that both changes another field *and* removes its
-    /// upstream — the finding this guards against had this "mixed" case
-    /// working by accident (the service request was never popped, since
-    /// `touches_non_upstream` was already true), but still ordered the
-    /// upstream DELETE *before* the service request that detaches it.
+    /// upstream still orders the upstream DELETE *before* the service
+    /// request that detaches it.
     #[test]
     fn service_update_changing_another_field_and_removing_its_upstream_still_detaches_before_deleting()
      {
@@ -809,6 +795,96 @@ mod tests {
         assert_eq!(*method, Method::PUT);
         assert_eq!(body.as_ref().unwrap()["upstream_id"], "svc1");
         assert!(path.ends_with("/services/svc1"), "{path}");
+    }
+
+    /// Regression: an upstream-content-only change (its presence is
+    /// unchanged, only e.g. a node's IP differs) must still rewrite the
+    /// upstream sub-resource *and* the service. Remote data written before
+    /// adc split upstreams out of services can have the upstream inlined
+    /// rather than already split into this separate resource — a diff that
+    /// only shows the content changing looks identical either way, so the
+    /// service request can't be skipped on the assumption that
+    /// `upstream_id` already points at an existing object.
+    #[test]
+    fn service_update_with_only_upstream_content_changed_still_rewrites_both() {
+        let old_value =
+            json!({ "name": "svc1", "upstream": { "nodes": [{"host":"1.1.1.1","port":80,"weight":1}] } });
+        let new_value =
+            json!({ "name": "svc1", "upstream": { "nodes": [{"host":"2.2.2.2","port":80,"weight":1}] } });
+        let diff = vec![ValueDiff::Edit {
+            path: vec![
+                PathSegment::Key("upstream".to_string()),
+                PathSegment::Key("nodes".to_string()),
+            ],
+            lhs: old_value["upstream"]["nodes"].clone(),
+            rhs: new_value["upstream"]["nodes"].clone(),
+        }];
+        let service_event = Event::new(
+            ResourceType::Service,
+            EventKind::Update {
+                old_value,
+                new_value,
+                diff: Some(diff),
+            },
+            "svc1",
+            "svc1",
+        );
+
+        let requests = build_requests(&service_event, &Version::new(3, 17, 0)).unwrap();
+        assert_eq!(requests.len(), 2);
+
+        let (method, path, _, kind) = &requests[0];
+        assert!(
+            matches!(kind, RequestKind::Upstream),
+            "upstream PUT must come first"
+        );
+        assert_eq!(*method, Method::PUT);
+        assert!(path.ends_with("/upstreams/svc1"), "{path}");
+
+        let (method, path, body, kind) = &requests[1];
+        assert!(matches!(kind, RequestKind::Main), "service request too");
+        assert_eq!(*method, Method::PUT);
+        assert_eq!(body.as_ref().unwrap()["upstream_id"], "svc1");
+        assert!(path.ends_with("/services/svc1"), "{path}");
+    }
+
+    /// Regression: a service update that doesn't touch `upstream` in the
+    /// diff at all (only some unrelated field changed) must still write the
+    /// upstream sub-resource when the service has one, for the same reason
+    /// as above — the diff can't tell an already-split upstream apart from
+    /// one that's still inlined in old remote data, so writing it can't be
+    /// conditioned on the diff mentioning it.
+    #[test]
+    fn service_update_touching_only_another_field_still_writes_its_existing_upstream() {
+        let old_value = json!({ "name": "svc1", "description": "old", "upstream": { "nodes": [{"host":"1.1.1.1","port":80,"weight":1}] } });
+        let new_value = json!({ "name": "svc1", "description": "new", "upstream": { "nodes": [{"host":"1.1.1.1","port":80,"weight":1}] } });
+        let diff = vec![ValueDiff::Edit {
+            path: vec![PathSegment::Key("description".to_string())],
+            lhs: json!("old"),
+            rhs: json!("new"),
+        }];
+        let service_event = Event::new(
+            ResourceType::Service,
+            EventKind::Update {
+                old_value,
+                new_value,
+                diff: Some(diff),
+            },
+            "svc1",
+            "svc1",
+        );
+
+        let requests = build_requests(&service_event, &Version::new(3, 17, 0)).unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            matches!(requests[0].3, RequestKind::Upstream),
+            "upstream PUT must come first"
+        );
+        assert_eq!(requests[0].0, Method::PUT);
+        assert!(
+            matches!(requests[1].3, RequestKind::Main),
+            "service request too"
+        );
     }
 
     #[test]

--- a/rust/crates/adc-backend-apisix/tests/e2e_operator.rs
+++ b/rust/crates/adc-backend-apisix/tests/e2e_operator.rs
@@ -55,6 +55,31 @@ async fn update_time(path: &str) -> Option<i64> {
     body["value"]["update_time"].as_i64()
 }
 
+/// The resource's own body (the `value` envelope's contents), or `None` if
+/// it doesn't currently exist. Same panic-vs-`None` split as `update_time`.
+async fn get_value(path: &str) -> Option<Value> {
+    let client = client();
+    let request = client.request(Method::GET, path).expect("building the get_value request should never fail for a well-formed path");
+    let response = client.execute(request).await.expect("transport failure while reading a resource");
+    if !response.status().is_success() {
+        return None;
+    }
+    let body: Value = response.json().await.ok()?;
+    Some(body["value"].clone())
+}
+
+/// PUTs a body straight to the admin API, bypassing the operator (and
+/// therefore `transform_service`) entirely — used to seed a service the way
+/// an APISIX instance predating adc's upstream/service split would have it:
+/// the upstream inlined into the service's own body, with no separate
+/// `/upstreams/{id}` resource at all.
+async fn put_raw(path: &str, body: Value) {
+    let client = client();
+    let request = client.request(Method::PUT, path).expect("building the put_raw request should never fail for a well-formed path").json(&body);
+    let response = client.execute(request).await.expect("transport failure while seeding legacy state");
+    assert!(response.status().is_success(), "seeding legacy state at {path} failed: {}", response.status());
+}
+
 fn create(rt: ResourceType, id: &str, new_value: Value) -> Event {
     Event::new(rt, EventKind::Create { new_value }, id, id)
 }
@@ -111,6 +136,89 @@ async fn update_touching_only_upstream_still_rewrites_the_service_record() {
 
     let after = update_time(&service_path).await.unwrap();
     assert!(after > before, "the service record must still be re-written even when only its upstream changed, to convert a remote inline upstream to the split form");
+
+    sync_ok(&backend, vec![delete(ResourceType::Service, service_id)]).await;
+}
+
+/// The actual bug this whole file exists to guard against: a service left
+/// over from before adc split upstreams out of services still has its
+/// upstream inlined, with no `/upstreams/{id}` resource at all. An update
+/// that only touches the upstream's content must still split it out —
+/// `update_touching_only_upstream_still_rewrites_the_service_record` above
+/// only proves a PUT happens, not that it actually produces the split form.
+#[tokio::test]
+#[ignore]
+async fn update_touching_only_upstream_migrates_a_legacy_inline_upstream_to_the_split_form() {
+    let service_id = "e2e-op-svc-legacy1";
+    let service_path = format!("/apisix/admin/services/{service_id}");
+    let upstream_path = format!("/apisix/admin/upstreams/{service_id}");
+
+    put_raw(
+        &service_path,
+        json!({ "name": service_id, "upstream": { "nodes": [{ "host": "1.1.1.1", "port": 80, "weight": 1 }] } }),
+    )
+    .await;
+    assert!(get_value(&upstream_path).await.is_none(), "test setup: no separate upstream resource should exist yet");
+
+    let backend = backend();
+    let event = Event::new(
+        ResourceType::Service,
+        EventKind::Update {
+            old_value: json!({ "name": service_id, "upstream": { "nodes": [{ "host": "1.1.1.1", "port": 80, "weight": 1 }] } }),
+            new_value: json!({ "name": service_id, "upstream": { "nodes": [{ "host": "2.2.2.2", "port": 80, "weight": 1 }] } }),
+            diff: Some(vec![upstream_diff()]),
+        },
+        service_id,
+        service_id,
+    );
+    sync_ok(&backend, vec![event]).await;
+
+    let service = get_value(&service_path).await.expect("service should still exist");
+    assert_eq!(service["upstream_id"], service_id, "service must now reference the split-out upstream by id");
+    assert!(service["upstream"].is_null(), "the upstream must no longer be inlined into the service");
+    let upstream = get_value(&upstream_path).await.expect("the legacy inline upstream must have been split into its own resource");
+    assert_eq!(upstream["nodes"][0]["host"], "2.2.2.2", "the split-out upstream must carry the updated content");
+
+    sync_ok(&backend, vec![delete(ResourceType::Service, service_id)]).await;
+}
+
+/// The mirror case: the diff doesn't mention `upstream` at all (only an
+/// unrelated field changed), yet a legacy inlined upstream must still be
+/// split out — the diff can't tell "already split" apart from "still
+/// inline", so writing the upstream can't be conditioned on the diff
+/// mentioning it.
+#[tokio::test]
+#[ignore]
+async fn update_touching_only_another_field_migrates_a_legacy_inline_upstream_to_the_split_form() {
+    let service_id = "e2e-op-svc-legacy2";
+    let service_path = format!("/apisix/admin/services/{service_id}");
+    let upstream_path = format!("/apisix/admin/upstreams/{service_id}");
+
+    put_raw(
+        &service_path,
+        json!({ "name": service_id, "upstream": { "nodes": [{ "host": "1.1.1.1", "port": 80, "weight": 1 }] } }),
+    )
+    .await;
+    assert!(get_value(&upstream_path).await.is_none(), "test setup: no separate upstream resource should exist yet");
+
+    let backend = backend();
+    let event = Event::new(
+        ResourceType::Service,
+        EventKind::Update {
+            old_value: json!({ "name": service_id, "upstream": { "nodes": [{ "host": "1.1.1.1", "port": 80, "weight": 1 }] } }),
+            new_value: json!({ "name": service_id, "upstream": { "nodes": [{ "host": "1.1.1.1", "port": 80, "weight": 1 }] }, "plugins": { "key-auth": {} } }),
+            diff: Some(vec![plugins_diff()]),
+        },
+        service_id,
+        service_id,
+    );
+    sync_ok(&backend, vec![event]).await;
+
+    let service = get_value(&service_path).await.expect("service should still exist");
+    assert_eq!(service["upstream_id"], service_id, "service must now reference the split-out upstream by id");
+    assert!(service["upstream"].is_null(), "the upstream must no longer be inlined into the service");
+    let upstream = get_value(&upstream_path).await.expect("the legacy inline upstream must have been split into its own resource, even though the diff never mentioned it");
+    assert_eq!(upstream["nodes"][0]["host"], "1.1.1.1", "the split-out upstream must carry the (unchanged) node content");
 
     sync_ok(&backend, vec![delete(ResourceType::Service, service_id)]).await;
 }

--- a/rust/crates/adc-backend-apisix/tests/e2e_operator.rs
+++ b/rust/crates/adc-backend-apisix/tests/e2e_operator.rs
@@ -81,7 +81,7 @@ async fn sync_ok(backend: &ApisixBackend, events: Vec<Event>) {
 
 #[tokio::test]
 #[ignore]
-async fn update_touching_only_upstream_does_not_rewrite_the_service_record() {
+async fn update_touching_only_upstream_still_rewrites_the_service_record() {
     let backend = backend();
     let service_id = "e2e-op-svc1";
     sync_ok(
@@ -110,7 +110,7 @@ async fn update_touching_only_upstream_does_not_rewrite_the_service_record() {
     sync_ok(&backend, vec![event]).await;
 
     let after = update_time(&service_path).await.unwrap();
-    assert_eq!(before, after, "the service record itself must not be re-written when only its upstream changed");
+    assert!(after > before, "the service record must still be re-written even when only its upstream changed, to convert a remote inline upstream to the split form");
 
     sync_ok(&backend, vec![delete(ResourceType::Service, service_id)]).await;
 }
@@ -157,7 +157,7 @@ async fn update_touching_both_writes_both_records() {
 
 #[tokio::test]
 #[ignore]
-async fn update_not_touching_upstream_does_not_rewrite_the_upstream_record() {
+async fn update_not_touching_upstream_still_rewrites_the_upstream_record() {
     let backend = backend();
     let service_id = "e2e-op-svc3";
     sync_ok(
@@ -186,7 +186,7 @@ async fn update_not_touching_upstream_does_not_rewrite_the_upstream_record() {
     sync_ok(&backend, vec![event]).await;
 
     let after = update_time(&upstream_path).await.unwrap();
-    assert_eq!(before, after, "the upstream record must not be re-written when only non-upstream fields changed");
+    assert!(after > before, "the upstream record must still be re-written even when the diff doesn't mention it, since the diff can't tell an already-split upstream from a remote inline one");
 
     sync_ok(&backend, vec![delete(ResourceType::Service, service_id)]).await;
 }


### PR DESCRIPTION
### Description

The apisix backend's operator skipped a service's own admin-API request whenever an update's diff showed only the default upstream's content changing, and only wrote the upstream sub-resource when the diff itself mentioned upstream. Both shortcuts assumed the diff can tell an already-split upstream (a separate /upstreams/{id} resource) apart from one still inlined into the service — remote data written before adc split upstreams out of services can be inlined, and the diff looks the same either way. As a result, migrating such data either silently wrote a new, unreferenced upstream object while the service kept serving its old inline config, or rewrote the service with an upstream_id pointing at an upstream that was never created, which apisix rejected with a 400.

This PR drops both shortcuts: a service update now always resends the service's own request, and always (re)writes the upstream sub-resource whenever the service's new value has one, regardless of what the diff says changed. This costs one extra /upstreams/{id} PUT per sync for services that already have an up-to-date, already-split upstream, in exchange for migrating inlined upstreams to the split form on every sync instead of silently failing.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Service updates now consistently apply changes to associated upstream resources.
  - Service requests are reliably sent when updating services with existing upstreams.
  - Removing an upstream now safely detaches it from the service before deletion.
  - Improved handling of updates affecting upstream content or unrelated service fields.
  - Legacy inline upstream configurations are now migrated to separate upstream resources during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->