### PR TITLE
fix(server): snake-case regression for response JSON key

### DIFF
--- a/apps/cli/src/server/sync.spec.ts
+++ b/apps/cli/src/server/sync.spec.ts
@@ -1,0 +1,110 @@
+import * as ADCSDK from '@api7/adc-sdk';
+
+import {
+  generateOutput,
+  generateOutputForAPISIXStandalone,
+  simplifyEvent,
+} from './sync';
+
+// resourceType/resourceId/resourceName/parentId: ADCSDK.Event's own field names
+// (libs/sdk/src/core/differ.ts), the wire format every /sync consumer (AIC included)
+// parses. TypeScript's structural typing means a stray snake_case field here would
+// only be caught by a runtime check like this, not the type system alone, since these
+// tests build plain object literals the same way real events are shaped on the wire.
+// Cast rather than fully typed: these only exercise the envelope's own keys, the
+// resource bodies under oldValue/newValue don't need to satisfy any specific
+// resource type's shape.
+const route = {
+  type: ADCSDK.EventType.UPDATE,
+  resourceId: 'r1',
+  resourceName: 'test-route',
+  resourceType: ADCSDK.ResourceType.ROUTE,
+  oldValue: { id: 'r1' },
+  newValue: { id: 'r1', uri: '/foo' },
+  parentId: 'svc1',
+} as unknown as ADCSDK.Event;
+
+const service = {
+  type: ADCSDK.EventType.CREATE,
+  resourceId: 'svc1',
+  resourceName: 'test-service',
+  resourceType: ADCSDK.ResourceType.SERVICE,
+  newValue: {},
+} as unknown as ADCSDK.Event;
+
+const syncResult = (
+  event: ADCSDK.Event,
+  overrides: Partial<ADCSDK.BackendSyncResult> = {},
+): ADCSDK.BackendSyncResult => ({
+  success: true,
+  event,
+  ...overrides,
+});
+
+describe('simplifyEvent', () => {
+  it('keeps the camelCase envelope and strips oldValue/newValue/diff/subEvents', () => {
+    const simplified = simplifyEvent(route);
+
+    expect(simplified).toStrictEqual({
+      type: ADCSDK.EventType.UPDATE,
+      resourceId: 'r1',
+      resourceName: 'test-route',
+      resourceType: ADCSDK.ResourceType.ROUTE,
+      parentId: 'svc1',
+    });
+    for (const key of ['resource_type', 'resource_id', 'resource_name', 'parent_id']) {
+      expect(simplified).not.toHaveProperty(key);
+    }
+    for (const key of ['oldValue', 'newValue', 'diff', 'subEvents']) {
+      expect(simplified).not.toHaveProperty(key);
+    }
+  });
+
+  it('omits parentId rather than nulling it when the event has none', () => {
+    const simplified = simplifyEvent(service);
+    expect(simplified).not.toHaveProperty('parentId');
+    expect(simplified.type).toBe(ADCSDK.EventType.CREATE);
+  });
+});
+
+describe('generateOutput', () => {
+  it('embeds the camelCase event envelope in both success and failed entries', () => {
+    const success = syncResult(service);
+    const failed = syncResult(route, {
+      success: false,
+      error: new Error('bad config'),
+    });
+
+    const output = generateOutput([[success, failed], [success], [failed]]);
+
+    expect(output.success[0].event).toMatchObject({
+      resourceType: ADCSDK.ResourceType.SERVICE,
+      resourceId: 'svc1',
+    });
+    expect(output.failed[0].event).toMatchObject({
+      resourceType: ADCSDK.ResourceType.ROUTE,
+      resourceId: 'r1',
+    });
+    for (const event of [output.success[0].event, output.failed[0].event]) {
+      expect(event).not.toHaveProperty('resource_type');
+      expect(event).not.toHaveProperty('resource_id');
+    }
+  });
+});
+
+describe('generateOutputForAPISIXStandalone', () => {
+  it('embeds the camelCase event envelope in its success entries', () => {
+    const result = syncResult(service);
+    const output = generateOutputForAPISIXStandalone(
+      [service],
+      [[result], [result], []],
+    );
+
+    expect(output.success[0].event).toMatchObject({
+      resourceType: ADCSDK.ResourceType.SERVICE,
+      resourceId: 'svc1',
+    });
+    expect(output.success[0].event).not.toHaveProperty('resource_type');
+    expect(output.success[0].event).not.toHaveProperty('resource_id');
+  });
+});

--- a/apps/cli/src/server/sync.ts
+++ b/apps/cli/src/server/sync.ts
@@ -151,7 +151,9 @@ export const syncHandler: RequestHandler<
   }
 };
 
-const simplifyEvent = (event: ADCSDK.Event) =>
+export const simplifyEvent = (
+  event: ADCSDK.Event,
+): Omit<ADCSDK.Event, 'diff' | 'oldValue' | 'newValue' | 'subEvents'> =>
   omit(event, ['diff', 'oldValue', 'newValue', 'subEvents']);
 
 const formatAxiosResponse = (axiosResponse: AxiosResponse) => ({
@@ -170,7 +172,7 @@ const formatAxiosResponse = (axiosResponse: AxiosResponse) => ({
   },
 });
 
-const generateOutput = ([results, successes, faileds]: [
+export const generateOutput = ([results, successes, faileds]: [
   Array<ADCSDK.BackendSyncResult>,
   Array<ADCSDK.BackendSyncResult>,
   Array<ADCSDK.BackendSyncResult>,
@@ -218,7 +220,7 @@ const generateOutput = ([results, successes, faileds]: [
  * @param results
  * @returns
  */
-const generateOutputForAPISIXStandalone = (
+export const generateOutputForAPISIXStandalone = (
   events: Array<ADCSDK.Event>,
   [results, successes, faileds]: [
     Array<ADCSDK.BackendSyncResult>,

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "typescript-eslint": "^8.61.0",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000"
+  "packageManager": "pnpm@12.3.1+sha512.3c14c15408d1489d350f8ed7f93361d26cc707054f6849a4eea3bb7407ff4fe4564b413a1c421a773a176ab1168a8df1c7d548f2cd0dc7d344f58c4e680a5b18"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.1
+        version: 12.3.1
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.1':
+    resolution: {integrity: sha512-Yer+aZnQtgE+OOLKwbRHaAEt74WBJdH8eXpLrSWf+5vj7DkkDvhSR45HVxN3a5d430fMUyF0lmQai02T650r4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.1':
+    resolution: {integrity: sha512-XPZYf+XpxufwZS8tpQQdftsv6eUtPDA0uU5NlfXA1uMVPvXJesw5PLGWmmJZHcI4rIscn2H6FngkIcvkuZaaKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.1':
+    resolution: {integrity: sha512-WjKcLeuierWGSQHjb0QeDl8avQTel8rN5jDMCI55tBJTrTBXNQsdlpgzP9uCD0GSzjPH+hjWKb+GjeMNvv5Ruw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.1':
+    resolution: {integrity: sha512-X0HxHlEYubFRuMPBOy+ytKsv6c11v4em/ovVVCy5KCdJVBtVGF7vF5ywlGqw7EjpGdqM39pdLTWFwH9Q77lUzQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.1':
+    resolution: {integrity: sha512-ZvzQI2+Ek0v+V6m30XV3ShIx5sm+ZIZoM669Z0F/RvMSpHgklqv3CBdEwAsQCZ7XBNZLMQIE7RPR2yIwxt3mnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.1':
+    resolution: {integrity: sha512-ubvbQ2OSt7fR3kSnhtknx5xnm2H7uRi0kC32ADmzKJ1vZz337kmL30rTHoUzTG7ZcIyEhODg7R+zI1cW1ZdVDw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.1':
+    resolution: {integrity: sha512-e+5CjFBGWP7U7RfFlH/EQnlFaP9Uyo/Y0BDCEbitsC4if28WBur3ajAkc25rRwiEwmmEpipTSzqNsKIs9Mq72Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.1':
+    resolution: {integrity: sha512-5pW8NQuVF3dkNdaUCm03PeoDiC5I9h4y9Fz717KLWi5jxDKmgARmD1zDdm60F5ohRZHPrRv/jAg94a/5+VXxow==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.1:
+    resolution: {integrity: sha512-PBTBVAjRSJ01D47X+TNh0mzHBwVPaEmk7qO7dAf/T+RWS0E6HEIadzoXarEWio3xx9VI8s0Nx9NE9YxOaApbGA==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.1':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.1':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.1':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.1':
+    optional: true
+
+  pnpm@12.3.1:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.1
+      '@pnpm/exe.darwin-x64': 12.3.1
+      '@pnpm/exe.linux-arm64': 12.3.1
+      '@pnpm/exe.linux-arm64-musl': 12.3.1
+      '@pnpm/exe.linux-x64': 12.3.1
+      '@pnpm/exe.linux-x64-musl': 12.3.1
+      '@pnpm/exe.win32-arm64': 12.3.1
+      '@pnpm/exe.win32-x64': 12.3.1
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/rust/crates/adc-backend-api7/tests/common/mod.rs
+++ b/rust/crates/adc-backend-api7/tests/common/mod.rs
@@ -492,9 +492,9 @@ fn resource_type_from_fixture_str(value: &str) -> ResourceType {
 
 /// Loads a `testdata/*.json` fixture — a plain JSON array of events in the
 /// TS suite's own camelCase field names (`resourceType`/`resourceId`/...),
-/// not `Event`'s own (deliberately snake_case, `Serialize`-only) wire
-/// shape — so this reads the raw JSON structurally instead of deriving
-/// `Deserialize` on `Event` just for this one fixture-loading path.
+/// which is also `Event`'s own wire shape (`Serialize`-only, no `Deserialize`
+/// impl exists) — so this reads the raw JSON structurally instead of adding
+/// one just for this fixture-loading path.
 pub fn load_events_fixture(name: &str) -> Vec<Event> {
     let raw: Value = serde_json::from_str(&read_asset(&format!("testdata/{name}")))
         .unwrap_or_else(|e| panic!("parsing fixture {name}: {e}"));

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -422,8 +422,9 @@ mod tests {
         assert_eq!(failed_event["resourceType"], json!("route"));
         assert_eq!(failed_event["resourceId"], json!("r1"));
         for event in [success_event, failed_event] {
-            assert!(event["resource_type"].is_null(), "{body}");
-            assert!(event["resource_id"].is_null(), "{body}");
+            let object = event.as_object().unwrap();
+            assert!(!object.contains_key("resource_type"), "{body}");
+            assert!(!object.contains_key("resource_id"), "{body}");
         }
     }
 

--- a/rust/crates/adc-cli/src/server/sync.rs
+++ b/rust/crates/adc-cli/src/server/sync.rs
@@ -321,8 +321,8 @@ fn simplify_event(event: &Event) -> Value {
         Err(error) => return json!({"error": format!("failed to serialize event: {error}")}),
     };
     if let Value::Object(map) = &mut value {
-        map.remove("old_value");
-        map.remove("new_value");
+        map.remove("oldValue");
+        map.remove("newValue");
         map.remove("diff");
     }
     value
@@ -337,10 +337,94 @@ fn lint_issue_json(issue: &adc_sdk::lint::LintIssue) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use adc_sdk::EventKind;
+
     use super::*;
 
     fn result(success: bool, confirmed: Option<bool>) -> BackendSyncResult {
         BackendSyncResult { success, event: None, error: None, server: Some("s1".to_string()), confirmed }
+    }
+
+    /// `resourceType`/`resourceId`/`resourceName`/`parentId`: the TS `Event`'s own field
+    /// names (`libs/sdk/src/core/differ.ts`), the wire format every `/sync` consumer (AIC
+    /// included) expects. `Event`/`EventKind` carry `#[serde(rename_all = ...)]` for this;
+    /// asserting on the actual serialized keys here, rather than just trusting the
+    /// attribute is still there, is what catches it if that attribute is ever lost.
+    #[test]
+    fn simplify_event_serializes_the_envelope_in_camel_case() {
+        let mut event = Event::new(
+            ResourceType::Route,
+            EventKind::Update { old_value: json!({"id": "r1"}), new_value: json!({"id": "r1", "uri": "/foo"}), diff: None },
+            "r1",
+            "test-route",
+        );
+        event.parent_id = Some("svc1".to_string());
+
+        let value = simplify_event(&event);
+        let object = value.as_object().expect("event serializes to an object");
+
+        for key in ["resourceType", "type", "resourceId", "resourceName", "parentId"] {
+            assert!(object.contains_key(key), "missing {key:?} in {value}");
+        }
+        for key in ["resource_type", "resource_id", "resource_name", "parent_id"] {
+            assert!(!object.contains_key(key), "unexpected snake_case key {key:?} in {value}");
+        }
+        assert_eq!(object["resourceType"], json!("route"));
+        assert_eq!(object["type"], json!("update"));
+        assert_eq!(object["resourceId"], json!("r1"));
+        assert_eq!(object["resourceName"], json!("test-route"));
+        assert_eq!(object["parentId"], json!("svc1"));
+
+        // old_value/new_value are stripped by simplify_event, under either casing.
+        for key in ["oldValue", "newValue", "old_value", "new_value"] {
+            assert!(!object.contains_key(key), "unexpected {key:?} in {value}");
+        }
+    }
+
+    /// A `Create` event has no `parentId` at all, and its casing shouldn't depend on
+    /// which `EventKind` variant produced it.
+    #[test]
+    fn simplify_event_omits_parent_id_rather_than_nulling_it_when_absent() {
+        let event = Event::new(ResourceType::Service, EventKind::Create { new_value: json!({}) }, "svc1", "test-service");
+
+        let value = simplify_event(&event);
+        let object = value.as_object().unwrap();
+        assert!(!object.contains_key("parentId"), "{value}");
+        assert!(!object.contains_key("parent_id"), "{value}");
+        assert_eq!(object["type"], json!("create"));
+    }
+
+    /// The full `/sync` response body embeds the same camelCase envelope in both
+    /// `success[]` and `failed[]` entries: this is the actual shape a caller like AIC
+    /// parses `event.resourceType`/`event.resourceId` out of.
+    #[test]
+    fn output_embeds_the_camel_case_event_envelope_in_success_and_failed_entries() {
+        let success_event = Event::new(ResourceType::Service, EventKind::Create { new_value: json!({}) }, "svc1", "test-service");
+        let failed_event = Event::new(ResourceType::Route, EventKind::Create { new_value: json!({}) }, "r1", "test-route");
+
+        let results = vec![
+            BackendSyncResult { success: true, event: Some(success_event), error: None, server: Some("s1".into()), confirmed: Some(true) },
+            BackendSyncResult {
+                success: false,
+                event: Some(failed_event),
+                error: Some(BackendError::Api { status: 400, message: "bad config".into() }),
+                server: Some("s1".into()),
+                confirmed: None,
+            },
+        ];
+
+        let body = output(&results);
+        let success_event = &body["success"][0]["event"];
+        let failed_event = &body["failed"][0]["event"];
+
+        assert_eq!(success_event["resourceType"], json!("service"));
+        assert_eq!(success_event["resourceId"], json!("svc1"));
+        assert_eq!(failed_event["resourceType"], json!("route"));
+        assert_eq!(failed_event["resourceId"], json!("r1"));
+        for event in [success_event, failed_event] {
+            assert!(event["resource_type"].is_null(), "{body}");
+            assert!(event["resource_id"].is_null(), "{body}");
+        }
     }
 
     #[test]

--- a/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
+++ b/rust/crates/adc-cli/tests/e2e_server_sync_apisix_standalone.rs
@@ -239,7 +239,7 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
         assert_eq!(json["total_resources"], 1, "{json}");
         assert_eq!(json["failed_count"], 1, "{json}");
         assert_eq!(failed.len(), 1, "{json}");
-        let bad = failed.iter().find(|e| e["event"]["resource_name"] == "the-bad-one").expect("the bad resource must be in `failed`");
+        let bad = failed.iter().find(|e| e["event"]["resourceName"] == "the-bad-one").expect("the bad resource must be in `failed`");
         assert!(bad["reason"].as_str().unwrap().to_lowercase().contains("limit-count"), "{json}");
     } else {
         assert_eq!(json["total_resources"], 0, "{json}");
@@ -247,7 +247,7 @@ async fn an_all_server_rejection_reports_structured_per_resource_failures() {
         assert_eq!(failed.len(), 0, "{json}");
     }
     assert!(
-        failed.iter().all(|e| e["event"]["resource_name"] != "innocent-bystander"),
+        failed.iter().all(|e| e["event"]["resourceName"] != "innocent-bystander"),
         "an unattributed resource must never appear in failed[]: {json}"
     );
 

--- a/rust/crates/adc-sdk/src/backend/error.rs
+++ b/rust/crates/adc-sdk/src/backend/error.rs
@@ -61,13 +61,19 @@ mod tests {
 
     #[test]
     fn a_5xx_api_error_is_retriable() {
-        let err = BackendError::Api { status: 502, message: "bad gateway".into() };
+        let err = BackendError::Api {
+            status: 502,
+            message: "bad gateway".into(),
+        };
         assert!(err.is_retriable());
     }
 
     #[test]
     fn a_plain_4xx_api_error_is_not_retriable() {
-        let err = BackendError::Api { status: 400, message: "bad config".into() };
+        let err = BackendError::Api {
+            status: 400,
+            message: "bad config".into(),
+        };
         assert!(!err.is_retriable());
     }
 

--- a/rust/crates/adc-sdk/src/backend/mod.rs
+++ b/rust/crates/adc-sdk/src/backend/mod.rs
@@ -124,7 +124,11 @@ pub trait Backend: Send + Sync {
     /// whole document at once (apisix-standalone) reports one result per
     /// *server* instead, with `BackendSyncResult::event` left `None` since
     /// no single event owns that write.
-    async fn sync(&self, events: Vec<Event>, opts: BackendSyncOptions) -> Result<Vec<BackendSyncResult>, BackendError>;
+    async fn sync(
+        &self,
+        events: Vec<Event>,
+        opts: BackendSyncOptions,
+    ) -> Result<Vec<BackendSyncResult>, BackendError>;
 
     /// Not every backend can pre-validate events against the remote server
     /// before applying them, so this defaults to rejecting with

--- a/rust/crates/adc-sdk/src/event.rs
+++ b/rust/crates/adc-sdk/src/event.rs
@@ -23,8 +23,15 @@ pub enum EventType {
 ///
 /// `#[serde(tag = "type")]` keeps the wire format identical to a flat struct with
 /// a `type` discriminant field: `{"type": "create", "newValue": ...}`.
+///
+/// `rename_all_fields` matches the TS `Event`'s own camelCase (`oldValue`/`newValue`):
+/// `rename_all` alone only renames the variant names, not the fields inside them.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(
+    tag = "type",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
 pub enum EventKind {
     Create {
         new_value: Value,
@@ -51,14 +58,18 @@ impl EventKind {
 
     pub fn old_value(&self) -> Option<&Value> {
         match self {
-            EventKind::Delete { old_value } | EventKind::Update { old_value, .. } => Some(old_value),
+            EventKind::Delete { old_value } | EventKind::Update { old_value, .. } => {
+                Some(old_value)
+            }
             EventKind::Create { .. } => None,
         }
     }
 
     pub fn new_value(&self) -> Option<&Value> {
         match self {
-            EventKind::Create { new_value } | EventKind::Update { new_value, .. } => Some(new_value),
+            EventKind::Create { new_value } | EventKind::Update { new_value, .. } => {
+                Some(new_value)
+            }
             EventKind::Delete { .. } => None,
         }
     }
@@ -72,7 +83,13 @@ impl EventKind {
 }
 
 /// A single detected change between local and remote configuration for one resource.
+///
+/// `rename_all = "camelCase"` matches the TS `Event`'s own field names
+/// (`resourceType`/`resourceId`/`resourceName`/`parentId`): the wire format this was
+/// ported from, and what every consumer of the `/sync` and `/validate` responses (AIC
+/// included) still expects.
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Event {
     pub resource_type: ResourceType,
     #[serde(flatten)]

--- a/rust/crates/adc-sdk/src/lib.rs
+++ b/rust/crates/adc-sdk/src/lib.rs
@@ -22,8 +22,8 @@ pub mod utils;
 pub mod value_diff;
 
 pub use backend::{
-    Backend, BackendError, BackendMetadata, BackendSyncOptions, BackendSyncResult, BackendValidateResult,
-    BackendValidationError, DEFAULT_EXIT_ON_FAILURE, SYNC_EVENT_SPAN_NAME,
+    Backend, BackendError, BackendMetadata, BackendSyncOptions, BackendSyncResult,
+    BackendValidateResult, BackendValidationError, DEFAULT_EXIT_ON_FAILURE, SYNC_EVENT_SPAN_NAME,
 };
 pub use converter::{ConvertError, Converter};
 pub use default_value::DefaultValue;

--- a/rust/crates/adc-sdk/src/lint.rs
+++ b/rust/crates/adc-sdk/src/lint.rs
@@ -114,12 +114,20 @@ fn check_cross_field_rules(config: &Configuration, issues: &mut Vec<LintIssue>) 
         check_service(service, &push_index(&push_key(&[], "services"), i), issues);
     }
     for (i, consumer) in config.consumers.iter().flatten().enumerate() {
-        check_consumer_credentials(consumer, &push_index(&push_key(&[], "consumers"), i), issues);
+        check_consumer_credentials(
+            consumer,
+            &push_index(&push_key(&[], "consumers"), i),
+            issues,
+        );
     }
     for (i, group) in config.consumer_groups.iter().flatten().enumerate() {
         let group_path = push_index(&push_key(&[], "consumer_groups"), i);
         for (j, consumer) in group.consumers.iter().flatten().enumerate() {
-            check_consumer_credentials(consumer, &push_index(&push_key(&group_path, "consumers"), j), issues);
+            check_consumer_credentials(
+                consumer,
+                &push_index(&push_key(&group_path, "consumers"), j),
+                issues,
+            );
         }
     }
 }
@@ -147,7 +155,11 @@ fn check_service(service: &Service, path: &[PathSegment], issues: &mut Vec<LintI
         check_upstream_discovery(upstream, &push_key(path, "upstream"), issues);
     }
     for (i, upstream) in service.upstreams.iter().flatten().enumerate() {
-        check_upstream_discovery(upstream, &push_index(&push_key(path, "upstreams"), i), issues);
+        check_upstream_discovery(
+            upstream,
+            &push_index(&push_key(path, "upstreams"), i),
+            issues,
+        );
     }
 }
 
@@ -155,10 +167,17 @@ fn check_service(service: &Service, path: &[PathSegment], issues: &mut Vec<LintI
 /// mutually exclusive, and exactly one must be set:
 /// `(nodes && !discovery_type && !service_name) || (discovery_type &&
 /// service_name && !nodes)`.
-fn check_upstream_discovery(upstream: &Upstream, path: &[PathSegment], issues: &mut Vec<LintIssue>) {
-    let nodes_only = upstream.nodes.is_some() && upstream.discovery_type.is_none() && upstream.service_name.is_none();
-    let discovery_only =
-        upstream.discovery_type.is_some() && upstream.service_name.is_some() && upstream.nodes.is_none();
+fn check_upstream_discovery(
+    upstream: &Upstream,
+    path: &[PathSegment],
+    issues: &mut Vec<LintIssue>,
+) {
+    let nodes_only = upstream.nodes.is_some()
+        && upstream.discovery_type.is_none()
+        && upstream.service_name.is_none();
+    let discovery_only = upstream.discovery_type.is_some()
+        && upstream.service_name.is_some()
+        && upstream.nodes.is_none();
     if !(nodes_only || discovery_only) {
         issues.push(LintIssue {
             path: path.to_vec(),
@@ -170,7 +189,11 @@ fn check_upstream_discovery(upstream: &Upstream, path: &[PathSegment], issues: &
 
 const ALLOWED_CREDENTIAL_TYPES: [&str; 4] = ["key-auth", "basic-auth", "jwt-auth", "hmac-auth"];
 
-fn check_consumer_credentials(consumer: &Consumer, path: &[PathSegment], issues: &mut Vec<LintIssue>) {
+fn check_consumer_credentials(
+    consumer: &Consumer,
+    path: &[PathSegment],
+    issues: &mut Vec<LintIssue>,
+) {
     for (i, credential) in consumer.credentials.iter().flatten().enumerate() {
         if !ALLOWED_CREDENTIAL_TYPES.contains(&credential.r#type.as_str()) {
             issues.push(LintIssue {
@@ -196,7 +219,13 @@ mod tests {
             hash_on: None,
             key: None,
             checks: None,
-            nodes: Some(vec![UpstreamNode { host: "127.0.0.1".into(), port: 80, weight: 1, priority: 0, metadata: None }]),
+            nodes: Some(vec![UpstreamNode {
+                host: "127.0.0.1".into(),
+                port: 80,
+                weight: 1,
+                priority: 0,
+                metadata: None,
+            }]),
             scheme: Default::default(),
             retries: None,
             retry_timeout: None,
@@ -228,12 +257,22 @@ mod tests {
     }
 
     fn empty_config() -> Configuration {
-        Configuration { services: None, ssls: None, consumers: None, consumer_groups: None, global_rules: None, plugin_metadata: None }
+        Configuration {
+            services: None,
+            ssls: None,
+            consumers: None,
+            consumer_groups: None,
+            global_rules: None,
+            plugin_metadata: None,
+        }
     }
 
     #[test]
     fn a_valid_configuration_lints_clean() {
-        let config = Configuration { services: Some(vec![minimal_service()]), ..empty_config() };
+        let config = Configuration {
+            services: Some(vec![minimal_service()]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
@@ -242,8 +281,14 @@ mod tests {
         let mut upstream = minimal_upstream_with_nodes();
         upstream.discovery_type = Some("dns".into());
         upstream.service_name = Some("svc.local".into());
-        let service = Service { upstream: Some(upstream), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstream: Some(upstream),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
         assert_eq!(format_path(&issues[0].path), "services[0].upstream");
@@ -253,8 +298,14 @@ mod tests {
     fn upstream_with_neither_nodes_nor_discovery_is_rejected() {
         let mut upstream = minimal_upstream_with_nodes();
         upstream.nodes = None;
-        let service = Service { upstream: Some(upstream), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstream: Some(upstream),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config).len(), 1);
     }
 
@@ -264,15 +315,27 @@ mod tests {
         upstream.nodes = None;
         upstream.discovery_type = Some("dns".into());
         upstream.service_name = Some("svc.local".into());
-        let service = Service { upstream: Some(upstream), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstream: Some(upstream),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
     #[test]
     fn path_prefix_without_a_leading_slash_is_rejected() {
-        let service = Service { path_prefix: Some("no-slash".into()), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            path_prefix: Some("no-slash".into()),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
         assert_eq!(format_path(&issues[0].path), "services[0].path_prefix");
@@ -280,8 +343,14 @@ mod tests {
 
     #[test]
     fn path_prefix_with_a_leading_slash_is_accepted() {
-        let service = Service { path_prefix: Some("/api".into()), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            path_prefix: Some("/api".into()),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
@@ -289,8 +358,15 @@ mod tests {
     fn upstreams_without_a_default_upstream_is_rejected() {
         let mut named = minimal_upstream_with_nodes();
         named.name = Some("u1".into());
-        let service = Service { upstream: None, upstreams: Some(vec![named]), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstream: None,
+            upstreams: Some(vec![named]),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config).len(), 1);
     }
 
@@ -298,16 +374,28 @@ mod tests {
     fn upstreams_with_a_default_upstream_is_accepted() {
         let mut named = minimal_upstream_with_nodes();
         named.name = Some("u1".into());
-        let service = Service { upstreams: Some(vec![named]), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstreams: Some(vec![named]),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
     #[test]
     fn an_unnamed_entry_in_upstreams_is_rejected_by_the_schema() {
         let unnamed = minimal_upstream_with_nodes();
-        let service = Service { upstreams: Some(vec![unnamed]), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstreams: Some(vec![unnamed]),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert!(!lint(&config).is_empty());
     }
 
@@ -317,8 +405,14 @@ mod tests {
     fn an_id_on_the_default_upstream_is_rejected_by_the_schema() {
         let mut upstream = minimal_upstream_with_nodes();
         upstream.id = Some("u1".into());
-        let service = Service { upstream: Some(upstream), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstream: Some(upstream),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert!(!lint(&config).is_empty());
     }
 
@@ -327,23 +421,42 @@ mod tests {
         let mut named = minimal_upstream_with_nodes();
         named.id = Some("u1".into());
         named.name = Some("u1".into());
-        let service = Service { upstreams: Some(vec![named]), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            upstreams: Some(vec![named]),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
     #[test]
     fn a_name_or_description_at_exactly_the_64kb_limit_lints_clean() {
-        let service = Service { name: "0".repeat(64 * 1024), description: Some("0".repeat(64 * 1024)), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            name: "0".repeat(64 * 1024),
+            description: Some("0".repeat(64 * 1024)),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
     #[test]
     fn a_name_or_description_one_character_past_the_64kb_limit_is_rejected() {
-        let service =
-            Service { name: "0".repeat(64 * 1024 + 1), description: Some("0".repeat(64 * 1024 + 1)), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            name: "0".repeat(64 * 1024 + 1),
+            description: Some("0".repeat(64 * 1024 + 1)),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 2);
         assert_eq!(format_path(&issues[0].path), "services[0].name");
@@ -352,15 +465,27 @@ mod tests {
 
     #[test]
     fn an_id_at_exactly_the_256_character_limit_lints_clean() {
-        let service = Service { id: Some("0".repeat(256)), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            id: Some("0".repeat(256)),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
     #[test]
     fn an_id_one_character_past_the_256_character_limit_is_rejected_by_the_schema() {
-        let service = Service { id: Some("0".repeat(257)), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            id: Some("0".repeat(257)),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
         assert_eq!(format_path(&issues[0].path), "services[0].id");
@@ -368,8 +493,14 @@ mod tests {
 
     #[test]
     fn an_id_with_disallowed_characters_is_rejected_by_the_schema() {
-        let service = Service { id: Some("not valid!".into()), ..minimal_service() };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let service = Service {
+            id: Some("not valid!".into()),
+            ..minimal_service()
+        };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
         assert_eq!(format_path(&issues[0].path), "services[0].id");
@@ -383,11 +514,17 @@ mod tests {
             labels: None,
             r#type: Default::default(),
             snis: vec!["example.com".into()],
-            certificates: vec![SSLCertificate { certificate: "short".into(), key: "x".repeat(32) }],
+            certificates: vec![SSLCertificate {
+                certificate: "short".into(),
+                key: "x".repeat(32),
+            }],
             client: None,
             ssl_protocols: None,
         };
-        let config = Configuration { ssls: Some(vec![ssl]), ..empty_config() };
+        let config = Configuration {
+            ssls: Some(vec![ssl]),
+            ..empty_config()
+        };
         assert!(!lint(&config).is_empty());
     }
 
@@ -399,11 +536,17 @@ mod tests {
             labels: None,
             r#type: Default::default(),
             snis: vec!["example.com".into()],
-            certificates: vec![SSLCertificate { certificate: "$secret://vault/cert".into(), key: "$env://TLS_KEY".into() }],
+            certificates: vec![SSLCertificate {
+                certificate: "$secret://vault/cert".into(),
+                key: "$env://TLS_KEY".into(),
+            }],
             client: None,
             ssl_protocols: None,
         };
-        let config = Configuration { ssls: Some(vec![ssl]), ..empty_config() };
+        let config = Configuration {
+            ssls: Some(vec![ssl]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
@@ -423,11 +566,17 @@ mod tests {
             labels: None,
             r#type: Default::default(),
             snis: vec!["example.com".into()],
-            certificates: vec![SSLCertificate { certificate: "x".repeat(128), key: secret_value.into() }],
+            certificates: vec![SSLCertificate {
+                certificate: "x".repeat(128),
+                key: secret_value.into(),
+            }],
             client: None,
             ssl_protocols: None,
         };
-        let config = Configuration { ssls: Some(vec![ssl]), ..empty_config() };
+        let config = Configuration {
+            ssls: Some(vec![ssl]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
         assert!(
@@ -453,10 +602,16 @@ mod tests {
                 config: Default::default(),
             }]),
         };
-        let config = Configuration { consumers: Some(vec![consumer]), ..empty_config() };
+        let config = Configuration {
+            consumers: Some(vec![consumer]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
-        assert_eq!(format_path(&issues[0].path), "consumers[0].credentials[0].type");
+        assert_eq!(
+            format_path(&issues[0].path),
+            "consumers[0].credentials[0].type"
+        );
     }
 
     #[test]
@@ -475,7 +630,10 @@ mod tests {
                 config: Default::default(),
             }]),
         };
-        let config = Configuration { consumers: Some(vec![consumer]), ..empty_config() };
+        let config = Configuration {
+            consumers: Some(vec![consumer]),
+            ..empty_config()
+        };
         assert_eq!(lint(&config), Vec::new());
     }
 
@@ -495,11 +653,24 @@ mod tests {
                 config: Default::default(),
             }]),
         };
-        let group = ConsumerGroup { id: None, name: "g".into(), description: None, labels: None, plugins: None, consumers: Some(vec![consumer]) };
-        let config = Configuration { consumer_groups: Some(vec![group]), ..empty_config() };
+        let group = ConsumerGroup {
+            id: None,
+            name: "g".into(),
+            description: None,
+            labels: None,
+            plugins: None,
+            consumers: Some(vec![consumer]),
+        };
+        let config = Configuration {
+            consumer_groups: Some(vec![group]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         assert_eq!(issues.len(), 1);
-        assert_eq!(format_path(&issues[0].path), "consumer_groups[0].consumers[0].credentials[0].type");
+        assert_eq!(
+            format_path(&issues[0].path),
+            "consumer_groups[0].consumers[0].credentials[0].type"
+        );
     }
 
     #[test]
@@ -513,7 +684,10 @@ mod tests {
             upstream: Some(upstream),
             ..minimal_service()
         };
-        let config = Configuration { services: Some(vec![service]), ..empty_config() };
+        let config = Configuration {
+            services: Some(vec![service]),
+            ..empty_config()
+        };
         let issues = lint(&config);
         // id charset (schema), path_prefix leading slash, nodes/discovery
         // conflict — three independent violations, all reported together.

--- a/rust/crates/adc-sdk/src/resources/mod.rs
+++ b/rust/crates/adc-sdk/src/resources/mod.rs
@@ -23,16 +23,17 @@ pub mod service;
 pub mod ssl;
 pub mod upstream;
 
-pub use common::{Expr, Labels, LabelValue, Plugin, Plugins, Timeout};
+pub use common::{Expr, LabelValue, Labels, Plugin, Plugins, Timeout};
 pub use consumer::{Consumer, ConsumerCredential, ConsumerGroup};
 pub use route::{HttpMethod, Route, StreamRoute};
 pub use service::{Service, ServiceRoutes};
 pub use ssl::{SSL, SSLCertificate, SslClient, SslProtocol, SslType};
 pub use upstream::{
     Upstream, UpstreamBalancer, UpstreamHealthCheck, UpstreamHealthCheckActive,
-    UpstreamHealthCheckActiveHealthy, UpstreamHealthCheckActiveUnhealthy, UpstreamHealthCheckPassive,
-    UpstreamHealthCheckPassiveHealthy, UpstreamHealthCheckPassiveUnhealthy, UpstreamHealthCheckType,
-    UpstreamKeepalivePool, UpstreamNode, UpstreamPassHost, UpstreamScheme, UpstreamTls,
+    UpstreamHealthCheckActiveHealthy, UpstreamHealthCheckActiveUnhealthy,
+    UpstreamHealthCheckPassive, UpstreamHealthCheckPassiveHealthy,
+    UpstreamHealthCheckPassiveUnhealthy, UpstreamHealthCheckType, UpstreamKeepalivePool,
+    UpstreamNode, UpstreamPassHost, UpstreamScheme, UpstreamTls,
 };
 
 use schemars::JsonSchema;

--- a/rust/crates/adc-sdk/src/utils.rs
+++ b/rust/crates/adc-sdk/src/utils.rs
@@ -11,7 +11,11 @@ pub fn generate_id(name: &str) -> String {
     // Manual hex encoding rather than `format!("{:x}", ...)`: sha1 0.11's
     // `finalize()` output type (`hybrid_array::Array`) doesn't implement
     // `LowerHex`, unlike the `generic_array::GenericArray` it replaced.
-    hasher.finalize().iter().map(|byte| format!("{byte:02x}")).collect()
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
 }
 
 #[cfg(test)]
@@ -21,6 +25,9 @@ mod tests {
     #[test]
     fn matches_node_sha1_hex() {
         // echo -n "hello" | sha1sum -> aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
-        assert_eq!(generate_id("hello"), "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+        assert_eq!(
+            generate_id("hello"),
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+        );
     }
 }

--- a/rust/crates/adc-sdk/src/value_diff.rs
+++ b/rust/crates/adc-sdk/src/value_diff.rs
@@ -61,7 +61,11 @@ pub enum ValueDiff {
     Deleted { path: DiffPath, lhs: Value },
     /// Edit: present (with a different value or type) on both sides.
     #[serde(rename = "E")]
-    Edit { path: DiffPath, lhs: Value, rhs: Value },
+    Edit {
+        path: DiffPath,
+        lhs: Value,
+        rhs: Value,
+    },
     /// Array: a tail element was added/removed relative to the other side's length.
     #[serde(rename = "A")]
     Array {
@@ -87,13 +91,28 @@ fn real_type_of(v: &Value) -> &'static str {
 pub fn diff_value(lhs: &Value, rhs: &Value) -> Option<Vec<ValueDiff>> {
     let mut changes = Vec::new();
     deep_diff(Some(lhs), Some(rhs), &[], &mut changes);
-    if changes.is_empty() { None } else { Some(changes) }
+    if changes.is_empty() {
+        None
+    } else {
+        Some(changes)
+    }
 }
 
-fn deep_diff(lhs: Option<&Value>, rhs: Option<&Value>, path: &[PathSegment], changes: &mut Vec<ValueDiff>) {
+fn deep_diff(
+    lhs: Option<&Value>,
+    rhs: Option<&Value>,
+    path: &[PathSegment],
+    changes: &mut Vec<ValueDiff>,
+) {
     match (lhs, rhs) {
-        (None, Some(r)) => changes.push(ValueDiff::New { path: path.to_vec(), rhs: r.clone() }),
-        (Some(l), None) => changes.push(ValueDiff::Deleted { path: path.to_vec(), lhs: l.clone() }),
+        (None, Some(r)) => changes.push(ValueDiff::New {
+            path: path.to_vec(),
+            rhs: r.clone(),
+        }),
+        (Some(l), None) => changes.push(ValueDiff::Deleted {
+            path: path.to_vec(),
+            lhs: l.clone(),
+        }),
         (None, None) => {}
         (Some(l), Some(r)) => {
             // Equal subtrees can't contain a diff at any depth — skips the
@@ -107,7 +126,11 @@ fn deep_diff(lhs: Option<&Value>, rhs: Option<&Value>, path: &[PathSegment], cha
                 return;
             }
             if real_type_of(l) != real_type_of(r) {
-                changes.push(ValueDiff::Edit { path: path.to_vec(), lhs: l.clone(), rhs: r.clone() });
+                changes.push(ValueDiff::Edit {
+                    path: path.to_vec(),
+                    lhs: l.clone(),
+                    rhs: r.clone(),
+                });
                 return;
             }
             match (l, r) {
@@ -123,12 +146,20 @@ fn deep_diff(lhs: Option<&Value>, rhs: Option<&Value>, path: &[PathSegment], cha
                 // guarding against for gateway config values.
                 (Value::Number(ln), Value::Number(rn)) => {
                     if ln.as_f64() != rn.as_f64() {
-                        changes.push(ValueDiff::Edit { path: path.to_vec(), lhs: l.clone(), rhs: r.clone() });
+                        changes.push(ValueDiff::Edit {
+                            path: path.to_vec(),
+                            lhs: l.clone(),
+                            rhs: r.clone(),
+                        });
                     }
                 }
                 _ => {
                     if l != r {
-                        changes.push(ValueDiff::Edit { path: path.to_vec(), lhs: l.clone(), rhs: r.clone() });
+                        changes.push(ValueDiff::Edit {
+                            path: path.to_vec(),
+                            lhs: l.clone(),
+                            rhs: r.clone(),
+                        });
                     }
                 }
             }
@@ -136,7 +167,12 @@ fn deep_diff(lhs: Option<&Value>, rhs: Option<&Value>, path: &[PathSegment], cha
     }
 }
 
-fn diff_object(lo: &serde_json::Map<String, Value>, ro: &serde_json::Map<String, Value>, path: &[PathSegment], changes: &mut Vec<ValueDiff>) {
+fn diff_object(
+    lo: &serde_json::Map<String, Value>,
+    ro: &serde_json::Map<String, Value>,
+    path: &[PathSegment],
+    changes: &mut Vec<ValueDiff>,
+) {
     // lhs's own keys first, in insertion order (matches `Object.keys(lObj)`).
     for (key, lv) in lo {
         let mut sub_path = path.to_vec();
@@ -163,7 +199,10 @@ fn diff_array(la: &[Value], ra: &[Value], path: &[PathSegment], changes: &mut Ve
         changes.push(ValueDiff::Array {
             path: path.to_vec(),
             index: idx,
-            item: Box::new(ValueDiff::New { path: vec![], rhs: ra[idx].clone() }),
+            item: Box::new(ValueDiff::New {
+                path: vec![],
+                rhs: ra[idx].clone(),
+            }),
         });
         i -= 1;
     }
@@ -172,7 +211,10 @@ fn diff_array(la: &[Value], ra: &[Value], path: &[PathSegment], changes: &mut Ve
         changes.push(ValueDiff::Array {
             path: path.to_vec(),
             index: idx,
-            item: Box::new(ValueDiff::Deleted { path: vec![], lhs: la[idx].clone() }),
+            item: Box::new(ValueDiff::Deleted {
+                path: vec![],
+                lhs: la[idx].clone(),
+            }),
         });
         j -= 1;
     }
@@ -202,7 +244,10 @@ mod tests {
     fn new_key() {
         assert_eq!(
             diff_value(&json!({}), &json!({"a": 1})),
-            Some(vec![ValueDiff::New { path: vec![PathSegment::Key("a".into())], rhs: json!(1) }])
+            Some(vec![ValueDiff::New {
+                path: vec![PathSegment::Key("a".into())],
+                rhs: json!(1)
+            }])
         );
     }
 
@@ -210,7 +255,10 @@ mod tests {
     fn deleted_key() {
         assert_eq!(
             diff_value(&json!({"a": 1}), &json!({})),
-            Some(vec![ValueDiff::Deleted { path: vec![PathSegment::Key("a".into())], lhs: json!(1) }])
+            Some(vec![ValueDiff::Deleted {
+                path: vec![PathSegment::Key("a".into())],
+                lhs: json!(1)
+            }])
         );
     }
 
@@ -218,7 +266,11 @@ mod tests {
     fn edited_scalar() {
         assert_eq!(
             diff_value(&json!({"a": 1}), &json!({"a": 2})),
-            Some(vec![ValueDiff::Edit { path: vec![PathSegment::Key("a".into())], lhs: json!(1), rhs: json!(2) }])
+            Some(vec![ValueDiff::Edit {
+                path: vec![PathSegment::Key("a".into())],
+                lhs: json!(1),
+                rhs: json!(2)
+            }])
         );
     }
 
@@ -241,7 +293,10 @@ mod tests {
             Some(vec![ValueDiff::Array {
                 path: vec![],
                 index: 2,
-                item: Box::new(ValueDiff::New { path: vec![], rhs: json!(3) })
+                item: Box::new(ValueDiff::New {
+                    path: vec![],
+                    rhs: json!(3)
+                })
             }])
         );
     }
@@ -253,7 +308,10 @@ mod tests {
             Some(vec![ValueDiff::Array {
                 path: vec![],
                 index: 2,
-                item: Box::new(ValueDiff::Deleted { path: vec![], lhs: json!(3) })
+                item: Box::new(ValueDiff::Deleted {
+                    path: vec![],
+                    lhs: json!(3)
+                })
             }])
         );
     }
@@ -267,7 +325,11 @@ mod tests {
     fn array_element_edit() {
         assert_eq!(
             diff_value(&json!([1, 2]), &json!([1, 5])),
-            Some(vec![ValueDiff::Edit { path: vec![PathSegment::Index(1)], lhs: json!(2), rhs: json!(5) }])
+            Some(vec![ValueDiff::Edit {
+                path: vec![PathSegment::Index(1)],
+                lhs: json!(2),
+                rhs: json!(5)
+            }])
         );
     }
 
@@ -287,7 +349,11 @@ mod tests {
     fn a_type_change_from_null_to_object_is_one_edit() {
         assert_eq!(
             diff_value(&json!({"a": null}), &json!({"a": {"b": 1}})),
-            Some(vec![ValueDiff::Edit { path: vec![PathSegment::Key("a".into())], lhs: json!(null), rhs: json!({"b": 1}) }])
+            Some(vec![ValueDiff::Edit {
+                path: vec![PathSegment::Key("a".into())],
+                lhs: json!(null),
+                rhs: json!({"b": 1})
+            }])
         );
     }
 

--- a/rust/crates/adc-sdk/tests/resources_from_fixtures.rs
+++ b/rust/crates/adc-sdk/tests/resources_from_fixtures.rs
@@ -6,11 +6,15 @@
 
 use std::path::PathBuf;
 
-use adc_sdk::resources::{Consumer, FlatConfiguration, Route, Service, ServiceRoutes, UpstreamHealthCheck, SSL};
+use adc_sdk::resources::{
+    Consumer, FlatConfiguration, Route, SSL, Service, ServiceRoutes, UpstreamHealthCheck,
+};
 use serde_json::Value;
 
 fn fixture(name: &str) -> Value {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../fixtures/differ").join(name);
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../fixtures/differ")
+        .join(name);
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
 }
@@ -24,7 +28,14 @@ fn deserializes_service_with_nested_routes_and_upstream() {
 
     let service = &services[0];
     assert_eq!(service.name, "test");
-    assert_eq!(service.routes.as_ref().and_then(ServiceRoutes::http).map(<[_]>::len), Some(0));
+    assert_eq!(
+        service
+            .routes
+            .as_ref()
+            .and_then(ServiceRoutes::http)
+            .map(<[_]>::len),
+        Some(0)
+    );
     assert!(service.upstream.is_some());
     let upstreams = service.upstreams.as_ref().expect("upstreams");
     assert_eq!(upstreams.len(), 1);
@@ -34,7 +45,8 @@ fn deserializes_service_with_nested_routes_and_upstream() {
 #[test]
 fn deserializes_ssl_with_certificates() {
     let f = fixture("upstream.creates_and_updates_ssl_before_upstream.json");
-    let ssls: Vec<SSL> = serde_json::from_value(f["local"]["ssls"].clone()).expect("deserialize ssls");
+    let ssls: Vec<SSL> =
+        serde_json::from_value(f["local"]["ssls"].clone()).expect("deserialize ssls");
     assert_eq!(ssls.len(), 2);
     assert_eq!(ssls[0].snis, vec!["test1.com", "test2.com"]);
     assert_eq!(ssls[0].certificates.len(), 1);
@@ -73,7 +85,8 @@ fn deserializes_route_with_plugins_and_methods() {
 fn deserializes_full_health_check_block() {
     let f = fixture("usecase.selectively_merges_objects_in_default_values_on_a_service.json");
     let checks_patch = f["defaultValue"]["core"]["service"]["upstream"]["checks"].clone();
-    let checks: UpstreamHealthCheck = serde_json::from_value(checks_patch).expect("deserialize checks");
+    let checks: UpstreamHealthCheck =
+        serde_json::from_value(checks_patch).expect("deserialize checks");
 
     assert_eq!(checks.active.concurrency, 10);
     let active_healthy = checks.active.healthy.expect("active.healthy");
@@ -86,11 +99,13 @@ fn deserializes_full_health_check_block() {
 #[test]
 fn deserializes_whole_flat_configuration() {
     let f = fixture("upstream.creates_and_updates_ssl_before_upstream.json");
-    let local: FlatConfiguration = serde_json::from_value(f["local"].clone()).expect("deserialize local");
+    let local: FlatConfiguration =
+        serde_json::from_value(f["local"].clone()).expect("deserialize local");
     assert_eq!(local.services.map(|s| s.len()), Some(1));
     assert_eq!(local.ssls.map(|s| s.len()), Some(2));
 
-    let remote: FlatConfiguration = serde_json::from_value(f["remote"].clone()).expect("deserialize remote");
+    let remote: FlatConfiguration =
+        serde_json::from_value(f["remote"].clone()).expect("deserialize remote");
     assert_eq!(remote.services.map(|s| s.len()), Some(1));
     assert_eq!(remote.ssls.map(|s| s.len()), Some(1));
 }

--- a/rust/crates/adc-sdk/tests/schema_json.rs
+++ b/rust/crates/adc-sdk/tests/schema_json.rs
@@ -9,10 +9,13 @@
 #[test]
 fn schema_json_is_consistent_with_the_current_resource_model() {
     let current = schemars::schema_for!(adc_sdk::resources::Configuration);
-    let current_json = serde_json::to_string_pretty(&current).expect("schema serializes to JSON") + "\n";
+    let current_json =
+        serde_json::to_string_pretty(&current).expect("schema serializes to JSON") + "\n";
 
-    let committed = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../../schema.json"))
-        .expect("rust/schema.json should exist — run `cargo run -p adc-sdk --bin export-schema`");
+    let committed =
+        std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/../../schema.json")).expect(
+            "rust/schema.json should exist — run `cargo run -p adc-sdk --bin export-schema`",
+        );
 
     // Normalize CRLF -> LF on both sides: `current_json` is always built
     // with bare `\n`, but a CRLF checkout (e.g. git's `core.autocrlf` on


### PR DESCRIPTION
### Description

API responses in the ADC server should use camelCase as the JSON key, but Rust incorrectly implements this using snake_case—this is an implementation error.

This PR fixes it and adds regression tests on both ports.

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [ ] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible

<!--

Note:

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Serialized event data now uses camelCase field names, including `parentId`, `resourceName`, `oldValue`, and `newValue`.
  - Sync results consistently preserve event metadata for successful and failed operations, including APISIX Standalone workflows.

- **Bug Fixes**
  - Sync output now omits unavailable parent identifiers and excludes internal event details from simplified results.

- **Tests**
  - Added coverage for event serialization and standard and APISIX Standalone sync responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->